### PR TITLE
New feature: Suspendable (serializable state)

### DIFF
--- a/QUALITY_AND_STYLE.md
+++ b/QUALITY_AND_STYLE.md
@@ -12,6 +12,10 @@ lib.rs for all crates needs to contain: `#![forbid(missing_docs)]`, `#![no_std]`
 
 All primitives must be accompanied by a CLI in `/cli`.
 
+All algorithms with a state that is exercised across multiple API calls -- typically through a `do_update()`,
+`do_final()` pattern -- should implement SerializableState so that the user can pause the execution of this algorithm to
+a cache and resume later.
+
 # Quality
 
 ## Tests

--- a/alpha_0.1.2_release_notes.md
+++ b/alpha_0.1.2_release_notes.md
@@ -38,11 +38,20 @@
 
 # 0.1.2 Features / Changelog
 
+## Major features
+
 * New algorithms added to crypto/ :
     * mldsa (FIPS 204)
     * mldsa-lowmemory -- runs in about 1/10th of the usual memory (~ 30 kb of stack) with comparable performance impact.
     * mlkem (FIPS 203)
     * mlkem-lowmemory -- runs in about 1/4th of the usual memory (~ 12 kb of stack) with comparable performance impact.
+* New traits SerializeState and SerializeKeyedState allow algorithms with a streaming API (`do_update()` ->
+  `do_final()`) to be suspended to a small byte array and then resumed later, potentially from a different host. The
+  intended use case is if you are processing a large input that depends on one or more network round-trips and you wish
+  to suspect and potentially transfer to a new host while waiting for network IO.
+
+## Minor features / bug fixes
+
 * All public `*_out(.., out: &mut [u8])` functions now begin by zeroizing the entire output buffer with `.fill(0)`,
   preventing exposure of stale data in oversized output buffers or on early error returns.
 * Reworked the way KeyMaterial hazardous operations work; instead of a stateful .allow_hazardous_operations() /

--- a/alpha_0.1.2_release_notes.md
+++ b/alpha_0.1.2_release_notes.md
@@ -45,10 +45,11 @@
     * mldsa-lowmemory -- runs in about 1/10th of the usual memory (~ 30 kb of stack) with comparable performance impact.
     * mlkem (FIPS 203)
     * mlkem-lowmemory -- runs in about 1/4th of the usual memory (~ 12 kb of stack) with comparable performance impact.
-* New traits SerializeState and SerializeKeyedState allow algorithms with a streaming API (`do_update()` ->
-  `do_final()`) to be suspended to a small byte array and then resumed later, potentially from a different host. The
-  intended use case is if you are processing a large input that depends on one or more network round-trips and you wish
-  to suspect and potentially transfer to a new host while waiting for network IO.
+* New traits [Suspendable] and [SuspendableKeyed] allow algorithms with a streaming API (`do_update()` ->
+  `do_final()`) to be suspended to a small byte array and then resumed later, potentially from a different host and
+  potentially across versions of the library. The intended use case is if you are processing a large input that depends
+  on one or more network round-trips and you wish to suspend to a cache and potentially transfer to a new host while
+  waiting for network IO.
 
 ## Minor features / bug fixes
 

--- a/alpha_0.1.2_release_notes.md
+++ b/alpha_0.1.2_release_notes.md
@@ -51,6 +51,16 @@
   on one or more network round-trips and you wish to suspend to a cache and potentially transfer to a new host while
   waiting for network IO.
 
+## Breaking changes
+
+* The `Hash` trait now requires `Algorithm` as a supertrait (`trait Hash: Algorithm + Default`). Any
+  external implementor of `Hash` must now also implement `Algorithm`.
+* `bouncycastle_sha2::Sha512Internal` was renamed to `SHA512Internal` (the public type and the `SHA384`
+  / `SHA512` type aliases follow the all-caps convention).
+* The `MLDSATrait` verification method `verify_mu_internal(..) -> bool` is now public as
+  `verify_mu(..) -> Result<(), SignatureError>` (it also gained an optional pre-expanded `A_hat`
+  argument in the full `mldsa` crate). This supports external-mu / suspend-resume verification.
+
 ## Minor features / bug fixes
 
 * All public `*_out(.., out: &mut [u8])` functions now begin by zeroizing the entire output buffer with `.fill(0)`,

--- a/alpha_0.1.2_release_notes.md
+++ b/alpha_0.1.2_release_notes.md
@@ -51,16 +51,6 @@
   on one or more network round-trips and you wish to suspend to a cache and potentially transfer to a new host while
   waiting for network IO.
 
-## Breaking changes
-
-* The `Hash` trait now requires `Algorithm` as a supertrait (`trait Hash: Algorithm + Default`). Any
-  external implementor of `Hash` must now also implement `Algorithm`.
-* `bouncycastle_sha2::Sha512Internal` was renamed to `SHA512Internal` (the public type and the `SHA384`
-  / `SHA512` type aliases follow the all-caps convention).
-* The `MLDSATrait` verification method `verify_mu_internal(..) -> bool` is now public as
-  `verify_mu(..) -> Result<(), SignatureError>` (it also gained an optional pre-expanded `A_hat`
-  argument in the full `mldsa` crate). This supports external-mu / suspend-resume verification.
-
 ## Minor features / bug fixes
 
 * All public `*_out(.., out: &mut [u8])` functions now begin by zeroizing the entire output buffer with `.fill(0)`,

--- a/crypto/core-test-framework/src/lib.rs
+++ b/crypto/core-test-framework/src/lib.rs
@@ -13,6 +13,7 @@ pub mod hash;
 pub mod kdf;
 pub mod kem;
 pub mod mac;
+pub mod serializable_state;
 pub mod signature;
 
 mod fixed_seed_rng;

--- a/crypto/core-test-framework/src/lib.rs
+++ b/crypto/core-test-framework/src/lib.rs
@@ -13,8 +13,8 @@ pub mod hash;
 pub mod kdf;
 pub mod kem;
 pub mod mac;
-pub mod serializable_state;
 pub mod signature;
+pub mod suspendable_state;
 
 mod fixed_seed_rng;
 pub use fixed_seed_rng::FixedSeedRNG;

--- a/crypto/core-test-framework/src/serializable_state.rs
+++ b/crypto/core-test-framework/src/serializable_state.rs
@@ -1,6 +1,6 @@
 use bouncycastle_core::errors::SerializedStateError;
 use bouncycastle_core::serializable_state::{LIB_VERSION, SemVer};
-use bouncycastle_core::traits::SerializableState;
+use bouncycastle_core::traits::{SerializableKeyedState, SerializableState};
 
 pub struct TestFrameworkSerializableState {}
 
@@ -55,6 +55,68 @@ impl TestFrameworkSerializableState {
         futurever_serialized_state[..3]
             .copy_from_slice(&[future_ver.major, future_ver.minor, future_ver.patch]);
         match S::from_serialized_state(futurever_serialized_state) {
+            Err(SerializedStateError::IncompatibleVersion) => { /* good */ }
+            _ => {
+                panic!("Expected IncompatibleVersion error")
+            }
+        }
+    }
+}
+
+pub struct TestFrameworkSerializableKeyedState {}
+
+impl TestFrameworkSerializableKeyedState {
+    pub fn new() -> Self {
+        Self {}
+    }
+
+    /// Test all the members of trait SerializableState.
+    ///
+    /// Expects ta be handed an instance of the object that has some in-progress state to be serialized.
+    pub fn test<
+        const SERIALIZED_STATE_LEN: usize,
+        S: SerializableKeyedState<SERIALIZED_STATE_LEN> + Clone,
+    >(
+        &self,
+        instance: &S,
+        key: &S::Key,
+    ) {
+        // There's not a lot we can test here in the abstract, but we can test a few things to
+        // ensure that the SerializableState trait has been impl'd correctly.
+
+        // we need to work on a clone because .serialize_state() moves self, which you can't do on a
+        // borrowed instance.
+        let instance_clone = instance.clone();
+
+        // You can serialize and then deserialize the state.
+        let serialized_state = instance_clone.serialize_state();
+        assert_eq!(serialized_state.len(), SERIALIZED_STATE_LEN);
+
+        let _deserialized_state = S::from_serialized_state(serialized_state, key).unwrap();
+
+        // The serialized state MUST include a prefix indicating the current version of the library.
+        let state_sized: [u8; 3] = serialized_state[..3].try_into().unwrap();
+        assert_eq!(SemVer::from(state_sized), LIB_VERSION);
+
+        // All implementations MUST reject a serialized state from lib ver 0.0.0
+        // This doesn't really serve any purpose except testing that all impl's have properly
+        // used the helper functions.
+        let mut ver0_serialized_state = serialized_state.clone();
+        ver0_serialized_state[..3].copy_from_slice(&[0, 0, 0]);
+        match S::from_serialized_state(ver0_serialized_state, key) {
+            Err(SerializedStateError::IncompatibleVersion) => { /* good */ }
+            _ => {
+                panic!("Expected IncompatibleVersion error")
+            }
+        }
+
+        // All implementations MUST reject a serialized state from a future version.
+        let mut future_ver = LIB_VERSION;
+        future_ver.patch += 1;
+        let mut futurever_serialized_state = serialized_state.clone();
+        futurever_serialized_state[..3]
+            .copy_from_slice(&[future_ver.major, future_ver.minor, future_ver.patch]);
+        match S::from_serialized_state(futurever_serialized_state, key) {
             Err(SerializedStateError::IncompatibleVersion) => { /* good */ }
             _ => {
                 panic!("Expected IncompatibleVersion error")

--- a/crypto/core-test-framework/src/serializable_state.rs
+++ b/crypto/core-test-framework/src/serializable_state.rs
@@ -1,4 +1,4 @@
-use bouncycastle_core::errors::CoreError;
+use bouncycastle_core::errors::SerializedStateError;
 use bouncycastle_core::serializable_state::{LIB_VERSION, SemVer};
 use bouncycastle_core::traits::SerializableState;
 
@@ -12,15 +12,22 @@ impl TestFrameworkSerializableState {
     /// Test all the members of trait SerializableState.
     ///
     /// Expects ta be handed an instance of the object that has some in-progress state to be serialized.
-    pub fn test<const SERIALIZED_STATE_LEN: usize, S: SerializableState<SERIALIZED_STATE_LEN>>(
+    pub fn test<
+        const SERIALIZED_STATE_LEN: usize,
+        S: SerializableState<SERIALIZED_STATE_LEN> + Clone,
+    >(
         &self,
         instance: &S,
     ) {
         // There's not a lot we can test here in the abstract, but we can test a few things to
         // ensure that the SerializableState trait has been impl'd correctly.
 
+        // we need to work on a clone because .serialize_state() moves self, which you can't do on a
+        // borrowed instance.
+        let instance_clone = instance.clone();
+
         // You can serialize and then deserialize the state.
-        let serialized_state = instance.serialize_state();
+        let serialized_state = instance_clone.serialize_state();
         assert_eq!(serialized_state.len(), SERIALIZED_STATE_LEN);
 
         let _deserialized_state = S::from_serialized_state(serialized_state).unwrap();
@@ -35,7 +42,7 @@ impl TestFrameworkSerializableState {
         let mut ver0_serialized_state = serialized_state.clone();
         ver0_serialized_state[..3].copy_from_slice(&[0, 0, 0]);
         match S::from_serialized_state(ver0_serialized_state) {
-            Err(CoreError::IncompatibleVersion) => { /* good */ }
+            Err(SerializedStateError::IncompatibleVersion) => { /* good */ }
             _ => {
                 panic!("Expected IncompatibleVersion error")
             }
@@ -48,7 +55,7 @@ impl TestFrameworkSerializableState {
         futurever_serialized_state[..3]
             .copy_from_slice(&[future_ver.major, future_ver.minor, future_ver.patch]);
         match S::from_serialized_state(futurever_serialized_state) {
-            Err(CoreError::IncompatibleVersion) => { /* good */ }
+            Err(SerializedStateError::IncompatibleVersion) => { /* good */ }
             _ => {
                 panic!("Expected IncompatibleVersion error")
             }

--- a/crypto/core-test-framework/src/serializable_state.rs
+++ b/crypto/core-test-framework/src/serializable_state.rs
@@ -1,16 +1,16 @@
 use bouncycastle_core::errors::CoreError;
-use bouncycastle_core::serializable_state::{LIB_VERSION};
-use bouncycastle_core::traits::{SerializableState};
+use bouncycastle_core::serializable_state::LIB_VERSION;
+use bouncycastle_core::traits::SerializableState;
 
-pub struct TestFrameworkSerializableState { }
+pub struct TestFrameworkSerializableState {}
 
 impl TestFrameworkSerializableState {
     pub fn new() -> Self {
-        Self { }
+        Self {}
     }
 
     /// Test all the members of trait SerializableState.
-    /// 
+    ///
     /// Expects ta be handed an instance of the object that has some in-progress state to be serialized.
     pub fn test<const SERIALIZED_STATE_LEN: usize, S: SerializableState<SERIALIZED_STATE_LEN>>(
         &self,
@@ -18,26 +18,26 @@ impl TestFrameworkSerializableState {
     ) {
         // There's not a lot we can test here in the abstract, but we can test a few things to
         // ensure that the SerializableState trait has been impl'd correctly.
-        
+
         // You can serialize and then deserialize the state.
         let serialized_state = instance.serialize_state();
         assert_eq!(serialized_state.len(), SERIALIZED_STATE_LEN);
-        
+
         let _deserialized_state = S::from_serialized_state(serialized_state).unwrap();
-        
-        
+
         // The serialized state MUST include a prefix indicating the current version of the library.
         assert_eq!(serialized_state[..3], LIB_VERSION);
-        
-        
+
         // All implementations MUST reject a serialized state from lib ver 0.0.0
         // This doesn't really serve any purpose except testing that all impl's have properly
         // used the helper functions.
         let mut busted_serialized_state = serialized_state.clone();
         busted_serialized_state[..3].copy_from_slice(&[0, 0, 0]);
         match S::from_serialized_state(busted_serialized_state) {
-            Err(CoreError::IncompatibleVersion) => { /* good */ },
-            _ => { panic!("Expected IncompatibleVersion error") }
+            Err(CoreError::IncompatibleVersion) => { /* good */ }
+            _ => {
+                panic!("Expected IncompatibleVersion error")
+            }
         }
     }
 }

--- a/crypto/core-test-framework/src/serializable_state.rs
+++ b/crypto/core-test-framework/src/serializable_state.rs
@@ -1,5 +1,5 @@
 use bouncycastle_core::errors::CoreError;
-use bouncycastle_core::serializable_state::LIB_VERSION;
+use bouncycastle_core::serializable_state::{LIB_VERSION, SemVer};
 use bouncycastle_core::traits::SerializableState;
 
 pub struct TestFrameworkSerializableState {}
@@ -26,14 +26,28 @@ impl TestFrameworkSerializableState {
         let _deserialized_state = S::from_serialized_state(serialized_state).unwrap();
 
         // The serialized state MUST include a prefix indicating the current version of the library.
-        assert_eq!(serialized_state[..3], LIB_VERSION);
+        let state_sized: [u8; 3] = serialized_state[..3].try_into().unwrap();
+        assert_eq!(SemVer::from(state_sized), LIB_VERSION);
 
         // All implementations MUST reject a serialized state from lib ver 0.0.0
         // This doesn't really serve any purpose except testing that all impl's have properly
         // used the helper functions.
-        let mut busted_serialized_state = serialized_state.clone();
-        busted_serialized_state[..3].copy_from_slice(&[0, 0, 0]);
-        match S::from_serialized_state(busted_serialized_state) {
+        let mut ver0_serialized_state = serialized_state.clone();
+        ver0_serialized_state[..3].copy_from_slice(&[0, 0, 0]);
+        match S::from_serialized_state(ver0_serialized_state) {
+            Err(CoreError::IncompatibleVersion) => { /* good */ }
+            _ => {
+                panic!("Expected IncompatibleVersion error")
+            }
+        }
+
+        // All implementations MUST reject a serialized state from a future version.
+        let mut future_ver = LIB_VERSION;
+        future_ver.patch += 1;
+        let mut futurever_serialized_state = serialized_state.clone();
+        futurever_serialized_state[..3]
+            .copy_from_slice(&[future_ver.major, future_ver.minor, future_ver.patch]);
+        match S::from_serialized_state(futurever_serialized_state) {
             Err(CoreError::IncompatibleVersion) => { /* good */ }
             _ => {
                 panic!("Expected IncompatibleVersion error")

--- a/crypto/core-test-framework/src/serializable_state.rs
+++ b/crypto/core-test-framework/src/serializable_state.rs
@@ -1,0 +1,43 @@
+use bouncycastle_core::errors::CoreError;
+use bouncycastle_core::serializable_state::{LIB_VERSION};
+use bouncycastle_core::traits::{SerializableState};
+
+pub struct TestFrameworkSerializableState { }
+
+impl TestFrameworkSerializableState {
+    pub fn new() -> Self {
+        Self { }
+    }
+
+    /// Test all the members of trait SerializableState.
+    /// 
+    /// Expects ta be handed an instance of the object that has some in-progress state to be serialized.
+    pub fn test<const SERIALIZED_STATE_LEN: usize, S: SerializableState<SERIALIZED_STATE_LEN>>(
+        &self,
+        instance: &S,
+    ) {
+        // There's not a lot we can test here in the abstract, but we can test a few things to
+        // ensure that the SerializableState trait has been impl'd correctly.
+        
+        // You can serialize and then deserialize the state.
+        let serialized_state = instance.serialize_state();
+        assert_eq!(serialized_state.len(), SERIALIZED_STATE_LEN);
+        
+        let _deserialized_state = S::from_serialized_state(serialized_state).unwrap();
+        
+        
+        // The serialized state MUST include a prefix indicating the current version of the library.
+        assert_eq!(serialized_state[..3], LIB_VERSION);
+        
+        
+        // All implementations MUST reject a serialized state from lib ver 0.0.0
+        // This doesn't really serve any purpose except testing that all impl's have properly
+        // used the helper functions.
+        let mut busted_serialized_state = serialized_state.clone();
+        busted_serialized_state[..3].copy_from_slice(&[0, 0, 0]);
+        match S::from_serialized_state(busted_serialized_state) {
+            Err(CoreError::IncompatibleVersion) => { /* good */ },
+            _ => { panic!("Expected IncompatibleVersion error") }
+        }
+    }
+}

--- a/crypto/core-test-framework/src/suspendable_state.rs
+++ b/crypto/core-test-framework/src/suspendable_state.rs
@@ -1,10 +1,10 @@
 use bouncycastle_core::errors::SerializedStateError;
 use bouncycastle_core::serializable_state::{LIB_VERSION, SemVer};
-use bouncycastle_core::traits::{SerializableKeyedState, SerializableState};
+use bouncycastle_core::traits::{Suspendable, SuspendableKeyed};
 
-pub struct TestFrameworkSerializableState {}
+pub struct TestFrameworkSuspendableState {}
 
-impl TestFrameworkSerializableState {
+impl TestFrameworkSuspendableState {
     pub fn new() -> Self {
         Self {}
     }
@@ -12,10 +12,7 @@ impl TestFrameworkSerializableState {
     /// Test all the members of trait SerializableState.
     ///
     /// Expects ta be handed an instance of the object that has some in-progress state to be serialized.
-    pub fn test<
-        const SERIALIZED_STATE_LEN: usize,
-        S: SerializableState<SERIALIZED_STATE_LEN> + Clone,
-    >(
+    pub fn test<const SERIALIZED_STATE_LEN: usize, S: Suspendable<SERIALIZED_STATE_LEN> + Clone>(
         &self,
         instance: &S,
     ) {
@@ -27,10 +24,10 @@ impl TestFrameworkSerializableState {
         let instance_clone = instance.clone();
 
         // You can serialize and then deserialize the state.
-        let serialized_state = instance_clone.serialize_state();
+        let serialized_state = instance_clone.suspend();
         assert_eq!(serialized_state.len(), SERIALIZED_STATE_LEN);
 
-        let _deserialized_state = S::from_serialized_state(serialized_state).unwrap();
+        let _deserialized_state = S::from_suspended(serialized_state).unwrap();
 
         // The serialized state MUST include a prefix indicating the current version of the library.
         let state_sized: [u8; 3] = serialized_state[..3].try_into().unwrap();
@@ -41,7 +38,7 @@ impl TestFrameworkSerializableState {
         // used the helper functions.
         let mut ver0_serialized_state = serialized_state.clone();
         ver0_serialized_state[..3].copy_from_slice(&[0, 0, 0]);
-        match S::from_serialized_state(ver0_serialized_state) {
+        match S::from_suspended(ver0_serialized_state) {
             Err(SerializedStateError::IncompatibleVersion) => { /* good */ }
             _ => {
                 panic!("Expected IncompatibleVersion error")
@@ -54,7 +51,7 @@ impl TestFrameworkSerializableState {
         let mut futurever_serialized_state = serialized_state.clone();
         futurever_serialized_state[..3]
             .copy_from_slice(&[future_ver.major, future_ver.minor, future_ver.patch]);
-        match S::from_serialized_state(futurever_serialized_state) {
+        match S::from_suspended(futurever_serialized_state) {
             Err(SerializedStateError::IncompatibleVersion) => { /* good */ }
             _ => {
                 panic!("Expected IncompatibleVersion error")
@@ -63,9 +60,9 @@ impl TestFrameworkSerializableState {
     }
 }
 
-pub struct TestFrameworkSerializableKeyedState {}
+pub struct TestFrameworkSuspendableKeyedState {}
 
-impl TestFrameworkSerializableKeyedState {
+impl TestFrameworkSuspendableKeyedState {
     pub fn new() -> Self {
         Self {}
     }
@@ -75,7 +72,7 @@ impl TestFrameworkSerializableKeyedState {
     /// Expects ta be handed an instance of the object that has some in-progress state to be serialized.
     pub fn test<
         const SERIALIZED_STATE_LEN: usize,
-        S: SerializableKeyedState<SERIALIZED_STATE_LEN> + Clone,
+        S: SuspendableKeyed<SERIALIZED_STATE_LEN> + Clone,
     >(
         &self,
         instance: &S,
@@ -89,10 +86,10 @@ impl TestFrameworkSerializableKeyedState {
         let instance_clone = instance.clone();
 
         // You can serialize and then deserialize the state.
-        let serialized_state = instance_clone.serialize_state();
+        let serialized_state = instance_clone.suspend();
         assert_eq!(serialized_state.len(), SERIALIZED_STATE_LEN);
 
-        let _deserialized_state = S::from_serialized_state(serialized_state, key).unwrap();
+        let _deserialized_state = S::from_suspended(serialized_state, key).unwrap();
 
         // The serialized state MUST include a prefix indicating the current version of the library.
         let state_sized: [u8; 3] = serialized_state[..3].try_into().unwrap();
@@ -103,7 +100,7 @@ impl TestFrameworkSerializableKeyedState {
         // used the helper functions.
         let mut ver0_serialized_state = serialized_state.clone();
         ver0_serialized_state[..3].copy_from_slice(&[0, 0, 0]);
-        match S::from_serialized_state(ver0_serialized_state, key) {
+        match S::from_suspended(ver0_serialized_state, key) {
             Err(SerializedStateError::IncompatibleVersion) => { /* good */ }
             _ => {
                 panic!("Expected IncompatibleVersion error")
@@ -116,7 +113,7 @@ impl TestFrameworkSerializableKeyedState {
         let mut futurever_serialized_state = serialized_state.clone();
         futurever_serialized_state[..3]
             .copy_from_slice(&[future_ver.major, future_ver.minor, future_ver.patch]);
-        match S::from_serialized_state(futurever_serialized_state, key) {
+        match S::from_suspended(futurever_serialized_state, key) {
             Err(SerializedStateError::IncompatibleVersion) => { /* good */ }
             _ => {
                 panic!("Expected IncompatibleVersion error")

--- a/crypto/core-test-framework/src/suspendable_state.rs
+++ b/crypto/core-test-framework/src/suspendable_state.rs
@@ -1,5 +1,5 @@
 use bouncycastle_core::errors::SuspendableError;
-use bouncycastle_core::serializable_state::{LIB_VERSION, SemVer};
+use bouncycastle_core::suspendable_state::{LIB_VERSION, SemVer};
 use bouncycastle_core::traits::{Suspendable, SuspendableKeyed};
 
 pub struct TestFrameworkSuspendableState {}
@@ -45,9 +45,9 @@ impl TestFrameworkSuspendableState {
             }
         }
 
-        // All implementations MUST reject a serialized state from a future version.
+        // All implementations MUST reject a serialized state from a future MAJOR or MINOR version.
         let mut future_ver = LIB_VERSION;
-        future_ver.patch += 1;
+        future_ver.major += 1;
         let mut futurever_serialized_state = serialized_state.clone();
         futurever_serialized_state[..3]
             .copy_from_slice(&[future_ver.major, future_ver.minor, future_ver.patch]);
@@ -57,6 +57,34 @@ impl TestFrameworkSuspendableState {
                 panic!("Expected IncompatibleVersion error")
             }
         }
+
+        let mut future_ver = LIB_VERSION;
+        future_ver.minor += 1;
+        let mut futurever_serialized_state = serialized_state.clone();
+        futurever_serialized_state[..3]
+            .copy_from_slice(&[future_ver.major, future_ver.minor, future_ver.patch]);
+        match S::from_suspended(futurever_serialized_state) {
+            Err(SuspendableError::IncompatibleVersion) => { /* good */ }
+            _ => {
+                panic!("Expected IncompatibleVersion error")
+            }
+        }
+
+        // but should accept anything on the same patch stream.
+        let mut future_ver = LIB_VERSION;
+        future_ver.patch += 1;
+        let mut futurever_serialized_state = serialized_state.clone();
+        futurever_serialized_state[..3]
+            .copy_from_slice(&[future_ver.major, future_ver.minor, future_ver.patch]);
+        let _deserialized_state = S::from_suspended(futurever_serialized_state).unwrap();
+
+        // ... even up to patch 255
+        let mut future_ver = LIB_VERSION;
+        future_ver.patch = 255;
+        let mut futurever_serialized_state = serialized_state.clone();
+        futurever_serialized_state[..3]
+            .copy_from_slice(&[future_ver.major, future_ver.minor, future_ver.patch]);
+        let _deserialized_state = S::from_suspended(futurever_serialized_state).unwrap();
     }
 }
 
@@ -107,9 +135,9 @@ impl TestFrameworkSuspendableKeyedState {
             }
         }
 
-        // All implementations MUST reject a serialized state from a future version.
+        // All implementations MUST reject a serialized state from a future MAJOR or MINOR version.
         let mut future_ver = LIB_VERSION;
-        future_ver.patch += 1;
+        future_ver.major += 1;
         let mut futurever_serialized_state = serialized_state.clone();
         futurever_serialized_state[..3]
             .copy_from_slice(&[future_ver.major, future_ver.minor, future_ver.patch]);
@@ -119,5 +147,33 @@ impl TestFrameworkSuspendableKeyedState {
                 panic!("Expected IncompatibleVersion error")
             }
         }
+
+        let mut future_ver = LIB_VERSION;
+        future_ver.minor += 1;
+        let mut futurever_serialized_state = serialized_state.clone();
+        futurever_serialized_state[..3]
+            .copy_from_slice(&[future_ver.major, future_ver.minor, future_ver.patch]);
+        match S::from_suspended(futurever_serialized_state, key) {
+            Err(SuspendableError::IncompatibleVersion) => { /* good */ }
+            _ => {
+                panic!("Expected IncompatibleVersion error")
+            }
+        }
+
+        // but should accept anything on the same patch stream.
+        let mut future_ver = LIB_VERSION;
+        future_ver.patch += 1;
+        let mut futurever_serialized_state = serialized_state.clone();
+        futurever_serialized_state[..3]
+            .copy_from_slice(&[future_ver.major, future_ver.minor, future_ver.patch]);
+        let _deserialized_state = S::from_suspended(futurever_serialized_state, key).unwrap();
+
+        // ... even up to patch 255
+        let mut future_ver = LIB_VERSION;
+        future_ver.patch = 255;
+        let mut futurever_serialized_state = serialized_state.clone();
+        futurever_serialized_state[..3]
+            .copy_from_slice(&[future_ver.major, future_ver.minor, future_ver.patch]);
+        let _deserialized_state = S::from_suspended(futurever_serialized_state, key).unwrap();
     }
 }

--- a/crypto/core-test-framework/src/suspendable_state.rs
+++ b/crypto/core-test-framework/src/suspendable_state.rs
@@ -1,4 +1,4 @@
-use bouncycastle_core::errors::SerializedStateError;
+use bouncycastle_core::errors::SuspendableError;
 use bouncycastle_core::serializable_state::{LIB_VERSION, SemVer};
 use bouncycastle_core::traits::{Suspendable, SuspendableKeyed};
 
@@ -39,7 +39,7 @@ impl TestFrameworkSuspendableState {
         let mut ver0_serialized_state = serialized_state.clone();
         ver0_serialized_state[..3].copy_from_slice(&[0, 0, 0]);
         match S::from_suspended(ver0_serialized_state) {
-            Err(SerializedStateError::IncompatibleVersion) => { /* good */ }
+            Err(SuspendableError::IncompatibleVersion) => { /* good */ }
             _ => {
                 panic!("Expected IncompatibleVersion error")
             }
@@ -52,7 +52,7 @@ impl TestFrameworkSuspendableState {
         futurever_serialized_state[..3]
             .copy_from_slice(&[future_ver.major, future_ver.minor, future_ver.patch]);
         match S::from_suspended(futurever_serialized_state) {
-            Err(SerializedStateError::IncompatibleVersion) => { /* good */ }
+            Err(SuspendableError::IncompatibleVersion) => { /* good */ }
             _ => {
                 panic!("Expected IncompatibleVersion error")
             }
@@ -101,7 +101,7 @@ impl TestFrameworkSuspendableKeyedState {
         let mut ver0_serialized_state = serialized_state.clone();
         ver0_serialized_state[..3].copy_from_slice(&[0, 0, 0]);
         match S::from_suspended(ver0_serialized_state, key) {
-            Err(SerializedStateError::IncompatibleVersion) => { /* good */ }
+            Err(SuspendableError::IncompatibleVersion) => { /* good */ }
             _ => {
                 panic!("Expected IncompatibleVersion error")
             }
@@ -114,7 +114,7 @@ impl TestFrameworkSuspendableKeyedState {
         futurever_serialized_state[..3]
             .copy_from_slice(&[future_ver.major, future_ver.minor, future_ver.patch]);
         match S::from_suspended(futurever_serialized_state, key) {
-            Err(SerializedStateError::IncompatibleVersion) => { /* good */ }
+            Err(SuspendableError::IncompatibleVersion) => { /* good */ }
             _ => {
                 panic!("Expected IncompatibleVersion error")
             }

--- a/crypto/core/src/errors.rs
+++ b/crypto/core/src/errors.rs
@@ -1,10 +1,4 @@
 #[derive(Debug)]
-pub enum CoreError {
-    IncompatibleVersion,
-    InvalidData,
-}
-
-#[derive(Debug)]
 pub enum HashError {
     GenericError(&'static str),
     InvalidLength(&'static str),
@@ -76,6 +70,17 @@ pub enum RNGError {
     SecurityStrengthInsufficientForAlgorithm,
 
     KeyMaterialError(KeyMaterialError),
+}
+
+#[derive(Debug)]
+pub enum SerializedStateError {
+    /// The serialized state was produced by a library version incompatible with this one.
+    IncompatibleVersion,
+    /// The serialized state is malformed or corrupt.
+    InvalidData,
+    /// The key supplied to [crate::traits::SerializableKeyedState::from_serialized_state] does not
+    /// match the key the state was created with (it is bound to a different public-key hash `tr`).
+    IncorrectKey,
 }
 
 #[derive(Debug)]

--- a/crypto/core/src/errors.rs
+++ b/crypto/core/src/errors.rs
@@ -78,7 +78,7 @@ pub enum SerializedStateError {
     IncompatibleVersion,
     /// The serialized state is malformed or corrupt.
     InvalidData,
-    /// The key supplied to [crate::traits::SerializableKeyedState::from_serialized_state] does not
+    /// The key supplied to [crate::traits::SuspendableKeyed::from_suspended] does not
     /// match the key the state was created with (it is bound to a different public-key hash `tr`).
     IncorrectKey,
 }

--- a/crypto/core/src/errors.rs
+++ b/crypto/core/src/errors.rs
@@ -78,9 +78,6 @@ pub enum SuspendableError {
     IncompatibleVersion,
     /// The serialized state is malformed or corrupt.
     InvalidData,
-    /// The key supplied to [crate::traits::SuspendableKeyed::from_suspended] does not
-    /// match the key the state was created with (it is bound to a different public-key hash `tr`).
-    IncorrectKey,
 }
 
 #[derive(Debug)]

--- a/crypto/core/src/errors.rs
+++ b/crypto/core/src/errors.rs
@@ -1,4 +1,9 @@
 #[derive(Debug)]
+pub enum CoreError {
+    IncompatibleVersion,
+}
+
+#[derive(Debug)]
 pub enum HashError {
     GenericError(&'static str),
     InvalidLength(&'static str),

--- a/crypto/core/src/errors.rs
+++ b/crypto/core/src/errors.rs
@@ -73,7 +73,7 @@ pub enum RNGError {
 }
 
 #[derive(Debug)]
-pub enum SerializedStateError {
+pub enum SuspendableError {
     /// The serialized state was produced by a library version incompatible with this one.
     IncompatibleVersion,
     /// The serialized state is malformed or corrupt.

--- a/crypto/core/src/errors.rs
+++ b/crypto/core/src/errors.rs
@@ -1,6 +1,7 @@
 #[derive(Debug)]
 pub enum CoreError {
     IncompatibleVersion,
+    InvalidData,
 }
 
 #[derive(Debug)]

--- a/crypto/core/src/key_material.rs
+++ b/crypto/core/src/key_material.rs
@@ -50,7 +50,7 @@
 //!
 //! See [do_hazardous_operations] for documentation and sample code.
 
-use crate::errors::{CoreError, KeyMaterialError};
+use crate::errors::{KeyMaterialError, SerializedStateError};
 use crate::traits::{RNG, Secret, SecurityStrength};
 use bouncycastle_utils::{ct, min};
 
@@ -255,9 +255,9 @@ pub enum KeyType {
 }
 
 impl TryFrom<u8> for KeyType {
-    type Error = CoreError;
+    type Error = SerializedStateError;
 
-    /// Inverse of `self as u8`; rejects unrecognized discriminants with [CoreError::InvalidData].
+    /// Inverse of `self as u8`; rejects unrecognized discriminants with [SerializedStateError::InvalidData].
     fn try_from(value: u8) -> Result<Self, Self::Error> {
         Ok(match value {
             0 => Self::Zeroized,
@@ -266,7 +266,7 @@ impl TryFrom<u8> for KeyType {
             3 => Self::Seed,
             4 => Self::MACKey,
             5 => Self::SymmetricCipherKey,
-            _ => return Err(CoreError::InvalidData),
+            _ => return Err(SerializedStateError::InvalidData),
         })
     }
 }

--- a/crypto/core/src/key_material.rs
+++ b/crypto/core/src/key_material.rs
@@ -50,7 +50,7 @@
 //!
 //! See [do_hazardous_operations] for documentation and sample code.
 
-use crate::errors::{KeyMaterialError, SerializedStateError};
+use crate::errors::{KeyMaterialError, SuspendableError};
 use crate::traits::{RNG, Secret, SecurityStrength};
 use bouncycastle_utils::{ct, min};
 
@@ -255,9 +255,9 @@ pub enum KeyType {
 }
 
 impl TryFrom<u8> for KeyType {
-    type Error = SerializedStateError;
+    type Error = SuspendableError;
 
-    /// Inverse of `self as u8`; rejects unrecognized discriminants with [SerializedStateError::InvalidData].
+    /// Inverse of `self as u8`; rejects unrecognized discriminants with [SuspendableError::InvalidData].
     fn try_from(value: u8) -> Result<Self, Self::Error> {
         Ok(match value {
             0 => Self::Zeroized,
@@ -266,7 +266,7 @@ impl TryFrom<u8> for KeyType {
             3 => Self::Seed,
             4 => Self::MACKey,
             5 => Self::SymmetricCipherKey,
-            _ => return Err(SerializedStateError::InvalidData),
+            _ => return Err(SuspendableError::InvalidData),
         })
     }
 }

--- a/crypto/core/src/key_material.rs
+++ b/crypto/core/src/key_material.rs
@@ -50,7 +50,7 @@
 //!
 //! See [do_hazardous_operations] for documentation and sample code.
 
-use crate::errors::KeyMaterialError;
+use crate::errors::{CoreError, KeyMaterialError};
 use crate::traits::{RNG, Secret, SecurityStrength};
 use bouncycastle_utils::{ct, min};
 
@@ -221,10 +221,15 @@ pub struct KeyMaterial<const KEY_LEN: usize> {
 
 impl<const KEY_LEN: usize> Secret for KeyMaterial<KEY_LEN> {}
 
+// The explicit `#[repr(u8)]` discriminants are the stable on-the-wire encoding used by
+// `SerializableState` implementations (see the `TryFrom<u8>` impl below). Pin each value to its
+// variant name: reordering variants is fine, but never reuse or renumber an existing discriminant,
+// or previously-serialized states will be misread.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(u8)]
 pub enum KeyType {
     /// The KeyMaterial is zeroized and MUST NOT be used for any cryptographic operation in this state.
-    Zeroized,
+    Zeroized = 0,
 
     /// The KeyMaterial contains non-zero data of unknown key type.
     /// A KeyMaterial of key type Unknown will always have a [SecurityStrength] of [SecurityStrength::None].
@@ -234,19 +239,36 @@ pub enum KeyType {
     /// and must be done within a [do_hazardous_operations] closure.
     /// If you want to import key material directly into a known key type, use [KeyMaterial::from_bytes_as_type],
     /// which does not require a hazardous operations closure.
-    Unknown,
+    Unknown = 1,
 
     /// The KeyMaterial contains data of full entropy and can be safely converted to any other key type.
-    CryptographicRandom,
+    CryptographicRandom = 2,
 
     /// A seed for asymmetric private keys, RNGs, and other seed-based cryptographic objects.
-    Seed,
+    Seed = 3,
 
     /// A MAC key.
-    MACKey,
+    MACKey = 4,
 
     /// A key for a symmetric block or stream cipher.
-    SymmetricCipherKey,
+    SymmetricCipherKey = 5,
+}
+
+impl TryFrom<u8> for KeyType {
+    type Error = CoreError;
+
+    /// Inverse of `self as u8`; rejects unrecognized discriminants with [CoreError::InvalidData].
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        Ok(match value {
+            0 => Self::Zeroized,
+            1 => Self::Unknown,
+            2 => Self::CryptographicRandom,
+            3 => Self::Seed,
+            4 => Self::MACKey,
+            5 => Self::SymmetricCipherKey,
+            _ => return Err(CoreError::InvalidData),
+        })
+    }
 }
 
 impl<const KEY_LEN: usize> Default for KeyMaterial<KEY_LEN> {

--- a/crypto/core/src/lib.rs
+++ b/crypto/core/src/lib.rs
@@ -7,5 +7,5 @@
 
 pub mod errors;
 pub mod key_material;
-pub mod serializable_state;
+pub mod suspendable_state;
 pub mod traits;

--- a/crypto/core/src/lib.rs
+++ b/crypto/core/src/lib.rs
@@ -7,4 +7,5 @@
 
 pub mod errors;
 pub mod key_material;
+pub mod serializable_state;
 pub mod traits;

--- a/crypto/core/src/serializable_state.rs
+++ b/crypto/core/src/serializable_state.rs
@@ -45,17 +45,12 @@ fn test_cmp_lib_ver() {
     assert_eq!(cmp_lib_ver(&[1, 1, 1], &[1, 1, 1]), 0);
 }
 
-/// A helper for serializing an object's state
+/// Puts the library version into the first three bytes of the state array.
 ///
-/// The state array must have length SERIALIZED_LEN - 3 to account for adding the 3-byte symver tag.
-pub fn add_lib_ver<const SERIALIZED_LEN: usize>(state: &[u8]) -> [u8; SERIALIZED_LEN] {
-    assert_eq!(state.len(), SERIALIZED_LEN - 3);
-
-    let mut out = [0u8; SERIALIZED_LEN];
-    out[..3].copy_from_slice(&LIB_VERSION);
-    out[3..].copy_from_slice(state);
-
-    out
+/// Hands back a slice to the same array, starting after the version tag.
+pub fn add_lib_ver<const SERIALIZED_LEN: usize>(state: &mut [u8; SERIALIZED_LEN]) -> &mut [u8] {
+    state[..3].copy_from_slice(&LIB_VERSION);
+    &mut state[3..]
 }
 
 /// A helper for deserializing an object's state
@@ -67,14 +62,13 @@ pub fn add_lib_ver<const SERIALIZED_LEN: usize>(state: &[u8]) -> [u8; SERIALIZED
 ///
 /// Note that for testability, this will always reject if the serialized state contains a version tag
 /// of `[0,0,0]`.
-pub fn remove_lib_ver<const SERIALIZED_LEN: usize>(
-    state_in: &[u8; SERIALIZED_LEN],
-    state_out: &mut [u8],
+///
+/// Hands back a slice to the same array, starting after the version tag.
+pub fn check_lib_ver<const SERIALIZED_LEN: usize>(
+    state: &[u8; SERIALIZED_LEN],
     not_before: Option<[u8; 3]>,
-) -> Result<usize, CoreError> {
-    assert!(state_out.len() >= SERIALIZED_LEN - 3);
-
-    let ver: [u8; 3] = state_in[..3].try_into().unwrap();
+) -> Result<&[u8], CoreError> {
+    let ver: [u8; 3] = state[..3].try_into().unwrap();
 
     let not_before = not_before.unwrap_or([0, 0, 0]);
 
@@ -85,6 +79,5 @@ pub fn remove_lib_ver<const SERIALIZED_LEN: usize>(
         return Err(CoreError::IncompatibleVersion);
     };
 
-    state_out.copy_from_slice(&state_in[3..]);
-    Ok(SERIALIZED_LEN - 3)
+    Ok(&state[3..])
 }

--- a/crypto/core/src/serializable_state.rs
+++ b/crypto/core/src/serializable_state.rs
@@ -1,0 +1,90 @@
+//! Helper functions for standardizing serialization and deserialization of stateful objects.
+
+use crate::errors::CoreError;
+
+/// The current library version.
+// There is almost certainly a more elegant way to do this.
+pub const LIB_VERSION: [u8; 3] = [0, 1, 2];
+
+/// Compare two library semantic versions in the standard C format:
+/// * if a < b => -1
+///* if a == b => 0
+///* if a > b => 1
+pub fn cmp_lib_ver(a: &[u8; 3], b: &[u8; 3]) -> i8 {
+    if a[0] < b[0] {
+        -1
+    } else if a[0] > b[0] {
+        1
+    }
+    // first component is equal
+    else if a[1] < b[1] {
+        -1
+    } else if a[1] > b[1] {
+        1
+    }
+    // first two components are equal
+    else if a[2] < b[2] {
+        -1
+    } else if a[2] > b[2] {
+        1
+    }
+    // all three components are equal
+    else {
+        0
+    }
+}
+
+#[test]
+fn test_cmp_lib_ver() {
+    assert_eq!(cmp_lib_ver(&[0, 2, 1], &[1, 1, 1]), -1);
+    assert_eq!(cmp_lib_ver(&[2, 1, 1], &[1, 1, 1]), 1);
+    assert_eq!(cmp_lib_ver(&[1, 0, 2], &[1, 1, 1]), -1);
+    assert_eq!(cmp_lib_ver(&[1, 2, 0], &[1, 1, 1]), 1);
+    assert_eq!(cmp_lib_ver(&[1, 1, 0], &[1, 1, 1]), -1);
+    assert_eq!(cmp_lib_ver(&[1, 1, 2], &[1, 1, 1]), 1);
+    assert_eq!(cmp_lib_ver(&[1, 1, 1], &[1, 1, 1]), 0);
+}
+
+/// A helper for serializing an object's state
+///
+/// The state array must have length SERIALIZED_LEN - 3 to account for adding the 3-byte symver tag.
+pub fn add_lib_ver<const SERIALIZED_LEN: usize>(state: &[u8]) -> [u8; SERIALIZED_LEN] {
+    assert_eq!(state.len(), SERIALIZED_LEN - 3);
+
+    let mut out = [0u8; SERIALIZED_LEN];
+    out[..3].copy_from_slice(&LIB_VERSION);
+    out[3..].copy_from_slice(state);
+
+    out
+}
+
+/// A helper for deserializing an object's state
+///
+/// The state_out array must have length at least SERIALIZED_LEN - 3.
+///
+/// Returns the number of bytes written to state_out, or a [CoreError::IncompatibleVersion] if the
+/// serialized state contains a version header earlier than the specified `not_before` version.
+///
+/// Note that for testability, this will always reject if the serialized state contains a version tag
+/// of `[0,0,0]`.
+pub fn remove_lib_ver<const SERIALIZED_LEN: usize>(
+    state_in: &[u8; SERIALIZED_LEN],
+    state_out: &mut [u8],
+    not_before: Option<[u8; 3]>,
+) -> Result<usize, CoreError> {
+    assert!(state_out.len() >= SERIALIZED_LEN - 3);
+
+    let ver: [u8; 3] = state_in[..3].try_into().unwrap();
+
+    let not_before = not_before.unwrap_or([0, 0, 0]);
+
+    if cmp_lib_ver(&ver, &not_before) < 0 {
+        return Err(CoreError::IncompatibleVersion);
+    };
+    if ver == [0, 0, 0] {
+        return Err(CoreError::IncompatibleVersion);
+    };
+
+    state_out.copy_from_slice(&state_in[3..]);
+    Ok(SERIALIZED_LEN - 3)
+}

--- a/crypto/core/src/serializable_state.rs
+++ b/crypto/core/src/serializable_state.rs
@@ -2,54 +2,56 @@
 
 use crate::errors::CoreError;
 
-/// The current library version.
-// There is almost certainly a more elegant way to do this.
-pub const LIB_VERSION: [u8; 3] = [0, 1, 2];
+/// A semantic library version, ordered by `major`, then `minor`, then `patch`.
+///
+/// The field declaration order matters: the derived [`Ord`]/[`PartialOrd`] compare fields
+/// lexicographically in declaration order, which is exactly semantic-version precedence.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct SemVer {
+    pub major: u8,
+    pub minor: u8,
+    pub patch: u8,
+    // A semantic version can often also take a suffix, e.g. "alpha", "beta", "rc1", etc.
+    // We're not going to model that here because it's not useful for versioning serialized states.
+}
 
-/// Compare two library semantic versions in the standard C format:
-/// * if a < b => -1
-///* if a == b => 0
-///* if a > b => 1
-pub fn cmp_lib_ver(a: &[u8; 3], b: &[u8; 3]) -> i8 {
-    if a[0] < b[0] {
-        -1
-    } else if a[0] > b[0] {
-        1
-    }
-    // first component is equal
-    else if a[1] < b[1] {
-        -1
-    } else if a[1] > b[1] {
-        1
-    }
-    // first two components are equal
-    else if a[2] < b[2] {
-        -1
-    } else if a[2] > b[2] {
-        1
-    }
-    // all three components are equal
-    else {
-        0
+impl From<[u8; 3]> for SemVer {
+    fn from(v: [u8; 3]) -> Self {
+        SemVer { major: v[0], minor: v[1], patch: v[2] }
     }
 }
 
+impl From<SemVer> for [u8; 3] {
+    fn from(v: SemVer) -> Self {
+        [v.major, v.minor, v.patch]
+    }
+}
+
+/// The current library version.
+// There is almost certainly a more elegant way to do this.
+pub const LIB_VERSION: SemVer = SemVer { major: 0, minor: 1, patch: 2 };
+
 #[test]
 fn test_cmp_lib_ver() {
-    assert_eq!(cmp_lib_ver(&[0, 2, 1], &[1, 1, 1]), -1);
-    assert_eq!(cmp_lib_ver(&[2, 1, 1], &[1, 1, 1]), 1);
-    assert_eq!(cmp_lib_ver(&[1, 0, 2], &[1, 1, 1]), -1);
-    assert_eq!(cmp_lib_ver(&[1, 2, 0], &[1, 1, 1]), 1);
-    assert_eq!(cmp_lib_ver(&[1, 1, 0], &[1, 1, 1]), -1);
-    assert_eq!(cmp_lib_ver(&[1, 1, 2], &[1, 1, 1]), 1);
-    assert_eq!(cmp_lib_ver(&[1, 1, 1], &[1, 1, 1]), 0);
+    use core::cmp::Ordering;
+
+    assert!([0, 0, 0] < [0, 0, 1]);
+
+    let cmp = |a: [u8; 3], b: [u8; 3]| SemVer::from(a).cmp(&SemVer::from(b));
+    assert_eq!(cmp([0, 2, 1], [1, 1, 1]), Ordering::Less);
+    assert_eq!(cmp([2, 1, 1], [1, 1, 1]), Ordering::Greater);
+    assert_eq!(cmp([1, 0, 2], [1, 1, 1]), Ordering::Less);
+    assert_eq!(cmp([1, 2, 0], [1, 1, 1]), Ordering::Greater);
+    assert_eq!(cmp([1, 1, 0], [1, 1, 1]), Ordering::Less);
+    assert_eq!(cmp([1, 1, 2], [1, 1, 1]), Ordering::Greater);
+    assert_eq!(cmp([1, 1, 1], [1, 1, 1]), Ordering::Equal);
 }
 
 /// Puts the library version into the first three bytes of the state array.
 ///
 /// Hands back a slice to the same array, starting after the version tag.
 pub fn add_lib_ver<const SERIALIZED_LEN: usize>(state: &mut [u8; SERIALIZED_LEN]) -> &mut [u8] {
-    state[..3].copy_from_slice(&LIB_VERSION);
+    state[..3].copy_from_slice(&<[u8; 3]>::from(LIB_VERSION));
     &mut state[3..]
 }
 
@@ -68,16 +70,23 @@ pub fn check_lib_ver<const SERIALIZED_LEN: usize>(
     state: &[u8; SERIALIZED_LEN],
     not_before: Option<[u8; 3]>,
 ) -> Result<&[u8], CoreError> {
-    let ver: [u8; 3] = state[..3].try_into().unwrap();
+    let ver_bytes: [u8; 3] = state[..3].try_into().unwrap();
+    let ver = SemVer::from(ver_bytes);
 
-    let not_before = not_before.unwrap_or([0, 0, 0]);
+    let not_before = SemVer::from(not_before.unwrap_or([0, 0, 0]));
 
-    if cmp_lib_ver(&ver, &not_before) < 0 {
+    if ver < not_before {
         return Err(CoreError::IncompatibleVersion);
     };
-    if ver == [0, 0, 0] {
+    // Nothing is ever compatible with [0,0,0]
+    if ver == SemVer::from([0, 0, 0]) {
         return Err(CoreError::IncompatibleVersion);
     };
+
+    // Also not compatible with future versions.
+    if ver > LIB_VERSION {
+        return Err(CoreError::IncompatibleVersion);
+    }
 
     Ok(&state[3..])
 }

--- a/crypto/core/src/serializable_state.rs
+++ b/crypto/core/src/serializable_state.rs
@@ -1,6 +1,6 @@
 //! Helper functions for standardizing serialization and deserialization of stateful objects.
 
-use crate::errors::SerializedStateError;
+use crate::errors::SuspendableError;
 
 /// A semantic library version, ordered by `major`, then `minor`, then `patch`.
 ///
@@ -78,7 +78,7 @@ pub fn add_lib_ver<const SERIALIZED_LEN: usize>(state: &mut [u8; SERIALIZED_LEN]
 ///
 /// The state_out array must have length at least SERIALIZED_LEN - 3.
 ///
-/// Returns the number of bytes written to state_out, or a [SerializedStateError::IncompatibleVersion] if the
+/// Returns the number of bytes written to state_out, or a [SuspendableError::IncompatibleVersion] if the
 /// serialized state contains a version header earlier than the specified `not_before` version.
 ///
 /// Note that for testability, this will always reject if the serialized state contains a version tag
@@ -88,23 +88,23 @@ pub fn add_lib_ver<const SERIALIZED_LEN: usize>(state: &mut [u8; SERIALIZED_LEN]
 pub fn check_lib_ver<const SERIALIZED_LEN: usize>(
     state: &[u8; SERIALIZED_LEN],
     not_before: Option<[u8; 3]>,
-) -> Result<&[u8], SerializedStateError> {
+) -> Result<&[u8], SuspendableError> {
     let ver_bytes: [u8; 3] = state[..3].try_into().unwrap();
     let ver = SemVer::from(ver_bytes);
 
     let not_before = SemVer::from(not_before.unwrap_or([0, 0, 0]));
 
     if ver < not_before {
-        return Err(SerializedStateError::IncompatibleVersion);
+        return Err(SuspendableError::IncompatibleVersion);
     };
     // Nothing is ever compatible with [0,0,0]
     if ver == SemVer::from([0, 0, 0]) {
-        return Err(SerializedStateError::IncompatibleVersion);
+        return Err(SuspendableError::IncompatibleVersion);
     };
 
     // Also not compatible with future versions.
     if ver > LIB_VERSION {
-        return Err(SerializedStateError::IncompatibleVersion);
+        return Err(SuspendableError::IncompatibleVersion);
     }
 
     Ok(&state[3..])

--- a/crypto/core/src/serializable_state.rs
+++ b/crypto/core/src/serializable_state.rs
@@ -1,6 +1,6 @@
 //! Helper functions for standardizing serialization and deserialization of stateful objects.
 
-use crate::errors::CoreError;
+use crate::errors::SerializedStateError;
 
 /// A semantic library version, ordered by `major`, then `minor`, then `patch`.
 ///
@@ -27,9 +27,28 @@ impl From<SemVer> for [u8; 3] {
     }
 }
 
-/// The current library version.
-// There is almost certainly a more elegant way to do this.
-pub const LIB_VERSION: SemVer = SemVer { major: 0, minor: 1, patch: 2 };
+/// Parse a decimal ASCII string (a Cargo version component) into a u8 at compile time.
+const fn parse_version_component(s: &str) -> u8 {
+    let bytes = s.as_bytes();
+    let mut result: u8 = 0;
+    let mut i = 0;
+    while i < bytes.len() {
+        let d = bytes[i];
+        assert!(d >= b'0' && d <= b'9', "version component must be numeric");
+        // A component > 255 overflows u8 and fails the build (SemVer fields are u8 by design).
+        result = result * 10 + (d - b'0');
+        i += 1;
+    }
+    result
+}
+
+/// The current library version, taken from this crate's `Cargo.toml` at compile time (via Cargo's
+/// `CARGO_PKG_VERSION_*` env vars) so it can never drift from the published version.
+pub const LIB_VERSION: SemVer = SemVer {
+    major: parse_version_component(env!("CARGO_PKG_VERSION_MAJOR")),
+    minor: parse_version_component(env!("CARGO_PKG_VERSION_MINOR")),
+    patch: parse_version_component(env!("CARGO_PKG_VERSION_PATCH")),
+};
 
 #[test]
 fn test_cmp_lib_ver() {
@@ -59,7 +78,7 @@ pub fn add_lib_ver<const SERIALIZED_LEN: usize>(state: &mut [u8; SERIALIZED_LEN]
 ///
 /// The state_out array must have length at least SERIALIZED_LEN - 3.
 ///
-/// Returns the number of bytes written to state_out, or a [CoreError::IncompatibleVersion] if the
+/// Returns the number of bytes written to state_out, or a [SerializedStateError::IncompatibleVersion] if the
 /// serialized state contains a version header earlier than the specified `not_before` version.
 ///
 /// Note that for testability, this will always reject if the serialized state contains a version tag
@@ -69,23 +88,23 @@ pub fn add_lib_ver<const SERIALIZED_LEN: usize>(state: &mut [u8; SERIALIZED_LEN]
 pub fn check_lib_ver<const SERIALIZED_LEN: usize>(
     state: &[u8; SERIALIZED_LEN],
     not_before: Option<[u8; 3]>,
-) -> Result<&[u8], CoreError> {
+) -> Result<&[u8], SerializedStateError> {
     let ver_bytes: [u8; 3] = state[..3].try_into().unwrap();
     let ver = SemVer::from(ver_bytes);
 
     let not_before = SemVer::from(not_before.unwrap_or([0, 0, 0]));
 
     if ver < not_before {
-        return Err(CoreError::IncompatibleVersion);
+        return Err(SerializedStateError::IncompatibleVersion);
     };
     // Nothing is ever compatible with [0,0,0]
     if ver == SemVer::from([0, 0, 0]) {
-        return Err(CoreError::IncompatibleVersion);
+        return Err(SerializedStateError::IncompatibleVersion);
     };
 
     // Also not compatible with future versions.
     if ver > LIB_VERSION {
-        return Err(CoreError::IncompatibleVersion);
+        return Err(SerializedStateError::IncompatibleVersion);
     }
 
     Ok(&state[3..])

--- a/crypto/core/src/suspendable_state.rs
+++ b/crypto/core/src/suspendable_state.rs
@@ -42,8 +42,8 @@ const fn parse_version_component(s: &str) -> u8 {
     result
 }
 
-/// The current library version, taken from this crate's `Cargo.toml` at compile time (via Cargo's
-/// `CARGO_PKG_VERSION_*` env vars) so it can never drift from the published version.
+/// The current library version -- ie the version of the *bouncycastle-core* crate -- at compile time (via Cargo's
+/// `CARGO_PKG_VERSION_*` env vars).
 pub const LIB_VERSION: SemVer = SemVer {
     major: parse_version_component(env!("CARGO_PKG_VERSION_MAJOR")),
     minor: parse_version_component(env!("CARGO_PKG_VERSION_MINOR")),
@@ -78,8 +78,9 @@ pub fn add_lib_ver<const SERIALIZED_LEN: usize>(state: &mut [u8; SERIALIZED_LEN]
 ///
 /// The state_out array must have length at least SERIALIZED_LEN - 3.
 ///
-/// Returns the number of bytes written to state_out, or a [SuspendableError::IncompatibleVersion] if the
-/// serialized state contains a version header earlier than the specified `not_before` version.
+/// Returns the number of bytes written to state_out, or a [SuspendableError::IncompatibleVersion] if
+/// the version of the serialized state is earlier than the specified `not_before` version, or
+/// is a future MAJOR or MINOR version (but future PATCH versions are ok).
 ///
 /// Note that for testability, this will always reject if the serialized state contains a version tag
 /// of `[0,0,0]`.
@@ -89,6 +90,10 @@ pub fn check_lib_ver<const SERIALIZED_LEN: usize>(
     state: &[u8; SERIALIZED_LEN],
     not_before: Option<[u8; 3]>,
 ) -> Result<&[u8], SuspendableError> {
+    // the .unwrap is infallible after the guard check
+    if state.len() < 3 {
+        return Err(SuspendableError::InvalidData);
+    }
     let ver_bytes: [u8; 3] = state[..3].try_into().unwrap();
     let ver = SemVer::from(ver_bytes);
 
@@ -102,8 +107,10 @@ pub fn check_lib_ver<const SERIALIZED_LEN: usize>(
         return Err(SuspendableError::IncompatibleVersion);
     };
 
-    // Also not compatible with future versions.
-    if ver > LIB_VERSION {
+    // Check if state was produced by a later MAJOR or MINOR version;
+    // a future version on the same patch stream is ok (if not, then we've broken the rules of semantic versioning);
+    let patch_stream = SemVer::from([LIB_VERSION.major, LIB_VERSION.minor, 255]);
+    if ver > patch_stream {
         return Err(SuspendableError::IncompatibleVersion);
     }
 

--- a/crypto/core/src/suspendable_state.rs
+++ b/crypto/core/src/suspendable_state.rs
@@ -44,6 +44,14 @@ const fn parse_version_component(s: &str) -> u8 {
 
 /// The current library version -- ie the version of the *bouncycastle-core* crate -- at compile time (via Cargo's
 /// `CARGO_PKG_VERSION_*` env vars).
+///
+/// MAINTAINER NOTE: this single value is the *only* compatibility gate for every serialized state in
+/// the workspace (see [check_lib_ver]), and the policy accepts any future *patch* on the same
+/// major.minor stream. Therefore any change to the on-the-wire layout of *any* suspendable state --
+/// in this crate or in any primitive crate -- MUST bump this crate's **minor** version (never just
+/// the patch), otherwise an older build will silently accept and misread a newer, incompatible state.
+/// Also keep this crate's version reconciled with the workspace release version so the stamp is
+/// meaningful.
 pub const LIB_VERSION: SemVer = SemVer {
     major: parse_version_component(env!("CARGO_PKG_VERSION_MAJOR")),
     minor: parse_version_component(env!("CARGO_PKG_VERSION_MINOR")),

--- a/crypto/core/src/traits.rs
+++ b/crypto/core/src/traits.rs
@@ -1,6 +1,6 @@
 //! Provides simplified abstracted APIs over classes of cryptigraphic primitives, such as Hash, KDF, etc.
 
-use crate::errors::{CoreError, HashError, KDFError, KEMError, MACError, RNGError, SignatureError};
+use crate::errors::*;
 use crate::key_material::KeyMaterialTrait;
 use core::fmt::{Debug, Display};
 use core::marker::Sized;
@@ -399,9 +399,9 @@ pub enum SecurityStrength {
 }
 
 impl TryFrom<u8> for SecurityStrength {
-    type Error = CoreError;
+    type Error = SerializedStateError;
 
-    /// Inverse of `self as u8`; rejects unrecognized discriminants with [CoreError::InvalidData].
+    /// Inverse of `self as u8`; rejects unrecognized discriminants with [SerializedStateError::InvalidData].
     fn try_from(value: u8) -> Result<Self, Self::Error> {
         Ok(match value {
             0 => Self::None,
@@ -409,7 +409,7 @@ impl TryFrom<u8> for SecurityStrength {
             2 => Self::_128bit,
             3 => Self::_192bit,
             4 => Self::_256bit,
-            _ => return Err(CoreError::InvalidData),
+            _ => return Err(SerializedStateError::InvalidData),
         })
     }
 }
@@ -497,11 +497,18 @@ pub trait Secret: Drop + Debug + Display {}
 ///
 /// This is not intended as a mechanism to clone the state of an object since in most cases `.clone()`
 /// will be more straightforward.
+///
+/// The serialized state MAY contain short-term sensitive values such as nonces or IVs,
+/// but it MUST NOT include a serialized private key. Keyed algorithms MUST instead impl
+/// [SerializableKeyedState] which requires the key to be supplied independently at the time of deserialization.
 pub trait SerializableState<const SERIALIZED_STATE_LEN: usize>: Sized {
     /// Serialize the state of the object.
     ///
+    /// Note that this consumes `self` to prevent accidentally continuing to use the object after serialization.
+    /// If you want to do this intentionally, then you will need to clone the object before serializing it.
+    ///
     /// The serialized state MUST include a prefix indicating the version of the library that serialized it.
-    fn serialize_state(&self) -> [u8; SERIALIZED_STATE_LEN];
+    fn serialize_state(self) -> [u8; SERIALIZED_STATE_LEN];
 
     /// Create a new object from a serialized state.
     ///
@@ -511,7 +518,34 @@ pub trait SerializableState<const SERIALIZED_STATE_LEN: usize>: Sized {
     /// deserializer should reject serialized states from that version or older.
     fn from_serialized_state(
         serialized_state: [u8; SERIALIZED_STATE_LEN],
-    ) -> Result<Self, CoreError>;
+    ) -> Result<Self, SerializedStateError>;
+}
+
+/// Similar to [SerializableState] in that it allows a stateful object to serialize its state so that
+/// it can be paused and resumed later, potentially from a different host.
+///
+/// The difference is that this trait is for keyed algorithms -- MACs, symmetric ciphers, signatures, etc --
+/// which require a private key. For security reasons, the private key is not included in the serialized state
+/// and must be provided separately as part of the deserialization process.
+pub trait SerializableKeyedState<const SERIALIZED_STATE_LEN: usize, K>: Sized {
+    /// Serialize the state of the object.
+    ///
+    /// Note that this consumes `self` to prevent accidentally continuing to use the object after serialization.
+    /// If you want to do this intentionally, then you will need to clone the object before serializing it.
+    ///
+    /// The serialized state MUST include a prefix indicating the version of the library that serialized it.
+    fn serialize_state(self) -> [u8; SERIALIZED_STATE_LEN];
+
+    /// Create a new object from a serialized state.
+    ///
+    /// Deserializers SHOULD check the version and reject serialized states from incompatible versions
+    /// (including rejecting serializations from a future version of the library).
+    /// For example, if a given object made a breaking change to its serialization in version 1.2.3, then its
+    /// deserializer should reject serialized states from that version or older.
+    fn from_serialized_state(
+        serialized_state: [u8; SERIALIZED_STATE_LEN],
+        key: K,
+    ) -> Result<Self, SerializedStateError>;
 }
 
 /// Pre-Hashed Signer is an extension to [Signer] that adds functionality specific to signature

--- a/crypto/core/src/traits.rs
+++ b/crypto/core/src/traits.rs
@@ -517,9 +517,7 @@ pub trait Suspendable<const SERIALIZED_STATE_LEN: usize>: Sized {
     /// (including rejecting serializations from a future version of the library).
     /// For example, if a given object made a breaking change to its serialization in version 1.2.3, then its
     /// deserializer should reject serialized states from that version or older.
-    fn from_suspended(
-        state: [u8; SERIALIZED_STATE_LEN],
-    ) -> Result<Self, SerializedStateError>;
+    fn from_suspended(state: [u8; SERIALIZED_STATE_LEN]) -> Result<Self, SerializedStateError>;
 }
 
 /// Similar to [Suspendable] in that it allows a stateful object to suspend its operation by

--- a/crypto/core/src/traits.rs
+++ b/crypto/core/src/traits.rs
@@ -527,7 +527,10 @@ pub trait SerializableState<const SERIALIZED_STATE_LEN: usize>: Sized {
 /// The difference is that this trait is for keyed algorithms -- MACs, symmetric ciphers, signatures, etc --
 /// which require a private key. For security reasons, the private key is not included in the serialized state
 /// and must be provided separately as part of the deserialization process.
-pub trait SerializableKeyedState<const SERIALIZED_STATE_LEN: usize, K>: Sized {
+pub trait SerializableKeyedState<const SERIALIZED_STATE_LEN: usize>: Sized {
+    /// The type of key that must be re-supplied to resume this object.
+    type Key: ?Sized;
+
     /// Serialize the state of the object.
     ///
     /// Note that this consumes `self` to prevent accidentally continuing to use the object after serialization.
@@ -544,7 +547,7 @@ pub trait SerializableKeyedState<const SERIALIZED_STATE_LEN: usize, K>: Sized {
     /// deserializer should reject serialized states from that version or older.
     fn from_serialized_state(
         serialized_state: [u8; SERIALIZED_STATE_LEN],
-        key: K,
+        key: &Self::Key,
     ) -> Result<Self, SerializedStateError>;
 }
 

--- a/crypto/core/src/traits.rs
+++ b/crypto/core/src/traits.rs
@@ -1,6 +1,6 @@
 //! Provides simplified abstracted APIs over classes of cryptigraphic primitives, such as Hash, KDF, etc.
 
-use crate::errors::{HashError, KDFError, KEMError, MACError, RNGError, SignatureError};
+use crate::errors::{CoreError, HashError, KDFError, KEMError, MACError, RNGError, SignatureError};
 use crate::key_material::KeyMaterialTrait;
 use core::fmt::{Debug, Display};
 use core::marker::Sized;
@@ -37,7 +37,6 @@ pub trait Hash: Default {
     /// Provide a chunk of data to be absorbed into the hashes.
     /// `data` can be of any length, including zero bytes.
     /// do_update() is intended to be used as part of a streaming interface, and so may by called multiple times.
-    // fn do_update(&mut self, data: &[u8]) -> Result<(), HashError>;
     fn do_update(&mut self, data: &[u8]);
 
     /// Finish absorbing input and produce the hashes output.
@@ -469,6 +468,31 @@ pub trait RNG {
 // So I'm turning off this lint.
 #[allow(drop_bounds)]
 pub trait Secret: Drop + Debug + Display {}
+
+/// Allows a stateful object to serialize its state so that it can be paused and resumed later,
+/// potentially from a different host.
+///
+/// This is intended for situations where an object is being used through its streaming API
+/// (do_update, do_final) and the operation wants to be paused to a cache, for example while waiting
+/// for network IO.
+///
+/// This is not intended as a mechanism to clone the state of an object since in most cases `.clone()`
+/// will be more straightforward.
+pub trait SerializableState<const SERIALIZED_STATE_LEN: usize>: Sized {
+    /// Serialize the state of the object.
+    ///
+    /// The serialized state MUST include a prefix indicating the version of the library that serialized it.
+    fn serialize_state(&self) -> [u8; SERIALIZED_STATE_LEN];
+
+    /// Create a new object from a serialized state.
+    ///
+    /// Deserializers SHOULD check the version and reject serialized states from incompatible versions.
+    /// For example, if a given object made a breaking change to its serialization in version 1.2.3, then its
+    /// deserializer should reject serialized states from that version or older.
+    fn from_serialized_state(
+        serialized_state: [u8; SERIALIZED_STATE_LEN],
+    ) -> Result<Self, CoreError>;
+}
 
 /// Pre-Hashed Signer is an extension to [Signer] that adds functionality specific to signature
 /// primatives that can operate on a pre-hashed message instead of the full message.

--- a/crypto/core/src/traits.rs
+++ b/crypto/core/src/traits.rs
@@ -17,7 +17,7 @@ pub trait Algorithm {
     const MAX_SECURITY_STRENGTH: SecurityStrength;
 }
 
-pub trait Hash: Default {
+pub trait Hash: Algorithm + Default {
     /// The size of the internal block in bits -- needed by functions such as HMAC to compute security parameters.
     fn block_bitlen(&self) -> usize;
 
@@ -399,9 +399,9 @@ pub enum SecurityStrength {
 }
 
 impl TryFrom<u8> for SecurityStrength {
-    type Error = SerializedStateError;
+    type Error = SuspendableError;
 
-    /// Inverse of `self as u8`; rejects unrecognized discriminants with [SerializedStateError::InvalidData].
+    /// Inverse of `self as u8`; rejects unrecognized discriminants with [SuspendableError::InvalidData].
     fn try_from(value: u8) -> Result<Self, Self::Error> {
         Ok(match value {
             0 => Self::None,
@@ -409,7 +409,7 @@ impl TryFrom<u8> for SecurityStrength {
             2 => Self::_128bit,
             3 => Self::_192bit,
             4 => Self::_256bit,
-            _ => return Err(SerializedStateError::InvalidData),
+            _ => return Err(SuspendableError::InvalidData),
         })
     }
 }
@@ -517,7 +517,7 @@ pub trait Suspendable<const SERIALIZED_STATE_LEN: usize>: Sized {
     /// (including rejecting serializations from a future version of the library).
     /// For example, if a given object made a breaking change to its serialization in version 1.2.3, then its
     /// deserializer should reject serialized states from that version or older.
-    fn from_suspended(state: [u8; SERIALIZED_STATE_LEN]) -> Result<Self, SerializedStateError>;
+    fn from_suspended(state: [u8; SERIALIZED_STATE_LEN]) -> Result<Self, SuspendableError>;
 }
 
 /// Similar to [Suspendable] in that it allows a stateful object to suspend its operation by
@@ -548,7 +548,7 @@ pub trait SuspendableKeyed<const SERIALIZED_STATE_LEN: usize>: Sized {
     fn from_suspended(
         state: [u8; SERIALIZED_STATE_LEN],
         key: &Self::Key,
-    ) -> Result<Self, SerializedStateError>;
+    ) -> Result<Self, SuspendableError>;
 }
 
 /// Pre-Hashed Signer is an extension to [Signer] that adds functionality specific to signature

--- a/crypto/core/src/traits.rs
+++ b/crypto/core/src/traits.rs
@@ -488,8 +488,8 @@ pub trait RNG {
 #[allow(drop_bounds)]
 pub trait Secret: Drop + Debug + Display {}
 
-/// Allows a stateful object to serialize its state so that it can be paused and resumed later,
-/// potentially from a different host.
+/// Allows a stateful object to suspend its operation by serializing its state into a byte array
+///so that it can be resumed later, potentially from a different host.
 ///
 /// This is intended for situations where an object is being used through its streaming API
 /// (do_update, do_final) and the operation wants to be paused to a cache, for example while waiting
@@ -499,54 +499,56 @@ pub trait Secret: Drop + Debug + Display {}
 /// will be more straightforward.
 ///
 /// The serialized state MAY contain short-term sensitive values such as nonces or IVs,
-/// but it MUST NOT include a serialized private key. Keyed algorithms MUST instead impl
-/// [SerializableKeyedState] which requires the key to be supplied independently at the time of deserialization.
-pub trait SerializableState<const SERIALIZED_STATE_LEN: usize>: Sized {
-    /// Serialize the state of the object.
+/// but it MUST NOT include a serialized private key.
+/// Keyed algorithms MUST instead impl
+/// [SuspendableKeyed] which requires the key to be supplied independently at the time of deserialization.
+pub trait Suspendable<const SERIALIZED_STATE_LEN: usize>: Sized {
+    /// Suspend operation by serializing out the state of the object.
     ///
     /// Note that this consumes `self` to prevent accidentally continuing to use the object after serialization.
     /// If you want to do this intentionally, then you will need to clone the object before serializing it.
     ///
     /// The serialized state MUST include a prefix indicating the version of the library that serialized it.
-    fn serialize_state(self) -> [u8; SERIALIZED_STATE_LEN];
+    fn suspend(self) -> [u8; SERIALIZED_STATE_LEN];
 
-    /// Create a new object from a serialized state.
+    /// Resume operation from a serialized state.
     ///
     /// Deserializers SHOULD check the version and reject serialized states from incompatible versions
     /// (including rejecting serializations from a future version of the library).
     /// For example, if a given object made a breaking change to its serialization in version 1.2.3, then its
     /// deserializer should reject serialized states from that version or older.
-    fn from_serialized_state(
-        serialized_state: [u8; SERIALIZED_STATE_LEN],
+    fn from_suspended(
+        state: [u8; SERIALIZED_STATE_LEN],
     ) -> Result<Self, SerializedStateError>;
 }
 
-/// Similar to [SerializableState] in that it allows a stateful object to serialize its state so that
-/// it can be paused and resumed later, potentially from a different host.
+/// Similar to [Suspendable] in that it allows a stateful object to suspend its operation by
+/// serializing its state into a byte array so that it can be resumed later, potentially from a different host.
 ///
 /// The difference is that this trait is for keyed algorithms -- MACs, symmetric ciphers, signatures, etc --
-/// which require a private key. For security reasons, the private key is not included in the serialized state
+/// which require a private key in order to resume successfully.
+/// For security reasons, the private key is not included in the serialized state
 /// and must be provided separately as part of the deserialization process.
-pub trait SerializableKeyedState<const SERIALIZED_STATE_LEN: usize>: Sized {
+pub trait SuspendableKeyed<const SERIALIZED_STATE_LEN: usize>: Sized {
     /// The type of key that must be re-supplied to resume this object.
     type Key: ?Sized;
 
-    /// Serialize the state of the object.
+    /// Suspend operation by serializing out the state of the object.
     ///
     /// Note that this consumes `self` to prevent accidentally continuing to use the object after serialization.
     /// If you want to do this intentionally, then you will need to clone the object before serializing it.
     ///
     /// The serialized state MUST include a prefix indicating the version of the library that serialized it.
-    fn serialize_state(self) -> [u8; SERIALIZED_STATE_LEN];
+    fn suspend(self) -> [u8; SERIALIZED_STATE_LEN];
 
-    /// Create a new object from a serialized state.
+    /// Resume operation from a serialized state and the key.
     ///
     /// Deserializers SHOULD check the version and reject serialized states from incompatible versions
     /// (including rejecting serializations from a future version of the library).
     /// For example, if a given object made a breaking change to its serialization in version 1.2.3, then its
     /// deserializer should reject serialized states from that version or older.
-    fn from_serialized_state(
-        serialized_state: [u8; SERIALIZED_STATE_LEN],
+    fn from_suspended(
+        state: [u8; SERIALIZED_STATE_LEN],
         key: &Self::Key,
     ) -> Result<Self, SerializedStateError>;
 }

--- a/crypto/core/src/traits.rs
+++ b/crypto/core/src/traits.rs
@@ -386,13 +386,32 @@ pub trait MAC: Sized {
     fn max_security_strength(&self) -> SecurityStrength;
 }
 
-#[derive(Eq, PartialEq, PartialOrd, Clone, Debug)]
+// The explicit `#[repr(u8)]` discriminants are the stable on-the-wire encoding used by
+// `SerializableState` implementations (see the `TryFrom<u8>` impl below).
+#[derive(Eq, PartialEq, PartialOrd, Clone, Copy, Debug)]
+#[repr(u8)]
 pub enum SecurityStrength {
-    None,
-    _112bit,
-    _128bit,
-    _192bit,
-    _256bit,
+    None = 0,
+    _112bit = 1,
+    _128bit = 2,
+    _192bit = 3,
+    _256bit = 4,
+}
+
+impl TryFrom<u8> for SecurityStrength {
+    type Error = CoreError;
+
+    /// Inverse of `self as u8`; rejects unrecognized discriminants with [CoreError::InvalidData].
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        Ok(match value {
+            0 => Self::None,
+            1 => Self::_112bit,
+            2 => Self::_128bit,
+            3 => Self::_192bit,
+            4 => Self::_256bit,
+            _ => return Err(CoreError::InvalidData),
+        })
+    }
 }
 
 impl SecurityStrength {

--- a/crypto/core/src/traits.rs
+++ b/crypto/core/src/traits.rs
@@ -486,7 +486,8 @@ pub trait SerializableState<const SERIALIZED_STATE_LEN: usize>: Sized {
 
     /// Create a new object from a serialized state.
     ///
-    /// Deserializers SHOULD check the version and reject serialized states from incompatible versions.
+    /// Deserializers SHOULD check the version and reject serialized states from incompatible versions
+    /// (including rejecting serializations from a future version of the library).
     /// For example, if a given object made a breaking change to its serialization in version 1.2.3, then its
     /// deserializer should reject serialized states from that version or older.
     fn from_serialized_state(

--- a/crypto/factory/src/hash_factory.rs
+++ b/crypto/factory/src/hash_factory.rs
@@ -29,7 +29,7 @@
 use crate::{AlgorithmFactory, FactoryError};
 use crate::{DEFAULT, DEFAULT_128_BIT, DEFAULT_256_BIT};
 use bouncycastle_core::errors::HashError;
-use bouncycastle_core::traits::{Hash, SecurityStrength};
+use bouncycastle_core::traits::{Algorithm, Hash, SecurityStrength};
 use bouncycastle_sha2 as sha2;
 use bouncycastle_sha2::{SHA224_NAME, SHA256_NAME, SHA384_NAME, SHA512_NAME};
 use bouncycastle_sha3 as sha3;
@@ -81,6 +81,12 @@ impl AlgorithmFactory for HashFactory {
             ))),
         }
     }
+}
+
+// TODO -- this does't work. Perhaps Algorithm needs to be re-worked so that these are functions instead?
+impl Algorithm for HashFactory {
+    const ALG_NAME: &'static str = "TODO";
+    const MAX_SECURITY_STRENGTH: SecurityStrength = SecurityStrength::None;
 }
 
 impl Hash for HashFactory {

--- a/crypto/factory/src/hash_factory.rs
+++ b/crypto/factory/src/hash_factory.rs
@@ -83,10 +83,19 @@ impl AlgorithmFactory for HashFactory {
     }
 }
 
-// TODO -- this does't work. Perhaps Algorithm needs to be re-worked so that these are functions instead?
+// `HashFactory` is a runtime selector over several hash algorithms, so it cannot report a single
+// compile-time `ALG_NAME` / `MAX_SECURITY_STRENGTH` for the concrete algorithm it currently wraps.
+// `Algorithm`'s members are associated *consts*, which can't vary per enum variant. This impl
+// therefore describes the factory *type*, not the wrapped algorithm:
+//   - `ALG_NAME` is the factory's own name.
+//   - `MAX_SECURITY_STRENGTH` is the ceiling the factory can ever produce (SHA-512 / SHA3-512).
+// For the *selected* algorithm's actual properties, use the `Hash` trait methods on the instance
+// (e.g. `max_security_strength()`), which dispatch to the wrapped algorithm.
+// (Longer term: if callers need the wrapped algorithm's name at runtime, `Algorithm` would need a
+// method rather than a const.)
 impl Algorithm for HashFactory {
-    const ALG_NAME: &'static str = "TODO";
-    const MAX_SECURITY_STRENGTH: SecurityStrength = SecurityStrength::None;
+    const ALG_NAME: &'static str = "HashFactory";
+    const MAX_SECURITY_STRENGTH: SecurityStrength = SecurityStrength::_256bit;
 }
 
 impl Hash for HashFactory {

--- a/crypto/factory/src/hash_factory.rs
+++ b/crypto/factory/src/hash_factory.rs
@@ -83,19 +83,13 @@ impl AlgorithmFactory for HashFactory {
     }
 }
 
-// `HashFactory` is a runtime selector over several hash algorithms, so it cannot report a single
-// compile-time `ALG_NAME` / `MAX_SECURITY_STRENGTH` for the concrete algorithm it currently wraps.
-// `Algorithm`'s members are associated *consts*, which can't vary per enum variant. This impl
-// therefore describes the factory *type*, not the wrapped algorithm:
-//   - `ALG_NAME` is the factory's own name.
-//   - `MAX_SECURITY_STRENGTH` is the ceiling the factory can ever produce (SHA-512 / SHA3-512).
-// For the *selected* algorithm's actual properties, use the `Hash` trait methods on the instance
-// (e.g. `max_security_strength()`), which dispatch to the wrapped algorithm.
-// (Longer term: if callers need the wrapped algorithm's name at runtime, `Algorithm` would need a
-// method rather than a const.)
+// TODO -- this is broken.
+//      The designed behaviour here is that the Factory object pass these through to the underlying algorithm
+//      that it's wrapping, but that can't be done with consts, so I think the Algorithm trait needs
+//      a rework to be functions instead of consts.
 impl Algorithm for HashFactory {
-    const ALG_NAME: &'static str = "HashFactory";
-    const MAX_SECURITY_STRENGTH: SecurityStrength = SecurityStrength::_256bit;
+    const ALG_NAME: &'static str = "TODO";
+    const MAX_SECURITY_STRENGTH: SecurityStrength = SecurityStrength::None;
 }
 
 impl Hash for HashFactory {

--- a/crypto/hkdf/src/lib.rs
+++ b/crypto/hkdf/src/lib.rs
@@ -192,7 +192,7 @@
 
 #![forbid(unsafe_code)]
 
-use bouncycastle_core::errors::{KDFError, KeyMaterialError, MACError, SerializedStateError};
+use bouncycastle_core::errors::{KDFError, KeyMaterialError, MACError, SuspendableError};
 use bouncycastle_core::key_material;
 use bouncycastle_core::key_material::{
     KeyMaterial, KeyMaterial0, KeyMaterial512, KeyMaterialTrait, KeyType,
@@ -252,15 +252,15 @@ enum HkdfStates {
 }
 
 impl TryFrom<u8> for HkdfStates {
-    type Error = SerializedStateError;
+    type Error = SuspendableError;
 
-    /// Inverse of `self as u8`; rejects unrecognized discriminants with [SerializedStateError::InvalidData].
+    /// Inverse of `self as u8`; rejects unrecognized discriminants with [SuspendableError::InvalidData].
     fn try_from(value: u8) -> Result<Self, Self::Error> {
         Ok(match value {
             0 => Self::Uninitialized,
             1 => Self::Initialized,
             2 => Self::TakingAdditionalInfo,
-            _ => return Err(SerializedStateError::InvalidData),
+            _ => return Err(SuspendableError::InvalidData),
         })
     }
 }
@@ -830,7 +830,7 @@ macro_rules! impl_suspendable_keyed_state_for_hkdf {
             fn from_suspended(
                 state: [u8; $serialized_hkdf_len],
                 salt: &Self::Key,
-            ) -> Result<Self, SerializedStateError> {
+            ) -> Result<Self, SuspendableError> {
                 // Rebuild the salt-keyed HMAC (first in the payload) by re-supplying the salt.
 
                 // This double-dips on HMAC checking the version tag before going any further.
@@ -843,10 +843,21 @@ macro_rules! impl_suspendable_keyed_state_for_hkdf {
                         state[..$serialized_hmac_len].try_into().unwrap(),
                         salt,
                     )?),
-                    _ => return Err(SerializedStateError::InvalidData),
+                    _ => return Err(SuspendableError::InvalidData),
                 };
 
                 let hkdf_state = HkdfStates::try_from(state[$serialized_hmac_len + 1])?;
+
+                // check that the hkdf_state aligns with the presence of an hmac
+                if
+                    // an hmac object should not be present in the init state.
+                    (hmac.is_some() && hkdf_state == HkdfStates::Uninitialized) ||
+                    // any other state must have an hmac object.
+                    (hmac.is_none() && hkdf_state != HkdfStates::Uninitialized)
+                {
+                    return Err(SuspendableError::InvalidData);
+                }
+
                 let entropy = u64::from_le_bytes(
                     state[$serialized_hmac_len + 2..$serialized_hmac_len + 10].try_into().unwrap(),
                 ) as usize;

--- a/crypto/hkdf/src/lib.rs
+++ b/crypto/hkdf/src/lib.rs
@@ -179,9 +179,10 @@ pub type HKDF_SHA256 = HKDF<SHA256>;
 pub type HKDF_SHA512 = HKDF<SHA512>;
 
 pub struct HKDF<H: Hash + HashAlgParams + Default> {
-    hmac: Option<HMAC<H>>, // Optional because we can't construct an HMAC until they give us a key
+    // Optional because we can't construct an HMAC until they give us a key
     // to initialize it with.
     // None should correspond to a state of Uninitialized.
+    hmac: Option<HMAC<H>>,
     entropy: HkdfEntropyTracker<H>,
     state: HkdfStates,
 }
@@ -410,7 +411,6 @@ impl<H: Hash + HashAlgParams + Default> HKDF<H> {
         key_material::do_hazardous_operations(okm, |okm| {
             let out = okm.ref_to_bytes_mut()?;
             while i < N {
-                // todo: might need this to be new_allow_weak_key()
                 let mut hmac = HMAC::<H>::new(&prk_as_mac_key)
                     .map_err(|_| KeyMaterialError::GenericError("HMAC initialization failed"))?;
                 hmac.do_update(&T[..t_len]);
@@ -430,7 +430,6 @@ impl<H: Hash + HashAlgParams + Default> HKDF<H> {
 
         // On the last iteration, we don't take all of the output.
         let remaining = L - bytes_written;
-        // todo: might need this to be new_allow_weak_key()
         let mut hmac = HMAC::<H>::new(&prk_as_mac_key)?;
         hmac.do_update(&T[..t_len]);
         hmac.do_update(info);
@@ -489,8 +488,7 @@ impl<H: Hash + HashAlgParams + Default> HKDF<H> {
     /// The output KeyMaterial will be of fixed size, with a capacity large enough to cover any
     /// underlying hash function, but the actual key length will be appropriate to the underlying hash function.
     ///
-    /// Salt is optional, which is indicated by providing an uninitialized KeyMaterial object of length zero,
-    /// the capacity is irrelevant, so KeyMateriol256::new() or KeyMaterial_internal::<0>::new() would both count as an absent salt.
+    /// Salt is optional; to omit it, provide a KeyMaterial0, which will cause HKDF to use the default all-zero salt.
     ///
     /// Returns the number of bits of entropy credited to this input key material.
     pub fn do_extract_init(&mut self, salt: &impl KeyMaterialTrait) -> Result<usize, MACError> {

--- a/crypto/hkdf/src/lib.rs
+++ b/crypto/hkdf/src/lib.rs
@@ -144,16 +144,63 @@
 //! let mut okm = KeyMaterial::<200>::new();
 //! let _bytes_written = HKDF_SHA256::extract_and_expand_out(&salt, &ikm, info, 200, &mut okm).unwrap();
 //! ```
+//!
+//! # Suspending and resuming execution
+//!
+//! The *HKDF-Extract* phase supports a streaming API whereby any amount of additional input keying
+//! material can be provided either via [HKDF::do_extract_update_key] -- which will
+//! credit the entropy of the provided [KeyMaterial] -- or as raw uncredited bytes via
+//! [HKDF::do_extract_update_bytes].
+//!
+//! As such, The *HKDF-Extract* phase can be suspended to a cache and resumed later via the
+//! [SuspendableKeyed] trait.
+//!
+//! The HKDF algorithm is keyed by a `salt`, which is required twice: once at initialization and again
+//! during finalization. Suspension and resumption are supported via the [SuspendableKeyed] trait
+//! which requires the caller to store the salt securely and provide it again during resumption.
+//! Note that providing a different salt during resumption cannot be detected by the library and
+//! would silently produce a different PRK.
+//!
+//! ```rust
+//! use bouncycastle_hkdf::HKDF_SHA256;
+//! use bouncycastle_core::key_material::{KeyMaterial256, KeyType};
+//! use bouncycastle_core::traits::SuspendableKeyed;
+//!
+//! let salt = KeyMaterial256::from_bytes_as_type(
+//!             b"\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f",
+//!             KeyType::MACKey).unwrap();
+//! let ikm_part1 = b"input keying material part 1";
+//! let ikm_part2 = b" ...and part 2";
+//!
+//! let mut hkdf = HKDF_SHA256::new();
+//! hkdf.do_extract_init(&salt).unwrap();
+//! hkdf.do_extract_update_bytes(ikm_part1).unwrap();
+//!
+//! // suspend the in-progress extract (the salt is NOT included in the serialized state)
+//! let serialized_state = hkdf.suspend();
+//!
+//! // ...
+//! // do other things in the meantime
+//! // ...
+//!
+//! // ... later, possibly on another host: resume from the serialized state by re-supplying
+//! // the same salt (make sure you store it securely!).
+//! let mut hkdf = HKDF_SHA256::from_suspended(serialized_state, &salt).unwrap();
+//! hkdf.do_extract_update_bytes(ikm_part2).unwrap();
+//! let _prk = hkdf.do_extract_final().unwrap();
+//! ```
 
 #![forbid(unsafe_code)]
 
-use bouncycastle_core::errors::{KDFError, KeyMaterialError, MACError};
+use bouncycastle_core::errors::{KDFError, KeyMaterialError, MACError, SerializedStateError};
 use bouncycastle_core::key_material;
 use bouncycastle_core::key_material::{
     KeyMaterial, KeyMaterial0, KeyMaterial512, KeyMaterialTrait, KeyType,
 };
-use bouncycastle_core::traits::{Hash, HashAlgParams, KDF, MAC, SecurityStrength};
-use bouncycastle_hmac::HMAC;
+use bouncycastle_core::traits::{
+    Hash, HashAlgParams, KDF, MAC, SecurityStrength, SuspendableKeyed,
+};
+use bouncycastle_hmac::{HMAC, SUSPENDED_HMAC_SHA256_STATE_LEN, SUSPENDED_HMAC_SHA512_STATE_LEN};
 use bouncycastle_sha2::{SHA256, SHA512};
 use bouncycastle_utils::{max, min};
 use std::marker::PhantomData;
@@ -163,7 +210,7 @@ use bouncycastle_core::traits::XOF;
 // end doc-only imports
 
 /*** Constants ***/
-// Slightly hacky, but set this to accomodate the underlying hash primitive with the largest output size.
+// Slightly hacky, but set this to accommodate the underlying hash primitive with the largest output size.
 // Would be better to somehow pull that at compile time from H, but I'm not sure how to do that.
 const HMAC_BLOCK_LEN: usize = 64;
 
@@ -178,6 +225,7 @@ pub type HKDF_SHA256 = HKDF<SHA256>;
 #[allow(non_camel_case_types)]
 pub type HKDF_SHA512 = HKDF<SHA512>;
 
+#[derive(Clone)]
 pub struct HKDF<H: Hash + HashAlgParams + Default> {
     // Optional because we can't construct an HMAC until they give us a key
     // to initialize it with.
@@ -190,18 +238,34 @@ pub struct HKDF<H: Hash + HashAlgParams + Default> {
 // Note: does not need to impl Drop because HKDF itself does not hold any sensitive state data.
 
 #[derive(Clone, Debug, PartialOrd, PartialEq)]
+#[repr(u8)]
 enum HkdfStates {
     /// waiting for salt
-    Uninitialized,
+    Uninitialized = 0,
 
     /// Salt set, waiting for IKMs or do_final
-    Initialized,
+    Initialized = 1,
 
     /// [HKDF::do_extract_update_key] has been called, after which no more credited IKMs can be given.
     /// This is in conformance with NIST SP 800-133 which requires all keys to come before other inputs.
-    TakingAdditionalInfo,
+    TakingAdditionalInfo = 2,
 }
 
+impl TryFrom<u8> for HkdfStates {
+    type Error = SerializedStateError;
+
+    /// Inverse of `self as u8`; rejects unrecognized discriminants with [SerializedStateError::InvalidData].
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        Ok(match value {
+            0 => Self::Uninitialized,
+            1 => Self::Initialized,
+            2 => Self::TakingAdditionalInfo,
+            _ => return Err(SerializedStateError::InvalidData),
+        })
+    }
+}
+
+#[derive(Clone)]
 struct HkdfEntropyTracker<H: Hash + HashAlgParams + Default> {
     _phantomhash: PhantomData<H>,
     entropy: usize,
@@ -711,3 +775,105 @@ impl<H: Hash + HashAlgParams + Default> KDF for HKDF<H> {
         H::default().max_security_strength()
     }
 }
+
+/// Length in bytes of the serialized state of [HKDF_SHA256].
+pub const SUSPENDED_HKDF_SHA256_STATE_LEN: usize = SUSPENDED_HMAC_SHA256_STATE_LEN + 11;
+/// Length in bytes of the serialized state of [HKDF_SHA512].
+pub const SUSPENDED_HKDF_SHA512_STATE_LEN: usize = SUSPENDED_HMAC_SHA512_STATE_LEN + 11;
+
+/// HKDF is *keyed by its salt* -- the salt keys the extract-phase HMAC -- so it implements
+/// [SuspendableKeyed] (not [SerializableState]). An in-progress
+/// extract operation can be suspended and resumed, but the salt is NOT written into the serialized
+/// state and must be re-supplied to [SuspendableKeyed::from_serialized_state].
+///
+/// Only the extract phase carries resumable state (expand is a one-shot static operation). As with
+/// HMAC, resuming with the wrong salt cannot be detected and will silently produce a wrong PRK.
+///
+/// Serialized layout: the 3-byte library version header comes first and is checked before anything
+/// else is parsed; then, using `B` = the inner HMAC blob length:
+///   [0 .. B)         the inner HMAC's SerializableKeyedState blob (salt excluded); zeroed when absent
+///   [B]              inner-HMAC present flag (0 = extract not yet initialized)
+///   [B + 1]          state-machine tag (see `HkdfStates`)
+///   [B + 2 .. B + 10)  entropy counter (usize serialized as u64, little-endian)
+///   [B + 10]         accumulated security strength (1-byte tag)
+/// The number of bytes produced by `SerializableKeyedState::serialize_state` for each HKDF variant:
+/// the 3-byte library version header + 11 bytes of HKDF bookkeeping (HMAC-present flag, state tag,
+/// entropy counter, security strength) + the inner HMAC's serialized-state blob.
+macro_rules! impl_suspendable_keyed_state_for_hkdf {
+    // $hash: the concrete hash; $hmac_blob: the inner HMAC's serialized-state length for that hash;
+    // $total: the full HKDF serialized-state length (= 3 + 11 + $hmac_blob).
+    ($hash:ty, $serialized_hmac_len:expr, $serialized_hkdf_len:expr) => {
+        impl SuspendableKeyed<{ $serialized_hkdf_len }> for HKDF<$hash> {
+            // HMAC accepts any key material, so the key type is the trait object `dyn KeyMaterialTrait`
+            // rather than a single concrete key type. The key is only used (by reference) to reload the key
+            // bytes at from_serialized_state, so dynamic dispatch here is negligible.
+            type Key = dyn KeyMaterialTrait;
+
+            fn suspend(self) -> [u8; $serialized_hkdf_len] {
+                debug_assert_eq!($serialized_hkdf_len, $serialized_hmac_len + 11);
+                let mut state = [0u8; $serialized_hkdf_len];
+
+                // The inner HMAC blob goes first, which carries a lib version header.
+                if let Some(hmac) = self.hmac {
+                    state[..$serialized_hmac_len].copy_from_slice(&hmac.suspend());
+                    state[$serialized_hmac_len] = 1; // present flag
+                }
+
+                state[$serialized_hmac_len + 1] = self.state as u8;
+                state[$serialized_hmac_len + 2..$serialized_hmac_len + 10]
+                    .copy_from_slice(&(self.entropy.entropy as u64).to_le_bytes());
+                state[$serialized_hmac_len + 10] = self.entropy.security_strength as u8;
+
+                state
+            }
+
+            fn from_suspended(
+                state: [u8; $serialized_hkdf_len],
+                salt: &Self::Key,
+            ) -> Result<Self, SerializedStateError> {
+                // Rebuild the salt-keyed HMAC (first in the payload) by re-supplying the salt.
+
+                // This double-dips on HMAC checking the version tag before going any further.
+                // If ever we need to version-reject HKDF separately from HMAC, then we'll need to add
+                // an explicit version check here, and change "None" to the oldest accepted version.
+                // _ = check_lib_ver(&serialized_state, None)?;
+                let hmac = match state[$serialized_hmac_len] {
+                    0 => None,
+                    1 => Some(HMAC::<$hash>::from_suspended(
+                        state[..$serialized_hmac_len].try_into().unwrap(),
+                        salt,
+                    )?),
+                    _ => return Err(SerializedStateError::InvalidData),
+                };
+
+                let hkdf_state = HkdfStates::try_from(state[$serialized_hmac_len + 1])?;
+                let entropy = u64::from_le_bytes(
+                    state[$serialized_hmac_len + 2..$serialized_hmac_len + 10].try_into().unwrap(),
+                ) as usize;
+                let security_strength =
+                    SecurityStrength::try_from(state[$serialized_hmac_len + 10])?;
+
+                Ok(HKDF {
+                    hmac,
+                    entropy: HkdfEntropyTracker {
+                        _phantomhash: PhantomData,
+                        entropy,
+                        security_strength,
+                    },
+                    state: hkdf_state,
+                })
+            }
+        }
+    };
+}
+
+impl_suspendable_keyed_state_for_hkdf!(
+    SHA256,
+    SUSPENDED_HMAC_SHA256_STATE_LEN,
+    SUSPENDED_HKDF_SHA256_STATE_LEN
+);
+impl_suspendable_keyed_state_for_hkdf!(
+    SHA512,
+    SUSPENDED_HMAC_SHA512_STATE_LEN,
+    SUSPENDED_HKDF_SHA512_STATE_LEN
+);

--- a/crypto/hkdf/src/lib.rs
+++ b/crypto/hkdf/src/lib.rs
@@ -197,6 +197,7 @@ use bouncycastle_core::key_material;
 use bouncycastle_core::key_material::{
     KeyMaterial, KeyMaterial0, KeyMaterial512, KeyMaterialTrait, KeyType,
 };
+use bouncycastle_core::suspendable_state::{add_lib_ver, check_lib_ver};
 use bouncycastle_core::traits::{
     Hash, HashAlgParams, KDF, MAC, SecurityStrength, SuspendableKeyed,
 };
@@ -777,9 +778,9 @@ impl<H: Hash + HashAlgParams + Default> KDF for HKDF<H> {
 }
 
 /// Length in bytes of the serialized state of [HKDF_SHA256].
-pub const SUSPENDED_HKDF_SHA256_STATE_LEN: usize = SUSPENDED_HMAC_SHA256_STATE_LEN + 11;
+pub const SUSPENDED_HKDF_SHA256_STATE_LEN: usize = SUSPENDED_HMAC_SHA256_STATE_LEN + 14;
 /// Length in bytes of the serialized state of [HKDF_SHA512].
-pub const SUSPENDED_HKDF_SHA512_STATE_LEN: usize = SUSPENDED_HMAC_SHA512_STATE_LEN + 11;
+pub const SUSPENDED_HKDF_SHA512_STATE_LEN: usize = SUSPENDED_HMAC_SHA512_STATE_LEN + 14;
 
 /// HKDF is *keyed by its salt* -- the salt keys the extract-phase HMAC -- so it implements
 /// [SuspendableKeyed] (not [SerializableState]). An in-progress
@@ -789,19 +790,21 @@ pub const SUSPENDED_HKDF_SHA512_STATE_LEN: usize = SUSPENDED_HMAC_SHA512_STATE_L
 /// Only the extract phase carries resumable state (expand is a one-shot static operation). As with
 /// HMAC, resuming with the wrong salt cannot be detected and will silently produce a wrong PRK.
 ///
-/// Serialized layout: the 3-byte library version header comes first and is checked before anything
-/// else is parsed; then, using `B` = the inner HMAC blob length:
-///   [0 .. B)         the inner HMAC's SerializableKeyedState blob (salt excluded); zeroed when absent
-///   [B]              inner-HMAC present flag (0 = extract not yet initialized)
-///   [B + 1]          state-machine tag (see `HkdfStates`)
-///   [B + 2 .. B + 10)  entropy counter (usize serialized as u64, little-endian)
-///   [B + 10]         accumulated security strength (1-byte tag)
-/// The number of bytes produced by `SerializableKeyedState::serialize_state` for each HKDF variant:
-/// the 3-byte library version header + 11 bytes of HKDF bookkeeping (HMAC-present flag, state tag,
-/// entropy counter, security strength) + the inner HMAC's serialized-state blob.
+/// Serialized layout: HKDF writes its own 3-byte library version header first and checks it before
+/// parsing anything else. This matters because the inner HMAC blob (which carries its own header) is
+/// absent before extract is initialized -- without HKDF's own header, a pre-init state would have no
+/// version tag at all. Using `B` = the inner HMAC blob length:
+///   [0 .. 3)             HKDF library version header (checked on resume)
+///   [3]                  inner-HMAC present flag (0 = extract not yet initialized)
+///   [4 .. 4 + B)         the inner HMAC's SuspendableKeyed blob (salt excluded); zeroed when absent
+///   [4 + B]              state-machine tag (see `HkdfStates`)
+///   [5 + B .. 13 + B)    entropy counter (usize serialized as u64, little-endian)
+///   [13 + B]             accumulated security strength (1-byte tag)
+/// So the total per HKDF variant is the 3-byte version header + 11 bytes of HKDF bookkeeping
+/// (present flag, state tag, entropy counter, security strength) + the inner HMAC's blob = `B + 14`.
 macro_rules! impl_suspendable_keyed_state_for_hkdf {
-    // $hash: the concrete hash; $hmac_blob: the inner HMAC's serialized-state length for that hash;
-    // $total: the full HKDF serialized-state length (= 3 + 11 + $hmac_blob).
+    // $hash: the concrete hash; $serialized_hmac_len: the inner HMAC's serialized-state length for that
+    // hash; $serialized_hkdf_len: the full HKDF serialized-state length (= 3 + 11 + $serialized_hmac_len).
     ($hash:ty, $serialized_hmac_len:expr, $serialized_hkdf_len:expr) => {
         impl SuspendableKeyed<{ $serialized_hkdf_len }> for HKDF<$hash> {
             // HMAC accepts any key material, so the key type is the trait object `dyn KeyMaterialTrait`
@@ -810,19 +813,27 @@ macro_rules! impl_suspendable_keyed_state_for_hkdf {
             type Key = dyn KeyMaterialTrait;
 
             fn suspend(self) -> [u8; $serialized_hkdf_len] {
-                debug_assert_eq!($serialized_hkdf_len, $serialized_hmac_len + 11);
+                debug_assert_eq!($serialized_hkdf_len, $serialized_hmac_len + 14);
                 let mut state = [0u8; $serialized_hkdf_len];
 
-                // The inner HMAC blob goes first, which carries a lib version header.
-                if let Some(hmac) = self.hmac {
-                    state[..$serialized_hmac_len].copy_from_slice(&hmac.suspend());
-                    state[$serialized_hmac_len] = 1; // present flag
-                }
+                // HKDF's own library version header comes first: the inner HMAC blob is absent before
+                // extract is initialized, so we can't rely on its header being present.
+                add_lib_ver(&mut state);
 
-                state[$serialized_hmac_len + 1] = self.state as u8;
-                state[$serialized_hmac_len + 2..$serialized_hmac_len + 10]
+                // The present flag, then (when present) the inner salt-keyed HMAC blob right after it.
+                if let Some(hmac) = self.hmac {
+                    state[3] = 1; // present flag
+                    state[4..4 + $serialized_hmac_len].copy_from_slice(&hmac.suspend());
+                }
+                // else None:
+                //  the presence flag = 0
+                //  the content = [u8; 0]
+                // which is how it already is, so nothing to do.
+
+                state[4 + $serialized_hmac_len] = self.state as u8;
+                state[5 + $serialized_hmac_len..13 + $serialized_hmac_len]
                     .copy_from_slice(&(self.entropy.entropy as u64).to_le_bytes());
-                state[$serialized_hmac_len + 10] = self.entropy.security_strength as u8;
+                state[13 + $serialized_hmac_len] = self.entropy.security_strength as u8;
 
                 state
             }
@@ -831,22 +842,20 @@ macro_rules! impl_suspendable_keyed_state_for_hkdf {
                 state: [u8; $serialized_hkdf_len],
                 salt: &Self::Key,
             ) -> Result<Self, SuspendableError> {
-                // Rebuild the salt-keyed HMAC (first in the payload) by re-supplying the salt.
+                // Check HKDF's own version header before parsing anything else.
+                check_lib_ver(&state, None)?;
 
-                // This double-dips on HMAC checking the version tag before going any further.
-                // If ever we need to version-reject HKDF separately from HMAC, then we'll need to add
-                // an explicit version check here, and change "None" to the oldest accepted version.
-                // _ = check_lib_ver(&serialized_state, None)?;
-                let hmac = match state[$serialized_hmac_len] {
+                // Rebuild the salt-keyed HMAC (when present) by re-supplying the salt.
+                let hmac = match state[3] {
                     0 => None,
                     1 => Some(HMAC::<$hash>::from_suspended(
-                        state[..$serialized_hmac_len].try_into().unwrap(),
+                        state[4..4 + $serialized_hmac_len].try_into().unwrap(),
                         salt,
                     )?),
                     _ => return Err(SuspendableError::InvalidData),
                 };
 
-                let hkdf_state = HkdfStates::try_from(state[$serialized_hmac_len + 1])?;
+                let hkdf_state = HkdfStates::try_from(state[4 + $serialized_hmac_len])?;
 
                 // check that the hkdf_state aligns with the presence of an hmac
                 if
@@ -859,10 +868,10 @@ macro_rules! impl_suspendable_keyed_state_for_hkdf {
                 }
 
                 let entropy = u64::from_le_bytes(
-                    state[$serialized_hmac_len + 2..$serialized_hmac_len + 10].try_into().unwrap(),
+                    state[5 + $serialized_hmac_len..13 + $serialized_hmac_len].try_into().unwrap(),
                 ) as usize;
                 let security_strength =
-                    SecurityStrength::try_from(state[$serialized_hmac_len + 10])?;
+                    SecurityStrength::try_from(state[13 + $serialized_hmac_len])?;
 
                 Ok(HKDF {
                     hmac,

--- a/crypto/hkdf/src/lib.rs
+++ b/crypto/hkdf/src/lib.rs
@@ -848,6 +848,7 @@ macro_rules! impl_suspendable_keyed_state_for_hkdf {
                 // Rebuild the salt-keyed HMAC (when present) by re-supplying the salt.
                 let hmac = match state[3] {
                     0 => None,
+                    // infallible: the sub-slice is exactly $serialized_hmac_len bytes by const construction.
                     1 => Some(HMAC::<$hash>::from_suspended(
                         state[4..4 + $serialized_hmac_len].try_into().unwrap(),
                         salt,
@@ -867,6 +868,7 @@ macro_rules! impl_suspendable_keyed_state_for_hkdf {
                     return Err(SuspendableError::InvalidData);
                 }
 
+                // infallible: the sub-slice is exactly 8 bytes by const construction.
                 let entropy = u64::from_le_bytes(
                     state[5 + $serialized_hmac_len..13 + $serialized_hmac_len].try_into().unwrap(),
                 ) as usize;

--- a/crypto/hkdf/tests/hkdf_tests.rs
+++ b/crypto/hkdf/tests/hkdf_tests.rs
@@ -11,7 +11,7 @@ mod hkdf_tests {
     use bouncycastle_core_test_framework::kdf::TestFrameworkKDF;
     use bouncycastle_hex as hex;
     use bouncycastle_hkdf::{HKDF, HKDF_SHA256, HKDF_SHA512};
-    use bouncycastle_sha2::SHA256;
+    use bouncycastle_sha2::{SHA256, SHA512};
     use bouncycastle_utils::ct;
 
     #[test]
@@ -738,5 +738,56 @@ mod hkdf_tests {
             additional_input.as_slice(),
             &mut expected_key,
         );
+    }
+    #[test]
+    fn serializable_keyed_state() {
+        use bouncycastle_core::traits::{Hash, SuspendableKeyed};
+        use bouncycastle_core_test_framework::suspendable_state::TestFrameworkSuspendableKeyedState;
+        use bouncycastle_hkdf::{SUSPENDED_HKDF_SHA256_STATE_LEN, SUSPENDED_HKDF_SHA512_STATE_LEN};
+
+        // HKDF is keyed by its salt: the salt is NOT serialized and is re-supplied on resume.
+        let salt =
+            KeyMaterial128::from_bytes_as_type(&DUMMY_SEED_512[..16], KeyType::MACKey).unwrap();
+        let ikm = &DUMMY_SEED_512[16..64];
+        let (part1, part2) = ikm.split_at(20);
+
+        // A helper that exercises the full round-trip for one HKDF variant. A concrete `&KeyMaterial128`
+        // works for `do_extract_init` (which wants a `Sized` `&impl KeyMaterialTrait`) and coerces to
+        // `&dyn KeyMaterialTrait` for the serialization APIs.
+        fn round_trip<const LEN: usize, H>(salt: &KeyMaterial128, part1: &[u8], part2: &[u8])
+        where
+            H: Hash + HashAlgParams + Default,
+            HKDF<H>: Clone + SuspendableKeyed<LEN, Key = dyn KeyMaterialTrait>,
+        {
+            let hkdf = HKDF::<H>::new();
+
+            // it can be serialized pre-init, which is kinda a no-op, but at least it works.
+            let serialized_state = hkdf.suspend();
+            assert_eq!(serialized_state.len(), LEN);
+            let mut hkdf = HKDF::<H>::from_suspended(serialized_state, salt).unwrap();
+
+            hkdf.do_extract_init(salt).unwrap();
+            hkdf.do_extract_update_bytes(part1).unwrap();
+
+            // generic trait-conformance tests (version header present, [0,0,0]/future rejected)
+            TestFrameworkSuspendableKeyedState::new().test(&hkdf, salt);
+
+            // serialize the in-progress extract state (on a clone), then finish the original
+            let serialized_state = hkdf.clone().suspend();
+            assert_eq!(serialized_state.len(), LEN);
+
+            hkdf.do_extract_update_bytes(part2).unwrap();
+            let prk = hkdf.do_extract_final().unwrap();
+
+            // resume (re-supplying the salt), feed the identical remaining IKM, and compare PRKs
+            let mut resumed = HKDF::<H>::from_suspended(serialized_state, salt).unwrap();
+            resumed.do_extract_update_bytes(part2).unwrap();
+            let prk_resumed = resumed.do_extract_final().unwrap();
+
+            assert_eq!(prk.ref_to_bytes(), prk_resumed.ref_to_bytes());
+        }
+
+        round_trip::<SUSPENDED_HKDF_SHA256_STATE_LEN, SHA256>(&salt, part1, part2);
+        round_trip::<SUSPENDED_HKDF_SHA512_STATE_LEN, SHA512>(&salt, part1, part2);
     }
 }

--- a/crypto/hkdf/tests/hkdf_tests.rs
+++ b/crypto/hkdf/tests/hkdf_tests.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod hkdf_tests {
-    use bouncycastle_core::errors::{KDFError, KeyMaterialError, MACError};
+    use bouncycastle_core::errors::{KDFError, KeyMaterialError, MACError, SuspendableError};
     use bouncycastle_core::key_material;
     use bouncycastle_core::key_material::{
         KeyMaterial, KeyMaterial0, KeyMaterial128, KeyMaterial256, KeyMaterial512,
@@ -571,7 +571,8 @@ mod hkdf_tests {
                 assert_eq!(okm_key.ref_to_bytes().len(), L);
                 assert_eq!(okm_key.ref_to_bytes(), hex::decode(okm).unwrap());
             }
-            Err(KDFError::KeyMaterialError(_)) => { /* some of the rfc5896 test vectors are in fact low entropy, so just skip */
+            Err(KDFError::KeyMaterialError(_)) => {
+                /* some of the rfc5896 test vectors are in fact low entropy, so just skip */
             }
             Err(_) => panic!("Should have returned a MACError::KeyMaterialError."),
         }
@@ -689,7 +690,7 @@ mod hkdf_tests {
 
         // SP800-56Cr2 tcId 1
         let mut salt = KeyMaterial::<128>::new(); // have to do it this way for it to accept a zeroized key
-        key_material::do_hazardous_operations(&mut salt, |salt|{
+        key_material::do_hazardous_operations(&mut salt, |salt| {
             salt.set_bytes_as_type(&hex::decode("00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000").unwrap(), KeyType::MACKey)
         }).unwrap();
 
@@ -789,5 +790,42 @@ mod hkdf_tests {
 
         round_trip::<SUSPENDED_HKDF_SHA256_STATE_LEN, SHA256>(&salt, part1, part2);
         round_trip::<SUSPENDED_HKDF_SHA512_STATE_LEN, SHA512>(&salt, part1, part2);
+
+        // Test the guard for invalid states
+        // testing just on HKDF_SHA256
+
+        const UNINITIALIZED: u8 = 0; // HkdfStates::Uninitialized
+        const INITIALIZED: u8 = 1; // HkdfStates::Initialized
+        let present_idx = SUSPENDED_HKDF_SHA256_STATE_LEN - 11;
+        let state_idx = SUSPENDED_HKDF_SHA256_STATE_LEN - 10;
+
+        // Case 1: no HMAC present but state claims Initialized -> reject.
+        // construct a valid, pre-init state: no HMAC (flag = 0), state = Uninitialized.
+        let valid_uninitialized = HKDF_SHA256::new().suspend();
+        assert_eq!(valid_uninitialized[present_idx], 0);
+        assert_eq!(valid_uninitialized[state_idx], UNINITIALIZED);
+
+        let mut corrupt = valid_uninitialized;
+        corrupt[state_idx] = INITIALIZED;
+        assert!(matches!(
+            HKDF_SHA256::from_suspended(corrupt, &salt),
+            Err(SuspendableError::InvalidData)
+        ));
+
+        // Case 2: HMAC present but state claims Uninitialized -> reject.
+        // construct a valid, mid-extract state: HMAC present (flag = 1), state = Initialized.
+        let mut hkdf = HKDF_SHA256::new();
+        hkdf.do_extract_init(&salt).unwrap();
+        hkdf.do_extract_update_bytes(ikm).unwrap();
+        let valid_initialized = hkdf.suspend();
+        assert_eq!(valid_initialized[present_idx], 1);
+        assert_ne!(valid_initialized[state_idx], UNINITIALIZED);
+
+        let mut corrupt = valid_initialized;
+        corrupt[state_idx] = UNINITIALIZED;
+        assert!(matches!(
+            HKDF_SHA256::from_suspended(corrupt, &salt),
+            Err(SuspendableError::InvalidData)
+        ));
     }
 }

--- a/crypto/hkdf/tests/hkdf_tests.rs
+++ b/crypto/hkdf/tests/hkdf_tests.rs
@@ -796,7 +796,8 @@ mod hkdf_tests {
 
         const UNINITIALIZED: u8 = 0; // HkdfStates::Uninitialized
         const INITIALIZED: u8 = 1; // HkdfStates::Initialized
-        let present_idx = SUSPENDED_HKDF_SHA256_STATE_LEN - 11;
+        // Layout: [version(3) | present flag | hmac blob | state | entropy(8) | strength].
+        let present_idx = 3;
         let state_idx = SUSPENDED_HKDF_SHA256_STATE_LEN - 10;
 
         // Case 1: no HMAC present but state claims Initialized -> reject.

--- a/crypto/hmac/src/lib.rs
+++ b/crypto/hmac/src/lib.rs
@@ -205,69 +205,76 @@ pub const HMAC_SHA3_512_NAME: &str = "HMAC-SHA3-512";
 
 /*** Type aliases ***/
 #[allow(non_camel_case_types)]
-pub type HMAC_SHA224 = HMAC<SHA224>;
+pub type HMAC_SHA224 = HMAC<SHA224, 64>;
 impl Algorithm for HMAC_SHA224 {
     const ALG_NAME: &'static str = HMAC_SHA224_NAME;
     const MAX_SECURITY_STRENGTH: SecurityStrength = SecurityStrength::_112bit;
 }
 
 #[allow(non_camel_case_types)]
-pub type HMAC_SHA256 = HMAC<SHA256>;
+pub type HMAC_SHA256 = HMAC<SHA256, 64>;
 impl Algorithm for HMAC_SHA256 {
     const ALG_NAME: &'static str = HMAC_SHA256_NAME;
     const MAX_SECURITY_STRENGTH: SecurityStrength = SecurityStrength::_128bit;
 }
 
 #[allow(non_camel_case_types)]
-pub type HMAC_SHA384 = HMAC<SHA384>;
+pub type HMAC_SHA384 = HMAC<SHA384, 128>;
 impl Algorithm for HMAC_SHA384 {
     const ALG_NAME: &'static str = HMAC_SHA384_NAME;
     const MAX_SECURITY_STRENGTH: SecurityStrength = SecurityStrength::_192bit;
 }
 
 #[allow(non_camel_case_types)]
-pub type HMAC_SHA512 = HMAC<SHA512>;
+pub type HMAC_SHA512 = HMAC<SHA512, 128>;
 impl Algorithm for HMAC_SHA512 {
     const ALG_NAME: &'static str = HMAC_SHA512_NAME;
     const MAX_SECURITY_STRENGTH: SecurityStrength = SecurityStrength::_256bit;
 }
 
 #[allow(non_camel_case_types)]
-pub type HMAC_SHA3_224 = HMAC<SHA3_224>;
+pub type HMAC_SHA3_224 = HMAC<SHA3_224, 144>;
 impl Algorithm for HMAC_SHA3_224 {
     const ALG_NAME: &'static str = HMAC_SHA3_224_NAME;
     const MAX_SECURITY_STRENGTH: SecurityStrength = SecurityStrength::_112bit;
 }
 
 #[allow(non_camel_case_types)]
-pub type HMAC_SHA3_256 = HMAC<SHA3_256>;
+pub type HMAC_SHA3_256 = HMAC<SHA3_256, 136>;
 impl Algorithm for HMAC_SHA3_256 {
     const ALG_NAME: &'static str = HMAC_SHA3_256_NAME;
     const MAX_SECURITY_STRENGTH: SecurityStrength = SecurityStrength::_128bit;
 }
 
 #[allow(non_camel_case_types)]
-pub type HMAC_SHA3_384 = HMAC<SHA3_384>;
+pub type HMAC_SHA3_384 = HMAC<SHA3_384, 104>;
 impl Algorithm for HMAC_SHA3_384 {
     const ALG_NAME: &'static str = HMAC_SHA3_384_NAME;
     const MAX_SECURITY_STRENGTH: SecurityStrength = SecurityStrength::_192bit;
 }
 
 #[allow(non_camel_case_types)]
-pub type HMAC_SHA3_512 = HMAC<SHA3_512>;
+pub type HMAC_SHA3_512 = HMAC<SHA3_512, 72>;
 impl Algorithm for HMAC_SHA3_512 {
     const ALG_NAME: &'static str = HMAC_SHA3_512_NAME;
     const MAX_SECURITY_STRENGTH: SecurityStrength = SecurityStrength::_256bit;
 }
 
-// TODO: is there a rustacious way to extract this from HASH?
-const LARGEST_HASHER_OUTPUT_LEN: usize = 64;
+// The internal key buffer must be able to hold a key up to the *block length* of the underlying hash:
+// per RFC 2104, a key no longer than the block is used verbatim (only longer keys are pre-hashed down
+// to the output length). So the buffer size is a const parameter of the struct, set per hash to its
+// block length by the type aliases below. Block lengths (bytes): SHA-224/256 = 64, SHA-384/512 = 128,
+// SHA3-224 = 144, SHA3-256 = 136, SHA3-384 = 104, SHA3-512 = 72.
+//
+// The default is used only when `HMAC<HASH>` is written without an explicit buffer size; it is the
+// largest block length across all supported hashes, so it is always large enough.
+const LARGEST_HASHER_BLOCK_LEN: usize = 144;
 
 // HMAC implements RFC 2104.
 #[derive(Clone)]
-pub struct HMAC<HASH: Hash + Default> {
+pub struct HMAC<HASH: Hash + Default, const KEY_BUF_LEN: usize = LARGEST_HASHER_BLOCK_LEN> {
     hasher: HASH,
-    key: [u8; LARGEST_HASHER_OUTPUT_LEN],
+    key: [u8; KEY_BUF_LEN],
     key_len: usize, // Doing it this way to avoid needing a vec, so that this can be made no_std friendly.
 }
 
@@ -286,21 +293,13 @@ const OPAD_BYTE: u8 = 0x5C;
 // be too strict about it,
 pub const MIN_FIPS_DIGEST_LEN: usize = 4; // 32 / 8;
 
-impl<HASH: Hash + Default> HMAC<HASH> {
+impl<HASH: Hash + Default, const KEY_BUF_LEN: usize> HMAC<HASH, KEY_BUF_LEN> {
     fn pad_key_into_hasher(&mut self, padding: u8) {
         // TODO: it would be nice to be able to statically extract the length of HASH and not need a Vec or over-sized array here.
         // TODO: make this no_std-friendly
         let mut padded = vec![0u8; self.hasher.block_bitlen() / 8];
-
-        // Per RFC 2104 Section 2, if the application key exceeds the block
-        // length of the underlying hashes algorithm, we apply a hash invocation
-        // over the key first.
-        // if self.key_len > self.hasher.block_bitlen() / 8 {
-        //     HASH::default().hash_out(&self.key[..self.key_len], &mut padded[..self.hasher.output_len()])?;
-        // } else {
-        // TODO: does this need a guard for a key_len longer than the block length?
+        
         padded[..self.key_len].copy_from_slice(&self.key[..self.key_len]);
-        // }
 
         // XXX: easier way to xor over Vec?
         for entry in &mut padded {
@@ -312,9 +311,10 @@ impl<HASH: Hash + Default> HMAC<HASH> {
         self.hasher.do_update(&padded)
     }
 
-    /// Loads the raw key bytes into `self.key` / `self.key_len`, pre-hashing them first if they
-    /// exceed the underlying hash's block length (per RFC 2104 Section 2). This does NOT absorb the
-    /// key into the hasher; that is done separately via [HMAC::pad_key_into_hasher].
+    /// Per RFC 2104 Section 2, if the application key exceeds the block
+    /// length of the underlying hashes algorithm, we apply a hash invocation
+    /// over the key first.
+    /// This does NOT absorb the key into the hasher; that is done separately via [HMAC::pad_key_into_hasher].
     fn load_key_material(&mut self, key_bytes: &[u8]) {
         if key_bytes.len() > self.hasher.block_bitlen() / 8 {
             // then we have to pre-hash it -- use a new instance of the hasher rather than the internal one
@@ -324,6 +324,12 @@ impl<HASH: Hash + Default> HMAC<HASH> {
             self.key[..key_bytes.len()].copy_from_slice(key_bytes);
             self.key_len = key_bytes.len();
         }
+        
+        // Just as a sanity-check.
+        assert!(
+            self.key_len <= KEY_BUF_LEN,
+            "Fatal error: Key length exceeds HMAC internal buffer length"
+        );
     }
 
     /// Private init so that users are forced to go through one of the public new methods and thus we
@@ -390,17 +396,15 @@ impl<HASH: Hash + Default> HMAC<HASH> {
 // TODO: This is essentially a "batch mode" where you want to perform many MACs or Verifications with the same key
 // TODO: against different data.
 
-impl<HASH: Hash + Default> MAC for HMAC<HASH> {
+impl<HASH: Hash + Default, const KEY_BUF_LEN: usize> MAC for HMAC<HASH, KEY_BUF_LEN> {
     fn new(key: &impl KeyMaterialTrait) -> Result<Self, MACError> {
-        let mut hmac =
-            Self { hasher: HASH::default(), key: [0u8; LARGEST_HASHER_OUTPUT_LEN], key_len: 0 };
+        let mut hmac = Self { hasher: HASH::default(), key: [0u8; KEY_BUF_LEN], key_len: 0 };
         hmac.init(key, false)?;
         Ok(hmac)
     }
 
     fn new_allow_weak_key(key: &impl KeyMaterialTrait) -> Result<Self, MACError> {
-        let mut hmac =
-            Self { hasher: HASH::default(), key: [0u8; LARGEST_HASHER_OUTPUT_LEN], key_len: 0 };
+        let mut hmac = Self { hasher: HASH::default(), key: [0u8; KEY_BUF_LEN], key_len: 0 };
         hmac.init(key, true)?;
         Ok(hmac)
     }
@@ -470,8 +474,11 @@ impl<HASH: Hash + Default> MAC for HMAC<HASH> {
 /// There is no way to detect a mismatched key on
 /// resume: the caller MUST supply the same key the HMAC was created with, otherwise the resumed
 /// operation will silently produce an incorrect MAC.
-impl<const HASH_STATE_LEN: usize, HASH: Hash + Default + SerializableState<HASH_STATE_LEN>>
-    SerializableKeyedState<HASH_STATE_LEN> for HMAC<HASH>
+impl<
+    const HASH_STATE_LEN: usize,
+    const KEY_BUF_LEN: usize,
+    HASH: Hash + Default + SerializableState<HASH_STATE_LEN>,
+> SerializableKeyedState<HASH_STATE_LEN> for HMAC<HASH, KEY_BUF_LEN>
 {
     // HMAC accepts any key material, so the key type is the trait object `dyn KeyMaterialTrait`
     // rather than a single concrete key type. The key is only used (by reference) to reload the key
@@ -494,7 +501,7 @@ impl<const HASH_STATE_LEN: usize, HASH: Hash + Default + SerializableState<HASH_
         // Re-load the key material exactly as `new()` did (pre-hashing an over-length key), but do
         // NOT re-absorb `K ⊕ ipad` — the deserialized hasher already contains it. The key is only
         // needed for the outer `K ⊕ opad` step at finalization.
-        let mut hmac = HMAC { hasher, key: [0u8; LARGEST_HASHER_OUTPUT_LEN], key_len: 0 };
+        let mut hmac = HMAC { hasher, key: [0u8; KEY_BUF_LEN], key_len: 0 };
         hmac.load_key_material(key.ref_to_bytes());
 
         Ok(hmac)

--- a/crypto/hmac/src/lib.rs
+++ b/crypto/hmac/src/lib.rs
@@ -137,29 +137,58 @@
 //! }
 //! ```
 //!
-//! # Request for feedback on fallability of this API
-//! We have made an effort to reduce the number of fallibly APIs in the [MAC] trait; in particular
-//! the APIs for the update and most of the finalize phases are infallible -- they just work.
-//! However, we were not able to design it to completely avoid runtime error conditions, such as
-//! providing [MAC::do_final_out] with a buffer that is too small to hold what NIST considered the smallest
-//! valid MAC value for the given underlying hash function.
+//! # Suspending and resuming execution via SerializableState
 //!
-//! Also, the key strength and type checking in the initialization phase means that both [MAC::new] and
-//! [MAC::new_allow_weak_key] have several runtime error conditions that they check for.
+//! When MAC'ing a large message, it can be advantageous to be able to suspend the operation
+//! to a cache and resume it later; for example if waiting for the message to stream over a slow network
+//! connection. For this reason, all HMAC algorithms impl [SerializableKeyedState].
 //!
-//! All of this leads to application code that requires a lot more .unwrap(), .expect(), or match than we would
-//! really like.
+//! Note that since HMAC is a keyed
+//! algorithm and we do not want to serialize the private key into the state, the trait structure forces you to
+//! re-provide the same key when you resume the operation. Securely storing this key in the interim
+//! is the responsibility of the caller. Note also that if you resume the HMAC with the wrong key,
+//! `from_serialized_state` has no way to detect this, so the end result will be a broken MAC value
+//! computed with different keys in the inner and outer pad. So make sure you resume with the same key!
 //!
-//! We would love feedback on an alternate design for this API than carries less runtime error
-//! conditions, without sacrificing the key strength checking that the metadata in the [KeyMaterialTrait] object allows.
+//!```rust
+//! use bouncycastle_hmac::HMAC_SHA256;
+//! use bouncycastle_core::key_material::KeyMaterial256;
+//! use bouncycastle_core::traits::{MAC, SerializableKeyedState};
+//! use bouncycastle_core::key_material::KeyType;
+//!
+//! let msg_part1 = b"The quick brown fox";
+//! let msg_part2 = b" jumped over the lazy dog";
+//!
+//! let key = KeyMaterial256::from_bytes_as_type(
+//!             b"\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f",
+//!             KeyType::MACKey).unwrap();
+//!
+//! let mut hmac = HMAC_SHA256::new(&key).unwrap();
+//! hmac.do_update(msg_part1);
+//!
+//! // here, we'll suspend while "waiting" for the second part of the message
+//! let serialized_state = hmac.serialize_state();
+//!
+//! // ...
+//! // do other things in the meantime
+//! // ...
+//!
+//! // Since the key is not serialized into the state, you have to store it somewhere and provide
+//! // it to the deserializer. Make sure you store it securely!
+//! let mut hmac_resumed = HMAC_SHA256::from_serialized_state(serialized_state, &key).unwrap();
+//! hmac_resumed.do_update(msg_part2);
+//! let h: Vec<u8> = hmac_resumed.do_final();
+//! ```
 
 #![forbid(unsafe_code)]
 #![allow(incomplete_features)] // because at time of writing, generic_const_exprs is not a stable feature
 #![feature(generic_const_exprs)]
 
-use bouncycastle_core::errors::{KeyMaterialError, MACError};
+use bouncycastle_core::errors::{KeyMaterialError, MACError, SerializedStateError};
 use bouncycastle_core::key_material::{KeyMaterialTrait, KeyType};
-use bouncycastle_core::traits::{Algorithm, Hash, MAC, SecurityStrength};
+use bouncycastle_core::traits::{
+    Algorithm, Hash, MAC, SecurityStrength, SerializableKeyedState, SerializableState,
+};
 use bouncycastle_sha2::{SHA224, SHA256, SHA384, SHA512};
 use bouncycastle_sha3::{SHA3_224, SHA3_256, SHA3_384, SHA3_512};
 use bouncycastle_utils::ct;
@@ -283,6 +312,20 @@ impl<HASH: Hash + Default> HMAC<HASH> {
         self.hasher.do_update(&padded)
     }
 
+    /// Loads the raw key bytes into `self.key` / `self.key_len`, pre-hashing them first if they
+    /// exceed the underlying hash's block length (per RFC 2104 Section 2). This does NOT absorb the
+    /// key into the hasher; that is done separately via [HMAC::pad_key_into_hasher].
+    fn load_key_material(&mut self, key_bytes: &[u8]) {
+        if key_bytes.len() > self.hasher.block_bitlen() / 8 {
+            // then we have to pre-hash it -- use a new instance of the hasher rather than the internal one
+            HASH::default().hash_out(key_bytes, &mut self.key[..self.hasher.output_len()]);
+            self.key_len = self.hasher.output_len();
+        } else {
+            self.key[..key_bytes.len()].copy_from_slice(key_bytes);
+            self.key_len = key_bytes.len();
+        }
+    }
+
     /// Private init so that users are forced to go through one of the public new methods and thus we
     /// don't need to track state errors.
     fn init(&mut self, key: &impl KeyMaterialTrait, allow_weak_keys: bool) -> Result<(), MACError> {
@@ -300,14 +343,7 @@ impl<HASH: Hash + Default> HMAC<HASH> {
         // length of the underlying hashes algorithm, we apply a hash invocation
         // over the key first.
 
-        if key.key_len() > self.hasher.block_bitlen() / 8 {
-            // then we have to pre-hash it -- use a new instance of the hasher rather than the internal one
-            HASH::default().hash_out(key.ref_to_bytes(), &mut self.key[..self.hasher.output_len()]);
-            self.key_len = self.hasher.output_len();
-        } else {
-            self.key[..key.key_len()].copy_from_slice(key.ref_to_bytes());
-            self.key_len = key.key_len();
-        }
+        self.load_key_material(key.ref_to_bytes());
 
         self.pad_key_into_hasher(IPAD_BYTE);
 
@@ -418,5 +454,49 @@ impl<HASH: Hash + Default> MAC for HMAC<HASH> {
 
     fn max_security_strength(&self) -> SecurityStrength {
         HASH::default().max_security_strength()
+    }
+}
+
+/// HMAC is a keyed algorithm, so it implements [SerializableKeyedState] (rather than
+/// [SerializableState]) for suspending and resuming in-progress operations.
+/// The key is deliberately NOT written into the serialized
+/// bytes and must be re-supplied at deserialization.
+///
+/// The serialized state is exactly the inner hasher's state (which has already absorbed `K ⊕ ipad`
+/// and any message chunks provided so far) — so this is a straight passthrough to the underlying hash's
+/// [SerializableState] impl. The re-supplied key is needed to reconstruct the material for the outer
+/// (`K ⊕ opad`) step at finalization.
+///
+/// There is no way to detect a mismatched key on
+/// resume: the caller MUST supply the same key the HMAC was created with, otherwise the resumed
+/// operation will silently produce an incorrect MAC.
+impl<const HASH_STATE_LEN: usize, HASH: Hash + Default + SerializableState<HASH_STATE_LEN>>
+    SerializableKeyedState<HASH_STATE_LEN> for HMAC<HASH>
+{
+    // HMAC accepts any key material, so the key type is the trait object `dyn KeyMaterialTrait`
+    // rather than a single concrete key type. The key is only used (by reference) to reload the key
+    // bytes at from_serialized_state, so dynamic dispatch here is negligible.
+    type Key = dyn KeyMaterialTrait;
+
+    fn serialize_state(self) -> [u8; HASH_STATE_LEN] {
+        // The key is intentionally excluded; the resumable state is just the inner hasher, which
+        // already carries the library version header from the hash's own SerializableState impl.
+        self.hasher.serialize_state()
+    }
+
+    fn from_serialized_state(
+        serialized_state: [u8; HASH_STATE_LEN],
+        key: &dyn KeyMaterialTrait,
+    ) -> Result<Self, SerializedStateError> {
+        // Rebuild the inner hasher (version-compatibility is validated by the hash's impl).
+        let hasher = HASH::from_serialized_state(serialized_state)?;
+
+        // Re-load the key material exactly as `new()` did (pre-hashing an over-length key), but do
+        // NOT re-absorb `K ⊕ ipad` — the deserialized hasher already contains it. The key is only
+        // needed for the outer `K ⊕ opad` step at finalization.
+        let mut hmac = HMAC { hasher, key: [0u8; LARGEST_HASHER_OUTPUT_LEN], key_len: 0 };
+        hmac.load_key_material(key.ref_to_bytes());
+
+        Ok(hmac)
     }
 }

--- a/crypto/hmac/src/lib.rs
+++ b/crypto/hmac/src/lib.rs
@@ -184,16 +184,17 @@
 #![allow(incomplete_features)] // because at time of writing, generic_const_exprs is not a stable feature
 #![feature(generic_const_exprs)]
 
-use bouncycastle_core::errors::{KeyMaterialError, MACError, SerializedStateError};
+use bouncycastle_core::errors::{KeyMaterialError, MACError, SuspendableError};
 use bouncycastle_core::key_material::{KeyMaterialTrait, KeyType};
 use bouncycastle_core::traits::{
-    Algorithm, Hash, MAC, SecurityStrength, Suspendable, SuspendableKeyed,
+    Algorithm, Hash, MAC, Secret, SecurityStrength, Suspendable, SuspendableKeyed,
 };
 use bouncycastle_sha2::{
     SHA224, SHA256, SHA384, SHA512, SUSPENDED_SHA256_STATE_LEN, SUSPENDED_SHA512_STATE_LEN,
 };
 use bouncycastle_sha3::{SHA3_224, SHA3_256, SHA3_384, SHA3_512, SUSPENDED_SHA3_STATE_LEN};
 use bouncycastle_utils::ct;
+use core::fmt::{Debug, Display, Formatter};
 
 /*** String constants ***/
 ///
@@ -286,6 +287,28 @@ pub struct HMAC<HASH: Hash + Default, const KEY_BUF_LEN: usize = LARGEST_HASHER_
     hasher: HASH,
     key: [u8; KEY_BUF_LEN],
     key_len: usize, // Doing it this way to avoid needing a vec, so that this can be made no_std friendly.
+}
+
+// Because the HMAC struct contains a copy of the long-term key
+impl<HASH: Hash + Default, const KEY_BUF_LEN: usize> Secret for HMAC<HASH, KEY_BUF_LEN> {}
+
+impl<HASH: Hash + Default, const KEY_BUF_LEN: usize> Drop for HMAC<HASH, KEY_BUF_LEN> {
+    fn drop(&mut self) {
+        self.key.fill(0);
+        self.key_len = 0;
+    }
+}
+
+impl<HASH: Hash + Default, const KEY_BUF_LEN: usize> Debug for HMAC<HASH, KEY_BUF_LEN> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "HMAC-{} instance", HASH::ALG_NAME,)
+    }
+}
+
+impl<HASH: Hash + Default, const KEY_BUF_LEN: usize> Display for HMAC<HASH, KEY_BUF_LEN> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "HMAC-{} instance", HASH::ALG_NAME,)
+    }
 }
 
 // See definitions in RFC 2104 Section 2.
@@ -391,13 +414,15 @@ impl<HASH: Hash + Default, const KEY_BUF_LEN: usize> HMAC<HASH, KEY_BUF_LEN> {
         // invalid outer hashes.
         // TODO: rework this to be no_std friendly (ie no vec!)
         let mut ihash = vec![0u8; self.hasher.output_len()];
-        self.hasher.do_final_out(&mut ihash);
+        // `HMAC` implements `Drop` (required by `Secret`), so we cannot move `self.hasher` out
+        // directly. Swap in a fresh default and consume the taken-out hasher instead.
+        core::mem::take(&mut self.hasher).do_final_out(&mut ihash);
 
         // ohash
         self.hasher = HASH::default();
         self.pad_key_into_hasher(OPAD_BYTE);
         self.hasher.do_update(&ihash);
-        Ok(self.hasher.do_final_out(out))
+        Ok(core::mem::take(&mut self.hasher).do_final_out(out))
     }
 }
 
@@ -515,16 +540,18 @@ impl<
     // bytes at from_serialized_state, so dynamic dispatch here is negligible.
     type Key = dyn KeyMaterialTrait;
 
-    fn suspend(self) -> [u8; HASH_STATE_LEN] {
+    fn suspend(mut self) -> [u8; HASH_STATE_LEN] {
         // The key is intentionally excluded; the resumable state is just the inner hasher, which
         // already carries the library version header from the hash's own SerializableState impl.
-        self.hasher.suspend()
+        // `HMAC` implements `Drop` (required by `Secret`), so move the hasher out via `mem::take`
+        // rather than a direct partial move.
+        core::mem::take(&mut self.hasher).suspend()
     }
 
     fn from_suspended(
         state: [u8; HASH_STATE_LEN],
         key: &Self::Key,
-    ) -> Result<Self, SerializedStateError> {
+    ) -> Result<Self, SuspendableError> {
         // Rebuild the inner hasher (version-compatibility is validated by the hash's impl).
         let hasher = HASH::from_suspended(state)?;
 

--- a/crypto/hmac/src/lib.rs
+++ b/crypto/hmac/src/lib.rs
@@ -137,11 +137,11 @@
 //! }
 //! ```
 //!
-//! # Suspending and resuming execution via SerializableState
+//! # Suspending and resuming execution
 //!
 //! When MAC'ing a large message, it can be advantageous to be able to suspend the operation
 //! to a cache and resume it later; for example if waiting for the message to stream over a slow network
-//! connection. For this reason, all HMAC algorithms impl [SerializableKeyedState].
+//! connection. For this reason, all HMAC algorithms impl [SuspendableKeyed].
 //!
 //! Note that since HMAC is a keyed
 //! algorithm and we do not want to serialize the private key into the state, the trait structure forces you to
@@ -153,7 +153,7 @@
 //!```rust
 //! use bouncycastle_hmac::HMAC_SHA256;
 //! use bouncycastle_core::key_material::KeyMaterial256;
-//! use bouncycastle_core::traits::{MAC, SerializableKeyedState};
+//! use bouncycastle_core::traits::{MAC, SuspendableKeyed};
 //! use bouncycastle_core::key_material::KeyType;
 //!
 //! let msg_part1 = b"The quick brown fox";
@@ -166,16 +166,16 @@
 //! let mut hmac = HMAC_SHA256::new(&key).unwrap();
 //! hmac.do_update(msg_part1);
 //!
-//! // here, we'll suspend while "waiting" for the second part of the message
-//! let serialized_state = hmac.serialize_state();
+//! // suspend the in-progress mac (the key is NOT included in the serialized state)
+//! let serialized_state = hmac.suspend();
 //!
 //! // ...
 //! // do other things in the meantime
 //! // ...
 //!
-//! // Since the key is not serialized into the state, you have to store it somewhere and provide
-//! // it to the deserializer. Make sure you store it securely!
-//! let mut hmac_resumed = HMAC_SHA256::from_serialized_state(serialized_state, &key).unwrap();
+//! // ... later, possibly on another host: resume from the serialized state by re-supplying
+//! // the same salt (make sure you store it securely!).
+//! let mut hmac_resumed = HMAC_SHA256::from_suspended(serialized_state, &key).unwrap();
 //! hmac_resumed.do_update(msg_part2);
 //! let h: Vec<u8> = hmac_resumed.do_final();
 //! ```
@@ -187,20 +187,30 @@
 use bouncycastle_core::errors::{KeyMaterialError, MACError, SerializedStateError};
 use bouncycastle_core::key_material::{KeyMaterialTrait, KeyType};
 use bouncycastle_core::traits::{
-    Algorithm, Hash, MAC, SecurityStrength, SerializableKeyedState, SerializableState,
+    Algorithm, Hash, MAC, SecurityStrength, Suspendable, SuspendableKeyed,
 };
-use bouncycastle_sha2::{SHA224, SHA256, SHA384, SHA512};
-use bouncycastle_sha3::{SHA3_224, SHA3_256, SHA3_384, SHA3_512};
+use bouncycastle_sha2::{
+    SHA224, SHA256, SHA384, SHA512, SUSPENDED_SHA256_STATE_LEN, SUSPENDED_SHA512_STATE_LEN,
+};
+use bouncycastle_sha3::{SHA3_224, SHA3_256, SHA3_384, SHA3_512, SUSPENDED_SHA3_STATE_LEN};
 use bouncycastle_utils::ct;
 
 /*** String constants ***/
+///
 pub const HMAC_SHA224_NAME: &str = "HMAC-SHA224";
+///
 pub const HMAC_SHA256_NAME: &str = "HMAC-SHA256";
+///
 pub const HMAC_SHA384_NAME: &str = "HMAC-SHA384";
+///
 pub const HMAC_SHA512_NAME: &str = "HMAC-SHA512";
+///
 pub const HMAC_SHA3_224_NAME: &str = "HMAC-SHA3-224";
+///
 pub const HMAC_SHA3_256_NAME: &str = "HMAC-SHA3-256";
+///
 pub const HMAC_SHA3_384_NAME: &str = "HMAC-SHA3-384";
+///
 pub const HMAC_SHA3_512_NAME: &str = "HMAC-SHA3-512";
 
 /*** Type aliases ***/
@@ -298,7 +308,7 @@ impl<HASH: Hash + Default, const KEY_BUF_LEN: usize> HMAC<HASH, KEY_BUF_LEN> {
         // TODO: it would be nice to be able to statically extract the length of HASH and not need a Vec or over-sized array here.
         // TODO: make this no_std-friendly
         let mut padded = vec![0u8; self.hasher.block_bitlen() / 8];
-        
+
         padded[..self.key_len].copy_from_slice(&self.key[..self.key_len]);
 
         // XXX: easier way to xor over Vec?
@@ -324,7 +334,7 @@ impl<HASH: Hash + Default, const KEY_BUF_LEN: usize> HMAC<HASH, KEY_BUF_LEN> {
             self.key[..key_bytes.len()].copy_from_slice(key_bytes);
             self.key_len = key_bytes.len();
         }
-        
+
         // Just as a sanity-check.
         assert!(
             self.key_len <= KEY_BUF_LEN,
@@ -461,14 +471,34 @@ impl<HASH: Hash + Default, const KEY_BUF_LEN: usize> MAC for HMAC<HASH, KEY_BUF_
     }
 }
 
-/// HMAC is a keyed algorithm, so it implements [SerializableKeyedState] (rather than
-/// [SerializableState]) for suspending and resuming in-progress operations.
+/* SerializedState */
+
+/*** Serialized-state length constants ***/
+/// Length in bytes of the serialized state of [HMAC_SHA224].
+pub const SUSPENDED_HMAC_SHA224_STATE_LEN: usize = SUSPENDED_SHA256_STATE_LEN;
+/// Length in bytes of the serialized state of [HMAC_SHA256].
+pub const SUSPENDED_HMAC_SHA256_STATE_LEN: usize = SUSPENDED_SHA256_STATE_LEN;
+/// Length in bytes of the serialized state of [HMAC_SHA384].
+pub const SUSPENDED_HMAC_SHA384_STATE_LEN: usize = SUSPENDED_SHA512_STATE_LEN;
+/// Length in bytes of the serialized state of [HMAC_SHA512].
+pub const SUSPENDED_HMAC_SHA512_STATE_LEN: usize = SUSPENDED_SHA512_STATE_LEN;
+/// Length in bytes of the serialized state of [HMAC_SHA3_224].
+pub const SUSPENDED_HMAC_SHA3_224_STATE_LEN: usize = SUSPENDED_SHA3_STATE_LEN;
+/// Length in bytes of the serialized state of [HMAC_SHA3_256].
+pub const SUSPENDED_HMAC_SHA3_256_STATE_LEN: usize = SUSPENDED_SHA3_STATE_LEN;
+/// Length in bytes of the serialized state of [HMAC_SHA3_384].
+pub const SUSPENDED_HMAC_SHA3_384_STATE_LEN: usize = SUSPENDED_SHA3_STATE_LEN;
+/// Length in bytes of the serialized state of [HMAC_SHA3_512].
+pub const SUSPENDED_HMAC_SHA3_512_STATE_LEN: usize = SUSPENDED_SHA3_STATE_LEN;
+
+/// HMAC is a keyed algorithm, so it implements [SuspendableKeyed] (rather than
+/// [Suspendable]) for suspending and resuming in-progress operations.
 /// The key is deliberately NOT written into the serialized
 /// bytes and must be re-supplied at deserialization.
 ///
 /// The serialized state is exactly the inner hasher's state (which has already absorbed `K ⊕ ipad`
 /// and any message chunks provided so far) — so this is a straight passthrough to the underlying hash's
-/// [SerializableState] impl. The re-supplied key is needed to reconstruct the material for the outer
+/// [Suspendable] impl. The re-supplied key is needed to reconstruct the material for the outer
 /// (`K ⊕ opad`) step at finalization.
 ///
 /// There is no way to detect a mismatched key on
@@ -477,26 +507,26 @@ impl<HASH: Hash + Default, const KEY_BUF_LEN: usize> MAC for HMAC<HASH, KEY_BUF_
 impl<
     const HASH_STATE_LEN: usize,
     const KEY_BUF_LEN: usize,
-    HASH: Hash + Default + SerializableState<HASH_STATE_LEN>,
-> SerializableKeyedState<HASH_STATE_LEN> for HMAC<HASH, KEY_BUF_LEN>
+    HASH: Hash + Default + Suspendable<HASH_STATE_LEN>,
+> SuspendableKeyed<HASH_STATE_LEN> for HMAC<HASH, KEY_BUF_LEN>
 {
     // HMAC accepts any key material, so the key type is the trait object `dyn KeyMaterialTrait`
     // rather than a single concrete key type. The key is only used (by reference) to reload the key
     // bytes at from_serialized_state, so dynamic dispatch here is negligible.
     type Key = dyn KeyMaterialTrait;
 
-    fn serialize_state(self) -> [u8; HASH_STATE_LEN] {
+    fn suspend(self) -> [u8; HASH_STATE_LEN] {
         // The key is intentionally excluded; the resumable state is just the inner hasher, which
         // already carries the library version header from the hash's own SerializableState impl.
-        self.hasher.serialize_state()
+        self.hasher.suspend()
     }
 
-    fn from_serialized_state(
-        serialized_state: [u8; HASH_STATE_LEN],
-        key: &dyn KeyMaterialTrait,
+    fn from_suspended(
+        state: [u8; HASH_STATE_LEN],
+        key: &Self::Key,
     ) -> Result<Self, SerializedStateError> {
         // Rebuild the inner hasher (version-compatibility is validated by the hash's impl).
-        let hasher = HASH::from_serialized_state(serialized_state)?;
+        let hasher = HASH::from_suspended(state)?;
 
         // Re-load the key material exactly as `new()` did (pre-hashing an over-length key), but do
         // NOT re-absorb `K ⊕ ipad` — the deserialized hasher already contains it. The key is only

--- a/crypto/hmac/tests/hmac_tests.rs
+++ b/crypto/hmac/tests/hmac_tests.rs
@@ -605,7 +605,7 @@ mod hmac_tests {
     #[test]
     fn suspendable_keyed_state() {
         use bouncycastle_core::errors::SuspendableError;
-        use bouncycastle_core::serializable_state::LIB_VERSION;
+        use bouncycastle_core::suspendable_state::LIB_VERSION;
         use bouncycastle_core::traits::SuspendableKeyed;
         use bouncycastle_core_test_framework::suspendable_state::TestFrameworkSuspendableKeyedState;
 

--- a/crypto/hmac/tests/hmac_tests.rs
+++ b/crypto/hmac/tests/hmac_tests.rs
@@ -580,4 +580,63 @@ mod hmac_tests {
             );
         }
     }
+
+    #[test]
+    fn serializable_keyed_state() {
+        use bouncycastle_core::errors::SerializedStateError;
+        use bouncycastle_core::serializable_state::LIB_VERSION;
+        use bouncycastle_core::traits::SerializableKeyedState;
+        use bouncycastle_core_test_framework::serializable_state::TestFrameworkSerializableKeyedState;
+
+        let key =
+            KeyMaterial256::from_bytes_as_type(&DUMMY_SEED_512[..32], KeyType::MACKey).unwrap();
+        let msg = b"Colorless green ideas sleep furiously";
+
+        // A helper that exercises the full round-trip for one HMAC variant. HMAC is keyed, so the
+        // key is NOT in the serialized state -- it is re-supplied (by reference) to
+        // from_serialized_state.
+        // The `+ 'static` on the trait object matches the associated type `type Key = dyn
+        // KeyMaterialTrait` (a bare `dyn` in an associated type defaults to `'static`). The concrete
+        // key types are owned, so they satisfy it.
+        fn round_trip<const N: usize, H>(
+            mut hmac: H,
+            key: &(dyn KeyMaterialTrait + 'static),
+            input: &[u8],
+        ) where
+            H: MAC + Clone + SerializableKeyedState<N, Key = dyn KeyMaterialTrait>,
+        {
+            hmac.do_update(&input[..10]);
+
+            // do the default trait-conformance tests
+            TestFrameworkSerializableKeyedState::new().test(&hmac, key);
+
+            // serialize the in-progress state (on a clone), then finish the original
+            let serialized_state = hmac.clone().serialize_state();
+
+            // the serialized state carries the library version header (from the inner hash)
+            let header: [u8; 3] = serialized_state[..3].try_into().unwrap();
+            assert_eq!(header, <[u8; 3]>::from(LIB_VERSION));
+
+            hmac.do_update(&input[10..]);
+            let expected = hmac.do_final();
+
+            // rebuild from the serialized state (re-supplying the key), feed the identical remaining
+            // input, and confirm the MAC matches
+            let mut from_state = H::from_serialized_state(serialized_state, key).unwrap();
+            from_state.do_update(&input[10..]);
+            assert_eq!(expected, from_state.do_final());
+
+            // a state whose version header is zeroed must be rejected (delegated to the hash's impl)
+            let mut busted = serialized_state;
+            busted[..3].copy_from_slice(&[0, 0, 0]);
+            match H::from_serialized_state(busted, key) {
+                Err(SerializedStateError::IncompatibleVersion) => { /* good */ }
+                _ => panic!("Expected IncompatibleVersion for a zeroed version header"),
+            }
+        }
+
+        round_trip(HMAC_SHA256::new(&key).unwrap(), &key, msg);
+        round_trip(HMAC_SHA512::new(&key).unwrap(), &key, msg);
+        round_trip(HMAC_SHA3_256::new(&key).unwrap(), &key, msg);
+    }
 }

--- a/crypto/hmac/tests/hmac_tests.rs
+++ b/crypto/hmac/tests/hmac_tests.rs
@@ -148,7 +148,7 @@ mod hmac_tests {
     fn long_key() {
         // Regression test: a key just under the maximum length before HMAC will hash it down.
         // (RFC 2104 only pre-hashes keys *longer* than the block).
-        // This test wil detect an overflow-write and panic on HMAC's internal key buffer.
+        // This test is designed to detect an overflow-write and panic on HMAC's internal key buffer.
 
         // SHA-512 has a 128-byte block, so use a 127-byte key
         let key = KeyMaterial::<200>::from_bytes_as_type(&[0x0B; 127], KeyType::MACKey).unwrap();
@@ -603,11 +603,11 @@ mod hmac_tests {
     }
 
     #[test]
-    fn serializable_keyed_state() {
+    fn suspendable_keyed_state() {
         use bouncycastle_core::errors::SerializedStateError;
         use bouncycastle_core::serializable_state::LIB_VERSION;
-        use bouncycastle_core::traits::SerializableKeyedState;
-        use bouncycastle_core_test_framework::serializable_state::TestFrameworkSerializableKeyedState;
+        use bouncycastle_core::traits::SuspendableKeyed;
+        use bouncycastle_core_test_framework::suspendable_state::TestFrameworkSuspendableKeyedState;
 
         let key =
             KeyMaterial256::from_bytes_as_type(&DUMMY_SEED_512[..32], KeyType::MACKey).unwrap();
@@ -624,15 +624,15 @@ mod hmac_tests {
             key: &(dyn KeyMaterialTrait + 'static),
             input: &[u8],
         ) where
-            H: MAC + Clone + SerializableKeyedState<N, Key = dyn KeyMaterialTrait>,
+            H: MAC + Clone + SuspendableKeyed<N, Key = dyn KeyMaterialTrait>,
         {
             hmac.do_update(&input[..10]);
 
             // do the default trait-conformance tests
-            TestFrameworkSerializableKeyedState::new().test(&hmac, key);
+            TestFrameworkSuspendableKeyedState::new().test(&hmac, key);
 
             // serialize the in-progress state (on a clone), then finish the original
-            let serialized_state = hmac.clone().serialize_state();
+            let serialized_state = hmac.clone().suspend();
 
             // the serialized state carries the library version header (from the inner hash)
             let header: [u8; 3] = serialized_state[..3].try_into().unwrap();
@@ -643,14 +643,14 @@ mod hmac_tests {
 
             // rebuild from the serialized state (re-supplying the key), feed the identical remaining
             // input, and confirm the MAC matches
-            let mut from_state = H::from_serialized_state(serialized_state, key).unwrap();
+            let mut from_state = H::from_suspended(serialized_state, key).unwrap();
             from_state.do_update(&input[10..]);
             assert_eq!(expected, from_state.do_final());
 
             // a state whose version header is zeroed must be rejected (delegated to the hash's impl)
             let mut busted = serialized_state;
             busted[..3].copy_from_slice(&[0, 0, 0]);
-            match H::from_serialized_state(busted, key) {
+            match H::from_suspended(busted, key) {
                 Err(SerializedStateError::IncompatibleVersion) => { /* good */ }
                 _ => panic!("Expected IncompatibleVersion for a zeroed version header"),
             }

--- a/crypto/hmac/tests/hmac_tests.rs
+++ b/crypto/hmac/tests/hmac_tests.rs
@@ -145,6 +145,27 @@ mod hmac_tests {
     }
 
     #[test]
+    fn long_key() {
+        // Regression test: a key just under the maximum length before HMAC will hash it down.
+        // (RFC 2104 only pre-hashes keys *longer* than the block).
+        // This test wil detect an overflow-write and panic on HMAC's internal key buffer.
+
+        // SHA-512 has a 128-byte block, so use a 127-byte key
+        let key = KeyMaterial::<200>::from_bytes_as_type(&[0x0B; 127], KeyType::MACKey).unwrap();
+        let mut mac = HMAC_SHA512::new(&key).unwrap();
+        mac.do_update(b"Hi There");
+        let tag = mac.do_final();
+        assert!(HMAC_SHA512::new(&key).unwrap().verify(b"Hi There", &tag));
+
+        // SHA3-224 has the largest block (144 bytes); a 143-byte key exercises the top of the range.
+        let key = KeyMaterial::<200>::from_bytes_as_type(&[0x0B; 143], KeyType::MACKey).unwrap();
+        let mut mac = HMAC_SHA3_224::new(&key).unwrap();
+        mac.do_update(b"Hi There");
+        let tag = mac.do_final();
+        assert!(HMAC_SHA3_224::new(&key).unwrap().verify(b"Hi There", &tag));
+    }
+
+    #[test]
     fn security_strength_tests() {
         // test: provided key has the correct length, but insufficient tagged security strength
         // HMAC should still work, but should return an error

--- a/crypto/hmac/tests/hmac_tests.rs
+++ b/crypto/hmac/tests/hmac_tests.rs
@@ -59,8 +59,8 @@ mod hmac_tests {
     #[test]
     fn test_type_aliases() {
         let key = KeyMaterial512::from_bytes_as_type(
-                    b"\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f",
-                    KeyType::MACKey).unwrap();
+            b"\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f",
+            KeyType::MACKey).unwrap();
 
         _ = HMAC::<SHA224>::new(&key).unwrap();
         _ = HMAC_SHA224::new(&key).unwrap();
@@ -330,14 +330,14 @@ mod hmac_tests {
             //    bytes (= block-size of SHA-224 and SHA-256).
             test_framework.test_mac::<HMAC<SHA224>>(&KeyMaterial256::from_bytes_as_type(&hex::decode("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa").unwrap(), KeyType::MACKey).unwrap(),
                                                     &hex::decode("dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd").unwrap(),
-                                                    &hex::decode("7fb3cb3588c6c1f6ffa9694d7d6ad2649365b0c1f65d69d1ec8333ea").unwrap()
+                                                    &hex::decode("7fb3cb3588c6c1f6ffa9694d7d6ad2649365b0c1f65d69d1ec8333ea").unwrap(),
             );
 
             // RFC4231 Test Case 4 -- Test with a combined length of key and data that is larger than 64
             //    bytes (= block-size of SHA-224 and SHA-256).
             test_framework.test_mac::<HMAC<SHA224>>(&KeyMaterial256::from_bytes_as_type(&hex::decode("0102030405060708090a0b0c0d0e0f10111213141516171819").unwrap(), KeyType::MACKey).unwrap(),
                                                     &hex::decode("cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd").unwrap(),
-                                                    &hex::decode("6c11506874013cac6a2abc1bb382627cec6a90d86efc012de7afec5a").unwrap()
+                                                    &hex::decode("6c11506874013cac6a2abc1bb382627cec6a90d86efc012de7afec5a").unwrap(),
             );
 
             // RFC4231 Test Case 5 -- Test with a truncation of output to 128 bits.
@@ -363,7 +363,7 @@ mod hmac_tests {
             //    of SHA-384 and SHA-512)
             test_framework.test_mac::<HMAC<SHA224>>(&KeyMaterial::<131>::from_bytes_as_type(&hex::decode("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa").unwrap(), KeyType::MACKey).unwrap(),
                                                     b"This is a test using a larger than block-size key and a larger than block-size data. The key needs to be hashed before being used by the HMAC algorithm.",
-                                                    &hex::decode("3a854166ac5d9f023f54d517d0b39dbd946770db9c2b95c9f6f565d1").unwrap()
+                                                    &hex::decode("3a854166ac5d9f023f54d517d0b39dbd946770db9c2b95c9f6f565d1").unwrap(),
             );
         }
 
@@ -411,14 +411,14 @@ mod hmac_tests {
             //    bytes (= block-size of SHA-224 and SHA-256).
             test_framework.test_mac::<HMAC<SHA256>>(&KeyMaterial256::from_bytes_as_type(&hex::decode("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa").unwrap(), KeyType::MACKey).unwrap(),
                                                     &hex::decode("dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd").unwrap(),
-                                                    &hex::decode("773ea91e36800e46854db8ebd09181a72959098b3ef8c122d9635514ced565fe").unwrap()
+                                                    &hex::decode("773ea91e36800e46854db8ebd09181a72959098b3ef8c122d9635514ced565fe").unwrap(),
             );
 
             // RFC4231 Test Case 4 -- Test with a combined length of key and data that is larger than 64
             //    bytes (= block-size of SHA-224 and SHA-256).
             test_framework.test_mac::<HMAC<SHA256>>(&KeyMaterial256::from_bytes_as_type(&hex::decode("0102030405060708090a0b0c0d0e0f10111213141516171819").unwrap(), KeyType::MACKey).unwrap(),
                                                     &hex::decode("cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd").unwrap(),
-                                                    &hex::decode("82558a389a443c0ea4cc819899f2083a85f0faa3e578f8077a2e3ff46729665b").unwrap()
+                                                    &hex::decode("82558a389a443c0ea4cc819899f2083a85f0faa3e578f8077a2e3ff46729665b").unwrap(),
             );
 
             // RFC4231 Test Case 5 -- Test with a truncation of output to 128 bits.
@@ -435,14 +435,14 @@ mod hmac_tests {
             //    bytes (= block-size of SHA-224 and SHA-256).
             test_framework.test_mac::<HMAC<SHA256>>(&KeyMaterial::<131>::from_bytes_as_type(&hex::decode("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa").unwrap(), KeyType::MACKey).unwrap(),
                                                     b"Test Using Larger Than Block-Size Key - Hash Key First",
-                                                    &hex::decode("60e431591ee0b67f0d8a26aacbf5b77f8e0bc6213728c5140546040f0ee37f54").unwrap()
+                                                    &hex::decode("60e431591ee0b67f0d8a26aacbf5b77f8e0bc6213728c5140546040f0ee37f54").unwrap(),
             );
 
             // RFC4231 Test Case 7 -- Test with a key and data that is larger than 128 bytes (= block-size
             //    of SHA-384 and SHA-512)
             test_framework.test_mac::<HMAC<SHA256>>(&KeyMaterial::<131>::from_bytes_as_type(&hex::decode("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa").unwrap(), KeyType::MACKey).unwrap(),
                                                     b"This is a test using a larger than block-size key and a larger than block-size data. The key needs to be hashed before being used by the HMAC algorithm.",
-                                                    &hex::decode("9b09ffa71b942fcb27635fbcd5b0e944bfdc63644f0713938a7f51535c3a35e2").unwrap()
+                                                    &hex::decode("9b09ffa71b942fcb27635fbcd5b0e944bfdc63644f0713938a7f51535c3a35e2").unwrap(),
             );
         }
 
@@ -486,14 +486,14 @@ mod hmac_tests {
             //    bytes (= block-size of SHA-224 and SHA-256).
             test_framework.test_mac::<HMAC<SHA384>>(&KeyMaterial256::from_bytes_as_type(&hex::decode("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa").unwrap(), KeyType::MACKey).unwrap(),
                                                     &hex::decode("dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd").unwrap(),
-                                                    &hex::decode("88062608d3e6ad8a0aa2ace014c8a86f0aa635d947ac9febe83ef4e55966144b2a5ab39dc13814b94e3ab6e101a34f27").unwrap()
+                                                    &hex::decode("88062608d3e6ad8a0aa2ace014c8a86f0aa635d947ac9febe83ef4e55966144b2a5ab39dc13814b94e3ab6e101a34f27").unwrap(),
             );
 
             // RFC4231 Test Case 4 -- Test with a combined length of key and data that is larger than 64
             //    bytes (= block-size of SHA-224 and SHA-256).
             test_framework.test_mac::<HMAC<SHA384>>(&KeyMaterial256::from_bytes_as_type(&hex::decode("0102030405060708090a0b0c0d0e0f10111213141516171819").unwrap(), KeyType::MACKey).unwrap(),
                                                     &hex::decode("cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd").unwrap(),
-                                                    &hex::decode("3e8a69b7783c25851933ab6290af6ca77a9981480850009cc5577c6e1f573b4e6801dd23c4a7d679ccf8a386c674cffb").unwrap()
+                                                    &hex::decode("3e8a69b7783c25851933ab6290af6ca77a9981480850009cc5577c6e1f573b4e6801dd23c4a7d679ccf8a386c674cffb").unwrap(),
             );
 
             // RFC4231 Test Case 5 -- Test with a truncation of output to 128 bits.
@@ -512,14 +512,14 @@ mod hmac_tests {
             //    bytes (= block-size of SHA-224 and SHA-256).
             test_framework.test_mac::<HMAC<SHA384>>(&KeyMaterial::<131>::from_bytes_as_type(&hex::decode("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa").unwrap(), KeyType::MACKey).unwrap(),
                                                     b"Test Using Larger Than Block-Size Key - Hash Key First",
-                                                    &hex::decode("4ece084485813e9088d2c63a041bc5b44f9ef1012a2b588f3cd11f05033ac4c60c2ef6ab4030fe8296248df163f44952").unwrap()
+                                                    &hex::decode("4ece084485813e9088d2c63a041bc5b44f9ef1012a2b588f3cd11f05033ac4c60c2ef6ab4030fe8296248df163f44952").unwrap(),
             );
 
             // RFC4231 Test Case 7 -- Test with a key and data that is larger than 128 bytes (= block-size
             //    of SHA-384 and SHA-512)
             test_framework.test_mac::<HMAC<SHA384>>(&KeyMaterial::<131>::from_bytes_as_type(&hex::decode("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa").unwrap(), KeyType::MACKey).unwrap(),
                                                     b"This is a test using a larger than block-size key and a larger than block-size data. The key needs to be hashed before being used by the HMAC algorithm.",
-                                                    &hex::decode("6617178e941f020d351e2f254e8fd32c602420feb0b8fb9adccebb82461e99c5a678cc31e799176d3860e6110c46523e").unwrap()
+                                                    &hex::decode("6617178e941f020d351e2f254e8fd32c602420feb0b8fb9adccebb82461e99c5a678cc31e799176d3860e6110c46523e").unwrap(),
             );
         }
 
@@ -564,14 +564,14 @@ mod hmac_tests {
             //    bytes (= block-size of SHA-224 and SHA-256).
             test_framework.test_mac::<HMAC<SHA512>>(&KeyMaterial256::from_bytes_as_type(&hex::decode("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa").unwrap(), KeyType::MACKey).unwrap(),
                                                     &hex::decode("dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd").unwrap(),
-                                                    &hex::decode("fa73b0089d56a284efb0f0756c890be9b1b5dbdd8ee81a3655f83e33b2279d39bf3e848279a722c806b485a47e67c807b946a337bee8942674278859e13292fb").unwrap()
+                                                    &hex::decode("fa73b0089d56a284efb0f0756c890be9b1b5dbdd8ee81a3655f83e33b2279d39bf3e848279a722c806b485a47e67c807b946a337bee8942674278859e13292fb").unwrap(),
             );
 
             // RFC4231 Test Case 4 -- Test with a combined length of key and data that is larger than 64
             //    bytes (= block-size of SHA-224 and SHA-256).
             test_framework.test_mac::<HMAC<SHA512>>(&KeyMaterial256::from_bytes_as_type(&hex::decode("0102030405060708090a0b0c0d0e0f10111213141516171819").unwrap(), KeyType::MACKey).unwrap(),
                                                     &hex::decode("cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd").unwrap(),
-                                                    &hex::decode("b0ba465637458c6990e5a8c5f61d4af7e576d97ff94b872de76f8050361ee3dba91ca5c11aa25eb4d679275cc5788063a5f19741120c4f2de2adebeb10a298dd").unwrap()
+                                                    &hex::decode("b0ba465637458c6990e5a8c5f61d4af7e576d97ff94b872de76f8050361ee3dba91ca5c11aa25eb4d679275cc5788063a5f19741120c4f2de2adebeb10a298dd").unwrap(),
             );
 
             // RFC4231 Test Case 5 -- Test with a truncation of output to 128 bits.
@@ -590,21 +590,21 @@ mod hmac_tests {
             //    bytes (= block-size of SHA-224 and SHA-256).
             test_framework.test_mac::<HMAC<SHA512>>(&KeyMaterial::<131>::from_bytes_as_type(&hex::decode("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa").unwrap(), KeyType::MACKey).unwrap(),
                                                     b"Test Using Larger Than Block-Size Key - Hash Key First",
-                                                    &hex::decode("80b24263c7c1a3ebb71493c1dd7be8b49b46d1f41b4aeec1121b013783f8f3526b56d037e05f2598bd0fd2215d6a1e5295e64f73f63f0aec8b915a985d786598").unwrap()
+                                                    &hex::decode("80b24263c7c1a3ebb71493c1dd7be8b49b46d1f41b4aeec1121b013783f8f3526b56d037e05f2598bd0fd2215d6a1e5295e64f73f63f0aec8b915a985d786598").unwrap(),
             );
 
             // RFC4231 Test Case 7 -- Test with a key and data that is larger than 128 bytes (= block-size
             //    of SHA-384 and SHA-512)
             test_framework.test_mac::<HMAC<SHA512>>(&KeyMaterial::<131>::from_bytes_as_type(&hex::decode("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa").unwrap(), KeyType::MACKey).unwrap(),
                                                     b"This is a test using a larger than block-size key and a larger than block-size data. The key needs to be hashed before being used by the HMAC algorithm.",
-                                                    &hex::decode("e37b6a775dc87dbaa4dfa9f96e5e3ffddebd71f8867289865df5a32d20cdc944b6022cac3c4982b10d5eeb55c3e4de15134676fb6de0446065c97440fa8c6a58").unwrap()
+                                                    &hex::decode("e37b6a775dc87dbaa4dfa9f96e5e3ffddebd71f8867289865df5a32d20cdc944b6022cac3c4982b10d5eeb55c3e4de15134676fb6de0446065c97440fa8c6a58").unwrap(),
             );
         }
     }
 
     #[test]
     fn suspendable_keyed_state() {
-        use bouncycastle_core::errors::SerializedStateError;
+        use bouncycastle_core::errors::SuspendableError;
         use bouncycastle_core::serializable_state::LIB_VERSION;
         use bouncycastle_core::traits::SuspendableKeyed;
         use bouncycastle_core_test_framework::suspendable_state::TestFrameworkSuspendableKeyedState;
@@ -651,7 +651,7 @@ mod hmac_tests {
             let mut busted = serialized_state;
             busted[..3].copy_from_slice(&[0, 0, 0]);
             match H::from_suspended(busted, key) {
-                Err(SerializedStateError::IncompatibleVersion) => { /* good */ }
+                Err(SuspendableError::IncompatibleVersion) => { /* good */ }
                 _ => panic!("Expected IncompatibleVersion for a zeroed version header"),
             }
         }
@@ -659,5 +659,29 @@ mod hmac_tests {
         round_trip(HMAC_SHA256::new(&key).unwrap(), &key, msg);
         round_trip(HMAC_SHA512::new(&key).unwrap(), &key, msg);
         round_trip(HMAC_SHA3_256::new(&key).unwrap(), &key, msg);
+
+        // test suspend / resume with a key larger than block size
+        let long_key =
+            KeyMaterial::<200>::from_bytes_as_type(&DUMMY_SEED_512[..200], KeyType::MACKey)
+                .unwrap();
+        round_trip(HMAC_SHA256::new(&long_key).unwrap(), &long_key, msg);
+    }
+
+    /// Tests that no private data is displayed
+    #[test]
+    fn test_display() {
+        let key = KeyMaterial256::from_bytes_as_type(
+            &hex::decode("0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b").unwrap(),
+            KeyType::MACKey,
+        )
+        .unwrap();
+        let hmac = HMAC_SHA256::new(&key).unwrap();
+
+        // test fmt
+        let fmt_str = format!("{}", &hmac);
+        assert_eq!(fmt_str, "HMAC-SHA256 instance");
+
+        // test debug
+        assert_eq!(format!("{:?}", &hmac), "HMAC-SHA256 instance");
     }
 }

--- a/crypto/mldsa-lowmemory/src/hash_mldsa.rs
+++ b/crypto/mldsa-lowmemory/src/hash_mldsa.rs
@@ -1236,7 +1236,7 @@ impl<
         let mut mu = [0u8; MLDSA_MU_LEN];
         _ = h.squeeze_out(&mut mu);
 
-        if MLDSA::<
+        MLDSA::<
             PK_LEN,
             SK_LEN,
             FULL_SK_LEN,
@@ -1262,11 +1262,6 @@ impl<
             GAMMA1_MINUS_BETA,
             GAMMA2_MINUS_BETA,
             GAMMA1_MASK_LEN,
-        >::verify_mu_internal(pk, &mu, sig_sized)
-        {
-            Ok(())
-        } else {
-            Err(SignatureError::SignatureVerificationFailed)
-        }
+        >::verify_mu(pk, &mu, sig_sized)
     }
 }

--- a/crypto/mldsa-lowmemory/src/lib.rs
+++ b/crypto/mldsa-lowmemory/src/lib.rs
@@ -258,5 +258,7 @@ pub use mldsa::{MLDSA44_PK_LEN, MLDSA44_SIG_LEN, MLDSA44_SK_LEN};
 pub use mldsa::{MLDSA65_PK_LEN, MLDSA65_SIG_LEN, MLDSA65_SK_LEN};
 pub use mldsa::{MLDSA87_PK_LEN, MLDSA87_SIG_LEN, MLDSA87_SK_LEN};
 
+pub use mldsa::MU_BUILDER_SERIALIZED_STATE_LEN;
+
 // re-export just so it's visible to unit tests
 pub use polynomial::Polynomial;

--- a/crypto/mldsa-lowmemory/src/mldsa.rs
+++ b/crypto/mldsa-lowmemory/src/mldsa.rs
@@ -397,7 +397,7 @@ use crate::{
     MLDSA44PrivateKey, MLDSA44PublicKey, MLDSA65PrivateKey, MLDSA65PublicKey, MLDSA87PrivateKey,
     MLDSA87PublicKey,
 };
-use bouncycastle_core::errors::{RNGError, SerializedStateError, SignatureError};
+use bouncycastle_core::errors::{RNGError, SignatureError, SuspendableError};
 use bouncycastle_core::key_material::KeyMaterial;
 use bouncycastle_core::traits::{
     Algorithm, RNG, SecurityStrength, SignatureVerifier, Signer, Suspendable, XOF,
@@ -1953,7 +1953,7 @@ impl Suspendable<SUSPENDED_SHA3_STATE_LEN> for MuBuilder {
 
     fn from_suspended(
         serialized_state: [u8; SUSPENDED_SHA3_STATE_LEN],
-    ) -> Result<Self, SerializedStateError> {
+    ) -> Result<Self, SuspendableError> {
         Ok(MuBuilder { h: H::from_suspended(serialized_state)? })
     }
 }

--- a/crypto/mldsa-lowmemory/src/mldsa.rs
+++ b/crypto/mldsa-lowmemory/src/mldsa.rs
@@ -308,6 +308,81 @@
 //! private key encoding (which is often called the "semi-expanded format" since the in-memory representation
 //! is still larger).
 //! Contact us if you need such a thing implemented.
+//!
+//! # Suspending and resuming execution via SerializableState
+//!
+//! When signing or verifying a large message, it can be advantageous to be able to suspend the operation
+//! to a cache and resume it later; for example if waiting for the message to stream over a slow network
+//! connection.
+//!
+//! This can bo accomplished for both the ML-DSA signer and verifier through the [MuBuilder] object.
+//!
+//! Suspending an in-progress sign operation:
+//!
+//! ```rust
+//! use bouncycastle_mldsa_lowmemory::{MLDSA65, MuBuilder, MLDSATrait, MLDSAPublicKeyTrait};
+//! use bouncycastle_core::traits::{Signer, SerializableState};
+//!
+//! let msg_part1 = b"The quick brown fox";
+//! let msg_part2 = b" jumped over the lazy dog";
+//!
+//! let (pk, sk) = MLDSA65::keygen().unwrap();
+//!
+//! let mut mb = MuBuilder::do_init(&pk.compute_tr(), None).unwrap();
+//! mb.do_update(msg_part1);
+//!
+//! // here, we'll suspend while "waiting" for the second part of the message
+//! let serialized_state = mb.serialize_state();
+//!
+//! // ...
+//! // do other things in the meantime
+//! // ...
+//!
+//! let mut mb_resumed = MuBuilder::from_serialized_state(serialized_state).unwrap();
+//! mb_resumed.do_update(msg_part2);
+//! let mu: [u8; 64] = mb_resumed.do_final();
+//!
+//! // Now we'll do the actual sign_mu operation
+//! let sig = MLDSA65::sign_mu(&sk, &mu).unwrap();
+//! ```
+//!
+//! Suspending an in-progress verify operation behaves exactly the same way:
+//!
+//! ```rust
+//! use bouncycastle_mldsa_lowmemory::{MLDSA65, MuBuilder, MLDSATrait, MLDSAPublicKeyTrait};
+//! use bouncycastle_core::traits::{Signer, SerializableState};
+//! use bouncycastle_core::errors::SignatureError;
+//!
+//! let (pk, sk) = MLDSA65::keygen().unwrap();
+//!
+//! // first, let's generate a signature to verify
+//! let sig = MLDSA65::sign(&sk, b"The quick brown fox jumped over the lazy dog", None).unwrap();
+//!
+//! // Now we'll verify it with a suspension in the middle
+//! let msg_part1 = b"The quick brown fox";
+//! let msg_part2 = b" jumped over the lazy dog";
+//!
+//! let mut mb = MuBuilder::do_init(&pk.compute_tr(), None).unwrap();
+//! mb.do_update(msg_part1);
+//!
+//! // here, we'll suspend while "waiting" for the second part of the message
+//! let serialized_state = mb.serialize_state();
+//!
+//! // ...
+//! // do other things in the meantime
+//! // ...
+//!
+//! let mut mb_resumed = MuBuilder::from_serialized_state(serialized_state).unwrap();
+//! mb_resumed.do_update(msg_part2);
+//! let mu: [u8; 64] = mb_resumed.do_final();
+//!
+//! // Now we'll do the actual verify_mu operation
+//! match MLDSA65::verify_mu(&pk, &mu, &sig) {
+//!     Ok(()) => println!("Signature is valid!"),
+//!     Err(SignatureError::SignatureVerificationFailed) => println!("Signature is invalid!"),
+//!     Err(e) => panic!("Something else went wrong: {:?}", e),
+//! }
+//! ```
 
 use crate::aux_functions::{
     bitlen_eta, bitpack_gamma1, sample_in_ball, unpack_c_tilde, unpack_h_row,
@@ -322,11 +397,13 @@ use crate::{
     MLDSA44PrivateKey, MLDSA44PublicKey, MLDSA65PrivateKey, MLDSA65PublicKey, MLDSA87PrivateKey,
     MLDSA87PublicKey,
 };
-use bouncycastle_core::errors::{RNGError, SignatureError};
+use bouncycastle_core::errors::{RNGError, SerializedStateError, SignatureError};
 use bouncycastle_core::key_material::KeyMaterial;
-use bouncycastle_core::traits::{Algorithm, RNG, SecurityStrength, SignatureVerifier, Signer, XOF};
+use bouncycastle_core::traits::{
+    Algorithm, RNG, SecurityStrength, SerializableState, SignatureVerifier, Signer, XOF,
+};
 use bouncycastle_rng::HashDRBG_SHA512;
-use bouncycastle_sha3::{SHAKE128, SHAKE256};
+use bouncycastle_sha3::{SHA3_SERIALIZED_STATE_LEN, SHAKE128, SHAKE256};
 use core::marker::PhantomData;
 
 // imports needed just for docs
@@ -1210,7 +1287,7 @@ impl<
     /// Internal function to verify a signature 𝜎 for a formatted message 𝑀′ .
     /// Input: Public key 𝑝𝑘 ∈ 𝔹32+32𝑘(bitlen (𝑞−1)−𝑑) and message 𝑀′ ∈ {0, 1}∗ .
     /// Input: Signature 𝜎 ∈ 𝔹𝜆/4+ℓ⋅32⋅(1+bitlen (𝛾1−1))+𝜔+𝑘.
-    fn verify_mu_internal(pk: &PK, mu: &[u8; 64], sig: &[u8; SIG_LEN]) -> bool {
+    fn verify_mu(pk: &PK, mu: &[u8; 64], sig: &[u8; SIG_LEN]) -> Result<(), SignatureError> {
         // 1: (𝜌, 𝐭1) ← pkDecode(𝑝𝑘)
         // Already done -- the pk struct is already decoded
 
@@ -1247,7 +1324,7 @@ impl<
             } {
                 Ok(wp_approx) => wp_approx,
                 // means the norm check on z failed
-                Err(_) => return false,
+                Err(_) => return Err(SignatureError::SignatureVerificationFailed),
             };
 
             let h_i = match unpack_h_row::<
@@ -1262,7 +1339,7 @@ impl<
             {
                 Some(h_i) => h_i,
                 // means there were more than OMEGA bits set in the hint
-                None => return false,
+                None => return Err(SignatureError::SignatureVerificationFailed),
             };
 
             // 10: 𝐰1′ ← UseHint(𝐡, 𝐰'_approx)
@@ -1278,7 +1355,11 @@ impl<
         // 13 (second half): return [[ ||𝐳||∞ < 𝛾1 − 𝛽]] and [[𝑐 ̃ = 𝑐′ ]]
         //   note: the first half of this check (the norm check) is buried in unpack_z_row(),
         //         which is called from compute_wp_approx_row()
-        bouncycastle_utils::ct::ct_eq_bytes(unpack_c_tilde::<LAMBDA_over_4>(sig), &c_tilde_p)
+        if bouncycastle_utils::ct::ct_eq_bytes(unpack_c_tilde::<LAMBDA_over_4>(sig), &c_tilde_p) {
+            Ok(())
+        } else {
+            Err(SignatureError::SignatureVerificationFailed)
+        }
     }
 }
 
@@ -1504,11 +1585,10 @@ pub trait MLDSATrait<
         seed: &KeyMaterial<32>,
         ctx: Option<&[u8]>,
     ) -> Result<Self, SignatureError>;
-    /// Algorithm 8 ML-DSA.Verify_internal(𝑝𝑘, 𝑀′, 𝜎)
-    /// Internal function to verify a signature 𝜎 for a formatted message 𝑀′ .
-    /// Input: Public key 𝑝𝑘 ∈ 𝔹32+32𝑘(bitlen (𝑞−1)−𝑑) and message 𝑀′ ∈ {0, 1}∗ .
-    /// Input: Signature 𝜎 ∈ 𝔹𝜆/4+ℓ⋅32⋅(1+bitlen (𝛾1−1))+𝜔+𝑘.
-    fn verify_mu_internal(pk: &PK, mu: &[u8; 64], sig: &[u8; SIG_LEN]) -> bool;
+    /// Performs an ML-DSA signature verification using the provided external message representative `mu`.
+    /// This implements FIPS 204 Algorithm 8 with line 7 removed; a modification that is allowed by both
+    /// FIPS 204 itself, as well as subsequent FAQ documents.
+    fn verify_mu(pk: &PK, mu: &[u8; 64], sig: &[u8; SIG_LEN]) -> Result<(), SignatureError>;
 }
 
 impl<
@@ -1746,11 +1826,7 @@ impl<
         if sig.len() != SIG_LEN {
             return Err(SignatureError::LengthError("Signature value is not the correct length."));
         }
-        if Self::verify_mu_internal(pk, &mu, &sig.try_into().unwrap()) {
-            Ok(())
-        } else {
-            Err(SignatureError::SignatureVerificationFailed)
-        }
+        Self::verify_mu(pk, &mu, &sig.try_into().unwrap())
     }
 
     fn verify_init(pk: &PK, ctx: Option<&[u8]>) -> Result<Self, SignatureError> {
@@ -1780,11 +1856,7 @@ impl<
             return Err(SignatureError::LengthError("Signature value is not the correct length."));
         }
 
-        if Self::verify_mu_internal(&self.pk.unwrap(), &mu, &sig.try_into().unwrap()) {
-            Ok(())
-        } else {
-            Err(SignatureError::SignatureVerificationFailed)
-        }
+        Self::verify_mu(&self.pk.unwrap(), &mu, &sig.try_into().unwrap())
     }
 }
 
@@ -1797,6 +1869,7 @@ impl<
 /// does not benefit from allowing external construction of the message representative mu.
 /// You can get the same behaviour by computing the pre-hash `ph` with the appropriate hash function
 /// and providing that to HashMLDSA via [PHSigner::sign_ph].
+#[derive(Clone)]
 pub struct MuBuilder {
     h: H,
 }
@@ -1860,5 +1933,27 @@ impl MuBuilder {
         self.h.squeeze_out(&mut mu);
 
         mu
+    }
+}
+
+/// The length, in bytes, of a serialized state of a [MuBuilder] object.
+pub const MU_BUILDER_SERIALIZED_STATE_LEN: usize = SHA3_SERIALIZED_STATE_LEN;
+
+/// If you are processing a large input message into ML-DSA and want to pause the operation
+/// -- maybe while waiting for slow network IO), you'll need to use [SerializableState].
+/// Serialization of the state of an in-progress ML-DSA instance is really just serialization
+/// of the construction of the message representative mu, since no other part of the ML-DSA algorithm
+/// has a pausable state.
+// A [MuBuilder]'s (and by virtue, an ML-DSA instance's) entire mutable state is its inner SHAKE256 sponge,
+// so serialization delegates directly to [SHAKE256]'s [SerializableState] impl.
+impl SerializableState<SHA3_SERIALIZED_STATE_LEN> for MuBuilder {
+    fn serialize_state(self) -> [u8; SHA3_SERIALIZED_STATE_LEN] {
+        self.h.serialize_state()
+    }
+
+    fn from_serialized_state(
+        serialized_state: [u8; SHA3_SERIALIZED_STATE_LEN],
+    ) -> Result<Self, SerializedStateError> {
+        Ok(MuBuilder { h: H::from_serialized_state(serialized_state)? })
     }
 }

--- a/crypto/mldsa-lowmemory/src/mldsa.rs
+++ b/crypto/mldsa-lowmemory/src/mldsa.rs
@@ -321,7 +321,7 @@
 //!
 //! ```rust
 //! use bouncycastle_mldsa_lowmemory::{MLDSA65, MuBuilder, MLDSATrait, MLDSAPublicKeyTrait};
-//! use bouncycastle_core::traits::{Signer, SerializableState};
+//! use bouncycastle_core::traits::{Signer, Suspendable};
 //!
 //! let msg_part1 = b"The quick brown fox";
 //! let msg_part2 = b" jumped over the lazy dog";
@@ -332,13 +332,13 @@
 //! mb.do_update(msg_part1);
 //!
 //! // here, we'll suspend while "waiting" for the second part of the message
-//! let serialized_state = mb.serialize_state();
+//! let serialized_state = mb.suspend();
 //!
 //! // ...
 //! // do other things in the meantime
 //! // ...
 //!
-//! let mut mb_resumed = MuBuilder::from_serialized_state(serialized_state).unwrap();
+//! let mut mb_resumed = MuBuilder::from_suspended(serialized_state).unwrap();
 //! mb_resumed.do_update(msg_part2);
 //! let mu: [u8; 64] = mb_resumed.do_final();
 //!
@@ -350,7 +350,7 @@
 //!
 //! ```rust
 //! use bouncycastle_mldsa_lowmemory::{MLDSA65, MuBuilder, MLDSATrait, MLDSAPublicKeyTrait};
-//! use bouncycastle_core::traits::{Signer, SerializableState};
+//! use bouncycastle_core::traits::{Signer, Suspendable};
 //! use bouncycastle_core::errors::SignatureError;
 //!
 //! let (pk, sk) = MLDSA65::keygen().unwrap();
@@ -366,13 +366,13 @@
 //! mb.do_update(msg_part1);
 //!
 //! // here, we'll suspend while "waiting" for the second part of the message
-//! let serialized_state = mb.serialize_state();
+//! let serialized_state = mb.suspend();
 //!
 //! // ...
 //! // do other things in the meantime
 //! // ...
 //!
-//! let mut mb_resumed = MuBuilder::from_serialized_state(serialized_state).unwrap();
+//! let mut mb_resumed = MuBuilder::from_suspended(serialized_state).unwrap();
 //! mb_resumed.do_update(msg_part2);
 //! let mu: [u8; 64] = mb_resumed.do_final();
 //!
@@ -400,10 +400,10 @@ use crate::{
 use bouncycastle_core::errors::{RNGError, SerializedStateError, SignatureError};
 use bouncycastle_core::key_material::KeyMaterial;
 use bouncycastle_core::traits::{
-    Algorithm, RNG, SecurityStrength, SerializableState, SignatureVerifier, Signer, XOF,
+    Algorithm, RNG, SecurityStrength, SignatureVerifier, Signer, Suspendable, XOF,
 };
 use bouncycastle_rng::HashDRBG_SHA512;
-use bouncycastle_sha3::{SHA3_SERIALIZED_STATE_LEN, SHAKE128, SHAKE256};
+use bouncycastle_sha3::{SHAKE128, SHAKE256, SUSPENDED_SHA3_STATE_LEN};
 use core::marker::PhantomData;
 
 // imports needed just for docs
@@ -1937,23 +1937,23 @@ impl MuBuilder {
 }
 
 /// The length, in bytes, of a serialized state of a [MuBuilder] object.
-pub const MU_BUILDER_SERIALIZED_STATE_LEN: usize = SHA3_SERIALIZED_STATE_LEN;
+pub const MU_BUILDER_SERIALIZED_STATE_LEN: usize = SUSPENDED_SHA3_STATE_LEN;
 
 /// If you are processing a large input message into ML-DSA and want to pause the operation
-/// -- maybe while waiting for slow network IO), you'll need to use [SerializableState].
+/// -- maybe while waiting for slow network IO), you'll need to use [Suspendable].
 /// Serialization of the state of an in-progress ML-DSA instance is really just serialization
 /// of the construction of the message representative mu, since no other part of the ML-DSA algorithm
 /// has a pausable state.
 // A [MuBuilder]'s (and by virtue, an ML-DSA instance's) entire mutable state is its inner SHAKE256 sponge,
 // so serialization delegates directly to [SHAKE256]'s [SerializableState] impl.
-impl SerializableState<SHA3_SERIALIZED_STATE_LEN> for MuBuilder {
-    fn serialize_state(self) -> [u8; SHA3_SERIALIZED_STATE_LEN] {
-        self.h.serialize_state()
+impl Suspendable<SUSPENDED_SHA3_STATE_LEN> for MuBuilder {
+    fn suspend(self) -> [u8; SUSPENDED_SHA3_STATE_LEN] {
+        self.h.suspend()
     }
 
-    fn from_serialized_state(
-        serialized_state: [u8; SHA3_SERIALIZED_STATE_LEN],
+    fn from_suspended(
+        serialized_state: [u8; SUSPENDED_SHA3_STATE_LEN],
     ) -> Result<Self, SerializedStateError> {
-        Ok(MuBuilder { h: H::from_serialized_state(serialized_state)? })
+        Ok(MuBuilder { h: H::from_suspended(serialized_state)? })
     }
 }

--- a/crypto/mldsa-lowmemory/tests/mldsa_tests.rs
+++ b/crypto/mldsa-lowmemory/tests/mldsa_tests.rs
@@ -2,7 +2,7 @@
 #[cfg(test)]
 mod mldsa_tests {
     use crate::{MLDSA44_KAT1, MLDSA65_KAT1, MLDSA87_KAT1};
-    use bouncycastle_core::errors::{RNGError, SerializedStateError, SignatureError};
+    use bouncycastle_core::errors::{RNGError, SignatureError, SuspendableError};
     use bouncycastle_core::key_material;
     use bouncycastle_core::key_material::{KeyMaterial256, KeyMaterialTrait, KeyType};
     use bouncycastle_core::traits::{
@@ -875,7 +875,7 @@ mod mldsa_tests {
         let mut busted = serialized_state;
         busted[3 + 1 + 400] = 42;
         match MuBuilder::from_suspended(busted) {
-            Err(SerializedStateError::InvalidData) => { /* good */ }
+            Err(SuspendableError::InvalidData) => { /* good */ }
             _ => panic!("Expected an error for a corrupt squeezing byte"),
         }
     }
@@ -894,7 +894,7 @@ mod mldsa_tests {
         let serialized_128 = shake128.suspend();
 
         match MuBuilder::from_suspended(serialized_128) {
-            Err(SerializedStateError::InvalidData) => { /* good */ }
+            Err(SuspendableError::InvalidData) => { /* good */ }
             _ => panic!("Expected an error when loading a SHAKE128 state into a MuBuilder"),
         }
     }

--- a/crypto/mldsa-lowmemory/tests/mldsa_tests.rs
+++ b/crypto/mldsa-lowmemory/tests/mldsa_tests.rs
@@ -6,12 +6,11 @@ mod mldsa_tests {
     use bouncycastle_core::key_material;
     use bouncycastle_core::key_material::{KeyMaterial256, KeyMaterialTrait, KeyType};
     use bouncycastle_core::traits::{
-        RNG, SecurityStrength, SerializableState, SignaturePrivateKey, SignaturePublicKey,
-        SignatureVerifier, Signer,
+        RNG, SecurityStrength, SignaturePrivateKey, SignaturePublicKey, SignatureVerifier, Signer,
+        Suspendable,
     };
     use bouncycastle_core_test_framework::DUMMY_SEED_1024;
     use bouncycastle_core_test_framework::FixedSeedRNG;
-    use bouncycastle_core_test_framework::serializable_state::TestFrameworkSerializableState;
     use bouncycastle_core_test_framework::signature::*;
     use bouncycastle_hex as hex;
     use bouncycastle_mldsa_lowmemory::{
@@ -817,9 +816,9 @@ mod mldsa_tests {
 
         // serializing and resuming after init
         let mb = MuBuilder::do_init(&pk.compute_tr(), None).unwrap();
-        let serialized_state = mb.serialize_state();
+        let serialized_state = mb.suspend();
 
-        let mut mb_resumed = MuBuilder::from_serialized_state(serialized_state).unwrap();
+        let mut mb_resumed = MuBuilder::from_suspended(serialized_state).unwrap();
         mb_resumed.do_update(msg);
         let mu_resumed = mb_resumed.do_final();
         assert_eq!(mu_resumed, mu1);
@@ -831,15 +830,17 @@ mod mldsa_tests {
         let mut mb = MuBuilder::do_init(&pk.compute_tr(), None).unwrap();
         mb.do_update(msg1);
 
-        let serialized_state = mb.serialize_state();
-        let mut mb_resumed = MuBuilder::from_serialized_state(serialized_state).unwrap();
+        let serialized_state = mb.suspend();
+        let mut mb_resumed = MuBuilder::from_suspended(serialized_state).unwrap();
         mb_resumed.do_update(msg2);
         let mu_resumed2 = mb_resumed.do_final();
         assert_eq!(mu_resumed2, mu1);
     }
 
     #[test]
-    fn mubuilder_serializable_state() {
+    fn mubuilder_suspendable_state() {
+        use bouncycastle_core_test_framework::suspendable_state::TestFrameworkSuspendableState;
+
         // `tr` is the 64-byte public-key hash that seeds mu computation; its exact value doesn't
         // matter for exercising serialization, only that it is fixed across the comparison.
         let tr = [0x42u8; 64];
@@ -851,16 +852,16 @@ mod mldsa_tests {
 
         // Generic trait-conformance tests (version header present, [0,0,0] and future versions
         // rejected).
-        TestFrameworkSerializableState::new().test(&mb);
+        TestFrameworkSuspendableState::new().test(&mb);
 
         // Serialize the in-progress state, then finish the original.
-        let serialized_state = mb.clone().serialize_state();
+        let serialized_state = mb.clone().suspend();
         mb.do_update(&msg[10..]);
         let expected_mu = mb.do_final();
 
         // Rebuild from the serialized state, feed it the identical remaining input, and confirm it
         // produces the same mu.
-        let mut from_state = MuBuilder::from_serialized_state(serialized_state).unwrap();
+        let mut from_state = MuBuilder::from_suspended(serialized_state).unwrap();
         from_state.do_update(&msg[10..]);
         assert_eq!(expected_mu, from_state.do_final());
 
@@ -873,7 +874,7 @@ mod mldsa_tests {
         // + bits_in_queue(8) + squeezing(1) -> the squeezing byte is at offset 3 + 1 + 400.
         let mut busted = serialized_state;
         busted[3 + 1 + 400] = 42;
-        match MuBuilder::from_serialized_state(busted) {
+        match MuBuilder::from_suspended(busted) {
             Err(SerializedStateError::InvalidData) => { /* good */ }
             _ => panic!("Expected an error for a corrupt squeezing byte"),
         }
@@ -890,9 +891,9 @@ mod mldsa_tests {
         // tag 6).
         let mut shake128 = SHAKE128::new();
         shake128.absorb(b"Colorless green ideas sleep furiously");
-        let serialized_128 = shake128.serialize_state();
+        let serialized_128 = shake128.suspend();
 
-        match MuBuilder::from_serialized_state(serialized_128) {
+        match MuBuilder::from_suspended(serialized_128) {
             Err(SerializedStateError::InvalidData) => { /* good */ }
             _ => panic!("Expected an error when loading a SHAKE128 state into a MuBuilder"),
         }

--- a/crypto/mldsa-lowmemory/tests/mldsa_tests.rs
+++ b/crypto/mldsa-lowmemory/tests/mldsa_tests.rs
@@ -2,14 +2,16 @@
 #[cfg(test)]
 mod mldsa_tests {
     use crate::{MLDSA44_KAT1, MLDSA65_KAT1, MLDSA87_KAT1};
-    use bouncycastle_core::errors::{RNGError, SignatureError};
+    use bouncycastle_core::errors::{RNGError, SerializedStateError, SignatureError};
     use bouncycastle_core::key_material;
     use bouncycastle_core::key_material::{KeyMaterial256, KeyMaterialTrait, KeyType};
     use bouncycastle_core::traits::{
-        RNG, SecurityStrength, SignaturePrivateKey, SignaturePublicKey, SignatureVerifier, Signer,
+        RNG, SecurityStrength, SerializableState, SignaturePrivateKey, SignaturePublicKey,
+        SignatureVerifier, Signer,
     };
     use bouncycastle_core_test_framework::DUMMY_SEED_1024;
     use bouncycastle_core_test_framework::FixedSeedRNG;
+    use bouncycastle_core_test_framework::serializable_state::TestFrameworkSerializableState;
     use bouncycastle_core_test_framework::signature::*;
     use bouncycastle_hex as hex;
     use bouncycastle_mldsa_lowmemory::{
@@ -810,6 +812,90 @@ mod mldsa_tests {
         mb.do_update(b"jumped over the lazy dog");
         let mu6 = mb.do_final();
         assert_eq!(mu1, mu6);
+
+        // test SerializedState for MuBuilder
+
+        // serializing and resuming after init
+        let mb = MuBuilder::do_init(&pk.compute_tr(), None).unwrap();
+        let serialized_state = mb.serialize_state();
+
+        let mut mb_resumed = MuBuilder::from_serialized_state(serialized_state).unwrap();
+        mb_resumed.do_update(msg);
+        let mu_resumed = mb_resumed.do_final();
+        assert_eq!(mu_resumed, mu1);
+
+        // serializing and resuming partway through message consumption
+        let msg1 = b"The quick brown fox";
+        let msg2 = b" jumped over the lazy dog";
+
+        let mut mb = MuBuilder::do_init(&pk.compute_tr(), None).unwrap();
+        mb.do_update(msg1);
+
+        let serialized_state = mb.serialize_state();
+        let mut mb_resumed = MuBuilder::from_serialized_state(serialized_state).unwrap();
+        mb_resumed.do_update(msg2);
+        let mu_resumed2 = mb_resumed.do_final();
+        assert_eq!(mu_resumed2, mu1);
+    }
+
+    #[test]
+    fn mubuilder_serializable_state() {
+        // `tr` is the 64-byte public-key hash that seeds mu computation; its exact value doesn't
+        // matter for exercising serialization, only that it is fixed across the comparison.
+        let tr = [0x42u8; 64];
+        let msg = b"Colorless green ideas sleep furiously";
+
+        // Put the builder into a mid-stream state (some, but not all, of the message absorbed).
+        let mut mb = MuBuilder::do_init(&tr, None).unwrap();
+        mb.do_update(&msg[..10]);
+
+        // Generic trait-conformance tests (version header present, [0,0,0] and future versions
+        // rejected).
+        TestFrameworkSerializableState::new().test(&mb);
+
+        // Serialize the in-progress state, then finish the original.
+        let serialized_state = mb.clone().serialize_state();
+        mb.do_update(&msg[10..]);
+        let expected_mu = mb.do_final();
+
+        // Rebuild from the serialized state, feed it the identical remaining input, and confirm it
+        // produces the same mu.
+        let mut from_state = MuBuilder::from_serialized_state(serialized_state).unwrap();
+        from_state.do_update(&msg[10..]);
+        assert_eq!(expected_mu, from_state.do_final());
+
+        // Anchor correctness to the existing one-shot path: streaming must match compute_mu.
+        let one_shot = MuBuilder::compute_mu(&tr, msg, None).unwrap();
+        assert_eq!(expected_mu, one_shot);
+
+        // A corrupt SHAKE256 `squeezing` byte must be rejected. Layout of the delegated SHAKE256
+        // state: 3 version bytes + variant tag(1) + [u64;25](200) + data_queue(192)
+        // + bits_in_queue(8) + squeezing(1) -> the squeezing byte is at offset 3 + 1 + 400.
+        let mut busted = serialized_state;
+        busted[3 + 1 + 400] = 42;
+        match MuBuilder::from_serialized_state(busted) {
+            Err(SerializedStateError::InvalidData) => { /* good */ }
+            _ => panic!("Expected an error for a corrupt squeezing byte"),
+        }
+    }
+
+    #[test]
+    fn serializable_state_mubuilder_rejects_wrong_variant() {
+        use bouncycastle_core::traits::XOF;
+        use bouncycastle_sha3::SHAKE128;
+
+        // A MuBuilder is always backed by SHAKE256. A serialized SHAKE128 state has the same length
+        // (both are SHA3-family states), so this would deserialize into the wrong sponge if the
+        // variant tag weren't checked -- SHAKE128 (tag 5) must be rejected by MuBuilder (SHAKE256,
+        // tag 6).
+        let mut shake128 = SHAKE128::new();
+        shake128.absorb(b"Colorless green ideas sleep furiously");
+        let serialized_128 = shake128.serialize_state();
+
+        match MuBuilder::from_serialized_state(serialized_128) {
+            Err(SerializedStateError::InvalidData) => { /* good */ }
+            _ => panic!("Expected an error when loading a SHAKE128 state into a MuBuilder"),
+        }
     }
 
     #[test]

--- a/crypto/mldsa-lowmemory/tests/wycheproof.rs
+++ b/crypto/mldsa-lowmemory/tests/wycheproof.rs
@@ -187,6 +187,8 @@ struct MLDSASignSeedTestCase {
     // testGroup-level fields, copied onto every test case in the group
     private_seed: String,
     public_key: String,
+    // test-level `rnd`: present only on hedged/randomized cases; absent = deterministic (all-zero).
+    rnd: Option<String>,
     // test-level fields
     tc_id: u32,
     comment: String,
@@ -203,6 +205,7 @@ impl MLDSASignSeedTestCase {
             parameter_set,
             private_seed: String::new(),
             public_key: String::new(),
+            rnd: None,
             tc_id: 0,
             comment: String::new(),
             msg: None,
@@ -232,6 +235,7 @@ impl MLDSASignSeedTestCase {
                     parameter_set: parameter_set.clone(),
                     private_seed: private_seed.clone(),
                     public_key: public_key.clone(),
+                    rnd: test["rnd"].as_str().map(|s| s.to_string()),
                     tc_id: test["tcId"].as_u64().expect("tcId missing") as u32,
                     comment: test["comment"].as_str().unwrap_or("").to_string(),
                     msg: match test["msg"].as_str() {
@@ -330,7 +334,14 @@ impl MLDSASignSeedTestCase {
         assert_eq!(mu, hex::decode(&self.mu).unwrap().as_slice());
 
         // generate the signature using an all-zero signing nonce
-        let sig = MLDSA44::sign_mu_deterministic(&sk, &mu, [0u8; 32]).unwrap();
+        // Use the vector's `rnd` when present (hedged/randomized cases); deterministic vectors omit
+        // it and are signed with the all-zero nonce.
+        let rnd: [u8; 32] = self
+            .rnd
+            .as_ref()
+            .map(|r| hex::decode(r).unwrap().try_into().unwrap())
+            .unwrap_or([0u8; 32]);
+        let sig = MLDSA44::sign_mu_deterministic(&sk, &mu, rnd).unwrap();
         assert_eq!(sig, hex::decode(&self.sig).unwrap().as_slice());
 
         let res =
@@ -424,7 +435,14 @@ impl MLDSASignSeedTestCase {
         assert_eq!(mu, hex::decode(&self.mu).unwrap().as_slice());
 
         // generate the signature using an all-zero signing nonce
-        let sig = MLDSA65::sign_mu_deterministic(&sk, &mu, [0u8; 32]).unwrap();
+        // Use the vector's `rnd` when present (hedged/randomized cases); deterministic vectors omit
+        // it and are signed with the all-zero nonce.
+        let rnd: [u8; 32] = self
+            .rnd
+            .as_ref()
+            .map(|r| hex::decode(r).unwrap().try_into().unwrap())
+            .unwrap_or([0u8; 32]);
+        let sig = MLDSA65::sign_mu_deterministic(&sk, &mu, rnd).unwrap();
         assert_eq!(sig, hex::decode(&self.sig).unwrap().as_slice());
 
         let res =
@@ -518,7 +536,14 @@ impl MLDSASignSeedTestCase {
         assert_eq!(mu, hex::decode(&self.mu).unwrap().as_slice());
 
         // generate the signature using an all-zero signing nonce
-        let sig = MLDSA87::sign_mu_deterministic(&sk, &mu, [0u8; 32]).unwrap();
+        // Use the vector's `rnd` when present (hedged/randomized cases); deterministic vectors omit
+        // it and are signed with the all-zero nonce.
+        let rnd: [u8; 32] = self
+            .rnd
+            .as_ref()
+            .map(|r| hex::decode(r).unwrap().try_into().unwrap())
+            .unwrap_or([0u8; 32]);
+        let sig = MLDSA87::sign_mu_deterministic(&sk, &mu, rnd).unwrap();
         assert_eq!(sig, hex::decode(&self.sig).unwrap().as_slice());
 
         let res =

--- a/crypto/mldsa-lowmemory/tests/wycheproof.rs
+++ b/crypto/mldsa-lowmemory/tests/wycheproof.rs
@@ -333,16 +333,13 @@ impl MLDSASignSeedTestCase {
         let sig = MLDSA44::sign_mu_deterministic(&sk, &mu, [0u8; 32]).unwrap();
         assert_eq!(sig, hex::decode(&self.sig).unwrap().as_slice());
 
-        let res = MLDSA44::verify_mu_internal(
-            &pk,
-            &mu,
-            &hex::decode(&self.sig).unwrap().try_into().unwrap(),
-        );
+        let res =
+            MLDSA44::verify_mu(&pk, &mu, &hex::decode(&self.sig).unwrap().try_into().unwrap());
 
         if self.result == "valid" {
-            assert!(res);
+            res.unwrap();
         } else {
-            assert!(!res);
+            assert!(res.is_err());
         };
     }
 
@@ -430,16 +427,13 @@ impl MLDSASignSeedTestCase {
         let sig = MLDSA65::sign_mu_deterministic(&sk, &mu, [0u8; 32]).unwrap();
         assert_eq!(sig, hex::decode(&self.sig).unwrap().as_slice());
 
-        let res = MLDSA65::verify_mu_internal(
-            &pk,
-            &mu,
-            &hex::decode(&self.sig).unwrap().try_into().unwrap(),
-        );
+        let res =
+            MLDSA65::verify_mu(&pk, &mu, &hex::decode(&self.sig).unwrap().try_into().unwrap());
 
         if self.result == "valid" {
-            assert!(res);
+            res.unwrap();
         } else {
-            assert!(!res);
+            assert!(res.is_err());
         };
     }
 
@@ -527,16 +521,13 @@ impl MLDSASignSeedTestCase {
         let sig = MLDSA87::sign_mu_deterministic(&sk, &mu, [0u8; 32]).unwrap();
         assert_eq!(sig, hex::decode(&self.sig).unwrap().as_slice());
 
-        let res = MLDSA87::verify_mu_internal(
-            &pk,
-            &mu,
-            &hex::decode(&self.sig).unwrap().try_into().unwrap(),
-        );
+        let res =
+            MLDSA87::verify_mu(&pk, &mu, &hex::decode(&self.sig).unwrap().try_into().unwrap());
 
         if self.result == "valid" {
-            assert!(res);
+            res.unwrap();
         } else {
-            assert!(!res);
+            assert!(res.is_err());
         };
     }
 }

--- a/crypto/mldsa/src/hash_mldsa.rs
+++ b/crypto/mldsa/src/hash_mldsa.rs
@@ -756,66 +756,52 @@ impl<
         };
 
         match A_hat {
-            Some(A_hat) => {
-                if MLDSA::<
-                    PK_LEN,
-                    SK_LEN,
-                    SIG_LEN,
-                    PK,
-                    SK,
-                    TAU,
-                    LAMBDA,
-                    GAMMA1,
-                    GAMMA2,
-                    k,
-                    l,
-                    ETA,
-                    BETA,
-                    OMEGA,
-                    C_TILDE,
-                    POLY_Z_PACKED_LEN,
-                    POLY_W1_PACKED_LEN,
-                    LAMBDA_over_4,
-                    GAMMA1_MINUS_BETA,
-                    GAMMA2_MINUS_BETA,
-                    GAMMA1_MASK_LEN,
-                >::verify_mu_internal(pk, A_hat, &mu, sig_sized)
-                {
-                    Ok(())
-                } else {
-                    Err(SignatureError::SignatureVerificationFailed)
-                }
-            }
-            None => {
-                if MLDSA::<
-                    PK_LEN,
-                    SK_LEN,
-                    SIG_LEN,
-                    PK,
-                    SK,
-                    TAU,
-                    LAMBDA,
-                    GAMMA1,
-                    GAMMA2,
-                    k,
-                    l,
-                    ETA,
-                    BETA,
-                    OMEGA,
-                    C_TILDE,
-                    POLY_Z_PACKED_LEN,
-                    POLY_W1_PACKED_LEN,
-                    LAMBDA_over_4,
-                    GAMMA1_MINUS_BETA,
-                    GAMMA2_MINUS_BETA,
-                    GAMMA1_MASK_LEN,
-                >::verify_mu_internal(pk, &pk.A_hat(), &mu, sig_sized)
-                {
-                    Ok(())
-                } else {
-                    Err(SignatureError::SignatureVerificationFailed)
-                }
-            }
+            Some(A_hat) => MLDSA::<
+                PK_LEN,
+                SK_LEN,
+                SIG_LEN,
+                PK,
+                SK,
+                TAU,
+                LAMBDA,
+                GAMMA1,
+                GAMMA2,
+                k,
+                l,
+                ETA,
+                BETA,
+                OMEGA,
+                C_TILDE,
+                POLY_Z_PACKED_LEN,
+                POLY_W1_PACKED_LEN,
+                LAMBDA_over_4,
+                GAMMA1_MINUS_BETA,
+                GAMMA2_MINUS_BETA,
+                GAMMA1_MASK_LEN,
+            >::verify_mu(pk, Some(A_hat), &mu, sig_sized),
+            None => MLDSA::<
+                PK_LEN,
+                SK_LEN,
+                SIG_LEN,
+                PK,
+                SK,
+                TAU,
+                LAMBDA,
+                GAMMA1,
+                GAMMA2,
+                k,
+                l,
+                ETA,
+                BETA,
+                OMEGA,
+                C_TILDE,
+                POLY_Z_PACKED_LEN,
+                POLY_W1_PACKED_LEN,
+                LAMBDA_over_4,
+                GAMMA1_MINUS_BETA,
+                GAMMA2_MINUS_BETA,
+                GAMMA1_MASK_LEN,
+            >::verify_mu(pk, Some(&pk.A_hat()), &mu, sig_sized),
         }
     }
 }

--- a/crypto/mldsa/src/lib.rs
+++ b/crypto/mldsa/src/lib.rs
@@ -176,6 +176,8 @@ pub use mldsa::{MLDSA44_PK_LEN, MLDSA44_SIG_LEN, MLDSA44_SK_LEN};
 pub use mldsa::{MLDSA65_PK_LEN, MLDSA65_SIG_LEN, MLDSA65_SK_LEN};
 pub use mldsa::{MLDSA87_PK_LEN, MLDSA87_SIG_LEN, MLDSA87_SK_LEN};
 
+pub use mldsa::MU_BUILDER_SERIALIZED_STATE_LEN;
+
 pub use matrix::Matrix;
 
 // re-export just so it's visible to unit tests

--- a/crypto/mldsa/src/mldsa.rs
+++ b/crypto/mldsa/src/mldsa.rs
@@ -411,7 +411,7 @@
 //!
 //! ```rust
 //! use bouncycastle_mldsa::{MLDSA65, MuBuilder, MLDSATrait, MLDSAPublicKeyTrait};
-//! use bouncycastle_core::traits::{Signer, SerializableState};
+//! use bouncycastle_core::traits::{Signer, Suspendable};
 //!
 //! let msg_part1 = b"The quick brown fox";
 //! let msg_part2 = b" jumped over the lazy dog";
@@ -422,13 +422,13 @@
 //! mb.do_update(msg_part1);
 //!
 //! // here, we'll suspend while "waiting" for the second part of the message
-//! let serialized_state = mb.serialize_state();
+//! let serialized_state = mb.suspend();
 //!
 //! // ...
 //! // do other things in the meantime
 //! // ...
 //!
-//! let mut mb_resumed = MuBuilder::from_serialized_state(serialized_state).unwrap();
+//! let mut mb_resumed = MuBuilder::from_suspended(serialized_state).unwrap();
 //! mb_resumed.do_update(msg_part2);
 //! let mu: [u8; 64] = mb_resumed.do_final();
 //!
@@ -440,7 +440,7 @@
 //!
 //! ```rust
 //! use bouncycastle_mldsa::{MLDSA65, MuBuilder, MLDSATrait, MLDSAPublicKeyTrait};
-//! use bouncycastle_core::traits::{Signer, SerializableState};
+//! use bouncycastle_core::traits::{Signer, Suspendable};
 //! use bouncycastle_core::errors::SignatureError;
 //!
 //! let (pk, sk) = MLDSA65::keygen().unwrap();
@@ -456,13 +456,13 @@
 //! mb.do_update(msg_part1);
 //!
 //! // here, we'll suspend while "waiting" for the second part of the message
-//! let serialized_state = mb.serialize_state();
+//! let serialized_state = mb.suspend();
 //!
 //! // ...
 //! // do other things in the meantime
 //! // ...
 //!
-//! let mut mb_resumed = MuBuilder::from_serialized_state(serialized_state).unwrap();
+//! let mut mb_resumed = MuBuilder::from_suspended(serialized_state).unwrap();
 //! mb_resumed.do_update(msg_part2);
 //! let mu: [u8; 64] = mb_resumed.do_final();
 //!
@@ -488,10 +488,10 @@ use crate::{
 use bouncycastle_core::errors::{RNGError, SerializedStateError, SignatureError};
 use bouncycastle_core::key_material::{KeyMaterial, KeyMaterial256, KeyMaterialTrait, KeyType};
 use bouncycastle_core::traits::{
-    Algorithm, RNG, SecurityStrength, SerializableState, SignatureVerifier, Signer, XOF,
+    Algorithm, RNG, SecurityStrength, SignatureVerifier, Signer, Suspendable, XOF,
 };
 use bouncycastle_rng::HashDRBG_SHA512;
-use bouncycastle_sha3::{SHA3_SERIALIZED_STATE_LEN, SHAKE128, SHAKE256};
+use bouncycastle_sha3::{SHAKE128, SHAKE256, SUSPENDED_SHA3_STATE_LEN};
 use core::marker::PhantomData;
 
 // imports needed just for docs
@@ -2259,23 +2259,23 @@ impl MuBuilder {
 }
 
 /// The length, in bytes, of a serialized state of a [MuBuilder] object.
-pub const MU_BUILDER_SERIALIZED_STATE_LEN: usize = SHA3_SERIALIZED_STATE_LEN;
+pub const MU_BUILDER_SERIALIZED_STATE_LEN: usize = SUSPENDED_SHA3_STATE_LEN;
 
 /// If you are processing a large input message into ML-DSA and want to pause the operation
-/// -- maybe while waiting for slow network IO), you'll need to use [SerializableState].
+/// -- maybe while waiting for slow network IO), you'll need to use [Suspendable].
 /// Serialization of the state of an in-progress ML-DSA instance is really just serialization
 /// of the construction of the message representative mu, since no other part of the ML-DSA algorithm
 /// has a pausable state.
 // A [MuBuilder]'s (and by virtue, an ML-DSA instance's) entire mutable state is its inner SHAKE256 sponge,
 // so serialization delegates directly to [SHAKE256]'s [SerializableState] impl.
-impl SerializableState<SHA3_SERIALIZED_STATE_LEN> for MuBuilder {
-    fn serialize_state(self) -> [u8; SHA3_SERIALIZED_STATE_LEN] {
-        self.h.serialize_state()
+impl Suspendable<SUSPENDED_SHA3_STATE_LEN> for MuBuilder {
+    fn suspend(self) -> [u8; SUSPENDED_SHA3_STATE_LEN] {
+        self.h.suspend()
     }
 
-    fn from_serialized_state(
-        serialized_state: [u8; SHA3_SERIALIZED_STATE_LEN],
+    fn from_suspended(
+        serialized_state: [u8; SUSPENDED_SHA3_STATE_LEN],
     ) -> Result<Self, SerializedStateError> {
-        Ok(MuBuilder { h: H::from_serialized_state(serialized_state)? })
+        Ok(MuBuilder { h: H::from_suspended(serialized_state)? })
     }
 }

--- a/crypto/mldsa/src/mldsa.rs
+++ b/crypto/mldsa/src/mldsa.rs
@@ -398,6 +398,81 @@
 //!     Err(e) => panic!("Something else went wrong: {:?}", e),
 //! }
 //! ```
+//!
+//! # Suspending and resuming execution via SerializableState
+//!
+//! When signing or verifying a large message, it can be advantageous to be able to suspend the operation
+//! to a cache and resume it later; for example if waiting for the message to stream over a slow network
+//! connection.
+//!
+//! This can bo accomplished for both the ML-DSA signer and verifier through the [MuBuilder] object.
+//!
+//! Suspending an in-progress sign operation:
+//!
+//! ```rust
+//! use bouncycastle_mldsa::{MLDSA65, MuBuilder, MLDSATrait, MLDSAPublicKeyTrait};
+//! use bouncycastle_core::traits::{Signer, SerializableState};
+//!
+//! let msg_part1 = b"The quick brown fox";
+//! let msg_part2 = b" jumped over the lazy dog";
+//!
+//! let (pk, sk) = MLDSA65::keygen().unwrap();
+//!
+//! let mut mb = MuBuilder::do_init(&pk.compute_tr(), None).unwrap();
+//! mb.do_update(msg_part1);
+//!
+//! // here, we'll suspend while "waiting" for the second part of the message
+//! let serialized_state = mb.serialize_state();
+//!
+//! // ...
+//! // do other things in the meantime
+//! // ...
+//!
+//! let mut mb_resumed = MuBuilder::from_serialized_state(serialized_state).unwrap();
+//! mb_resumed.do_update(msg_part2);
+//! let mu: [u8; 64] = mb_resumed.do_final();
+//!
+//! // Now we'll do the actual sign_mu operation
+//! let sig = MLDSA65::sign_mu(&sk, None, &mu).unwrap();
+//! ```
+//!
+//! Suspending an in-progress verify operation behaves exactly the same way:
+//!
+//! ```rust
+//! use bouncycastle_mldsa::{MLDSA65, MuBuilder, MLDSATrait, MLDSAPublicKeyTrait};
+//! use bouncycastle_core::traits::{Signer, SerializableState};
+//! use bouncycastle_core::errors::SignatureError;
+//!
+//! let (pk, sk) = MLDSA65::keygen().unwrap();
+//!
+//! // first, let's generate a signature to verify
+//! let sig = MLDSA65::sign(&sk, b"The quick brown fox jumped over the lazy dog", None).unwrap();
+//!
+//! // Now we'll verify it with a suspension in the middle
+//! let msg_part1 = b"The quick brown fox";
+//! let msg_part2 = b" jumped over the lazy dog";
+//!
+//! let mut mb = MuBuilder::do_init(&pk.compute_tr(), None).unwrap();
+//! mb.do_update(msg_part1);
+//!
+//! // here, we'll suspend while "waiting" for the second part of the message
+//! let serialized_state = mb.serialize_state();
+//!
+//! // ...
+//! // do other things in the meantime
+//! // ...
+//!
+//! let mut mb_resumed = MuBuilder::from_serialized_state(serialized_state).unwrap();
+//! mb_resumed.do_update(msg_part2);
+//! let mu: [u8; 64] = mb_resumed.do_final();
+//!
+//! // Now we'll do the actual verify_mu operation
+//! match MLDSA65::verify_mu(&pk, Some(&pk.A_hat()), &mu, &sig) {
+//!     Ok(()) => println!("Signature is valid!"),
+//!     Err(SignatureError::SignatureVerificationFailed) => println!("Signature is invalid!"),
+//!     Err(e) => panic!("Something else went wrong: {:?}", e),
+//! }
+//! ```
 
 use crate::aux_functions::{
     expand_mask, expandA, expandS, make_hint_vecs, power_2_round_vec, sample_in_ball, sig_decode,
@@ -410,11 +485,13 @@ use crate::{
     MLDSA44PrivateKey, MLDSA44PublicKey, MLDSA65PrivateKey, MLDSA65PublicKey, MLDSA87PrivateKey,
     MLDSA87PublicKey, MLDSAPrivateKeyExpanded, MLDSAPublicKeyExpanded,
 };
-use bouncycastle_core::errors::{RNGError, SignatureError};
+use bouncycastle_core::errors::{RNGError, SerializedStateError, SignatureError};
 use bouncycastle_core::key_material::{KeyMaterial, KeyMaterial256, KeyMaterialTrait, KeyType};
-use bouncycastle_core::traits::{Algorithm, RNG, SecurityStrength, SignatureVerifier, Signer, XOF};
+use bouncycastle_core::traits::{
+    Algorithm, RNG, SecurityStrength, SerializableState, SignatureVerifier, Signer, XOF,
+};
 use bouncycastle_rng::HashDRBG_SHA512;
-use bouncycastle_sha3::{SHAKE128, SHAKE256};
+use bouncycastle_sha3::{SHA3_SERIALIZED_STATE_LEN, SHAKE128, SHAKE256};
 use core::marker::PhantomData;
 
 // imports needed just for docs
@@ -1017,6 +1094,99 @@ impl<
 
         Ok(bytes_written)
     }
+
+    /// Algorithm 8 ML-DSA.Verify_internal(𝑝𝑘, 𝑀′, 𝜎)
+    /// Internal function to verify a signature 𝜎 for a formatted message 𝑀′ .
+    /// Input: Public key 𝑝𝑘 ∈ 𝔹32+32𝑘(bitlen (𝑞−1)−𝑑) and message 𝑀′ ∈ {0, 1}∗ .
+    /// Input: Signature 𝜎 ∈ 𝔹𝜆/4+ℓ⋅32⋅(1+bitlen (𝛾1−1))+𝜔+𝑘.
+    fn verify_internal(
+        pk: &PK,
+        A_hat: &Matrix<k, l>,
+        mu: &[u8; 64],
+        sig: &[u8; SIG_LEN],
+    ) -> Result<(), SignatureError> {
+        // 1: (𝜌, 𝐭1) ← pkDecode(𝑝𝑘)
+        // Already done -- the pk struct is already decoded
+
+        // 2: (𝑐_tilde, 𝐳, 𝐡) ← sigDecode(𝜎)
+        //  ▷ signer’s commitment hash c_tilde, response 𝐳, and hint 𝐡
+        // 3: if 𝐡 = ⊥ then return false
+        let (c_tilde, z, h) =
+            sig_decode::<GAMMA1, k, l, LAMBDA_over_4, OMEGA, POLY_Z_PACKED_LEN, SIG_LEN>(&sig)
+                .map_err(|_| SignatureError::SignatureVerificationFailed)?;
+
+        // 13 (first half) return [[ ||𝐳||∞ < 𝛾1 − 𝛽]]
+        if z.check_norm::<GAMMA1_MINUS_BETA>() {
+            return Err(SignatureError::SignatureVerificationFailed);
+        }
+
+        // 5: 𝐀 ← ExpandA(𝜌)
+        //   ▷ 𝐀 is generated and stored in NTT representation as 𝐀
+        // We're doing an optimization where the user can pre-expand A_hat within the
+        // public key object for faster repeated encapsulations against this public key.
+
+        // 6: 𝑡𝑟 ← H(𝑝𝑘, 64)
+        // 7: 𝜇 ← (H(BytesToBits(𝑡𝑟)||𝑀 ′, 64))
+        //   ▷ message representative that may optionally be
+        //     computed in a different cryptographic module
+        // skip because this function is being handed mu
+
+        // 8: 𝑐 ∈ 𝑅𝑞 ← SampleInBall(c_tilde)
+        let c_hat = {
+            let mut c = sample_in_ball::<LAMBDA_over_4, TAU>(&c_tilde);
+            c.ntt();
+
+            c
+        };
+
+        // 9: 𝐰′_approx ← NTT−1(𝐀_hat ∘ NTT(𝐳) − NTT(𝑐) ∘ NTT(𝐭1 ⋅ 2^𝑑))
+        //   broken out for clarity:
+        //   NTT−1(
+        //      𝐀_hat ∘ NTT(𝐳) −
+        //                  NTT(𝑐) ∘ NTT(𝐭1 ⋅ 2^𝑑)
+        //   )
+        // ▷ 𝐰'_approx = 𝐀𝐳 − 𝑐𝐭1 ⋅ 2^𝑑
+        // weird nested scoping is to reduce peak stack memory usage
+        let w1p = {
+            let Az = {
+                let mut z_hat = z.clone();
+                z_hat.ntt();
+                A_hat.matrix_vector_ntt(&z_hat)
+            };
+            let ct1 = {
+                // potential optimization -- pre-compute this on key load?
+                let mut t1_shift_hat = pk.t1().shift_left::<d>();
+                t1_shift_hat.ntt();
+                t1_shift_hat.scalar_vector_ntt(&c_hat)
+            };
+            let mut wp_approx = Az.sub_vector(&ct1);
+            wp_approx.inv_ntt();
+            wp_approx.conditional_add_q();
+
+            // 10: 𝐰1′ ← UseHint(𝐡, 𝐰'_approx)
+            // ▷ reconstruction of signer’s commitment
+            use_hint_vecs::<k, GAMMA2>(&h, &wp_approx)
+        };
+        // 12: 𝑐_tilde_p ← H(𝜇||w1Encode(𝐰1'), 𝜆/4)
+        // ▷ hash it; this should match 𝑐_tilde
+        let c_tilde_p = {
+            let mut c_tilde_p = [0u8; LAMBDA_over_4];
+            let mut hash = H::new();
+            hash.absorb(mu);
+            w1p.w1_encode_and_hash::<POLY_W1_PACKED_LEN>(&mut hash);
+            hash.squeeze_out(&mut c_tilde_p);
+
+            c_tilde_p
+        };
+
+        // verification probably doesn't technically need to be constant-time, but why not?
+        // 13 (second half): return [[ ||𝐳||∞ < 𝛾1 − 𝛽]] and [[𝑐 ̃ = 𝑐′ ]]
+        if bouncycastle_utils::ct::ct_eq_bytes(&c_tilde, &c_tilde_p) {
+            Ok(())
+        } else {
+            Err(SignatureError::SignatureVerificationFailed)
+        }
+    }
 }
 
 impl<
@@ -1524,108 +1694,19 @@ impl<
         let sig: &[u8; SIG_LEN] = sig.try_into().map_err(|_| {
             SignatureError::LengthError("Signature value is not the correct length.")
         })?;
-        Self::verify_mu_internal(&pk.pk, &pk.A_hat(), &mu, sig)
-            .then_some(())
-            .ok_or(SignatureError::SignatureVerificationFailed)
+        Self::verify_mu(&pk.pk, Some(&pk.A_hat()), &mu, sig)
     }
 
-    /// Algorithm 8 ML-DSA.Verify_internal(𝑝𝑘, 𝑀′, 𝜎)
-    /// Internal function to verify a signature 𝜎 for a formatted message 𝑀′ .
-    /// Input: Public key 𝑝𝑘 ∈ 𝔹32+32𝑘(bitlen (𝑞−1)−𝑑) and message 𝑀′ ∈ {0, 1}∗ .
-    /// Input: Signature 𝜎 ∈ 𝔹𝜆/4+ℓ⋅32⋅(1+bitlen (𝛾1−1))+𝜔+𝑘.
-    fn verify_mu_internal(
+    fn verify_mu(
         pk: &PK,
-        A_hat: &Matrix<k, l>,
+        A_hat: Option<&Matrix<k, l>>,
         mu: &[u8; 64],
         sig: &[u8; SIG_LEN],
-    ) -> bool {
-        // 1: (𝜌, 𝐭1) ← pkDecode(𝑝𝑘)
-        // Already done -- the pk struct is already decoded
-
-        // 2: (𝑐_tilde, 𝐳, 𝐡) ← sigDecode(𝜎)
-        //  ▷ signer’s commitment hash c_tilde, response 𝐳, and hint 𝐡
-        // 3: if 𝐡 = ⊥ then return false
-        let (c_tilde, z, h) = match sig_decode::<
-            GAMMA1,
-            k,
-            l,
-            LAMBDA_over_4,
-            OMEGA,
-            POLY_Z_PACKED_LEN,
-            SIG_LEN,
-        >(&sig)
-        {
-            Ok((c_tilde, z, h)) => (c_tilde, z, h),
-            Err(_) => return false,
-        };
-
-        // 13 (first half) return [[ ||𝐳||∞ < 𝛾1 − 𝛽]]
-        if z.check_norm::<GAMMA1_MINUS_BETA>() {
-            return false;
+    ) -> Result<(), SignatureError> {
+        match A_hat {
+            Some(A_hat) => Self::verify_internal(pk, A_hat, mu, sig),
+            None => Self::verify_internal(pk, &pk.A_hat(), mu, sig),
         }
-
-        // 5: 𝐀 ← ExpandA(𝜌)
-        //   ▷ 𝐀 is generated and stored in NTT representation as 𝐀
-        // We're doing an optimization where the user can pre-expand A_hat within the
-        // public key object for faster repeated encapsulations against this public key.
-
-        // 6: 𝑡𝑟 ← H(𝑝𝑘, 64)
-        // 7: 𝜇 ← (H(BytesToBits(𝑡𝑟)||𝑀 ′, 64))
-        //   ▷ message representative that may optionally be
-        //     computed in a different cryptographic module
-        // skip because this function is being handed mu
-
-        // 8: 𝑐 ∈ 𝑅𝑞 ← SampleInBall(c_tilde)
-        let c_hat = {
-            let mut c = sample_in_ball::<LAMBDA_over_4, TAU>(&c_tilde);
-            c.ntt();
-
-            c
-        };
-
-        // 9: 𝐰′_approx ← NTT−1(𝐀_hat ∘ NTT(𝐳) − NTT(𝑐) ∘ NTT(𝐭1 ⋅ 2^𝑑))
-        //   broken out for clarity:
-        //   NTT−1(
-        //      𝐀_hat ∘ NTT(𝐳) −
-        //                  NTT(𝑐) ∘ NTT(𝐭1 ⋅ 2^𝑑)
-        //   )
-        // ▷ 𝐰'_approx = 𝐀𝐳 − 𝑐𝐭1 ⋅ 2^𝑑
-        // weird nested scoping is to reduce peak stack memory usage
-        let w1p = {
-            let Az = {
-                let mut z_hat = z.clone();
-                z_hat.ntt();
-                A_hat.matrix_vector_ntt(&z_hat)
-            };
-            let ct1 = {
-                // potential optimization -- pre-compute this on key load?
-                let mut t1_shift_hat = pk.t1().shift_left::<d>();
-                t1_shift_hat.ntt();
-                t1_shift_hat.scalar_vector_ntt(&c_hat)
-            };
-            let mut wp_approx = Az.sub_vector(&ct1);
-            wp_approx.inv_ntt();
-            wp_approx.conditional_add_q();
-
-            // 10: 𝐰1′ ← UseHint(𝐡, 𝐰'_approx)
-            // ▷ reconstruction of signer’s commitment
-            use_hint_vecs::<k, GAMMA2>(&h, &wp_approx)
-        };
-        // 12: 𝑐_tilde_p ← H(𝜇||w1Encode(𝐰1'), 𝜆/4)
-        // ▷ hash it; this should match 𝑐_tilde
-        let c_tilde_p = {
-            let mut c_tilde_p = [0u8; LAMBDA_over_4];
-            let mut hash = H::new();
-            hash.absorb(mu);
-            w1p.w1_encode_and_hash::<POLY_W1_PACKED_LEN>(&mut hash);
-            hash.squeeze_out(&mut c_tilde_p);
-
-            c_tilde_p
-        };
-
-        // verification probably doesn't technically need to be constant-time, but why not?
-        // 13 (second half): return [[ ||𝐳||∞ < 𝛾1 − 𝛽]] and [[𝑐 ̃ = 𝑐′ ]]
-        bouncycastle_utils::ct::ct_eq_bytes(&c_tilde, &c_tilde_p)
     }
 }
 
@@ -1750,6 +1831,8 @@ pub trait MLDSATrait<
     /// This implements FIPS 204 Algorithm 7 with line 6 removed; a modification that is allowed by both
     /// FIPS 204 itself, as well as subsequent FAQ documents.
     /// This mode uses randomized signing (called "hedged mode" in FIPS 204) using an internal RNG.
+    ///
+    /// Optionally, takes a pre-expanded public matrix `A_hat`.
     fn sign_mu(
         sk: &SK,
         A_hat: Option<&Matrix<k, l>>,
@@ -1874,16 +1957,16 @@ pub trait MLDSATrait<
         ctx: Option<&[u8]>,
         sig: &[u8],
     ) -> Result<(), SignatureError>;
-    /// Algorithm 8 ML-DSA.Verify_internal(𝑝𝑘, 𝑀′, 𝜎)
-    /// Internal function to verify a signature 𝜎 for a formatted message 𝑀′ .
-    /// Input: Public key 𝑝𝑘 ∈ 𝔹32+32𝑘(bitlen (𝑞−1)−𝑑) and message 𝑀′ ∈ {0, 1}∗ .
-    /// Input: Signature 𝜎 ∈ 𝔹𝜆/4+ℓ⋅32⋅(1+bitlen (𝛾1−1))+𝜔+𝑘.
-    fn verify_mu_internal(
+    /// Performs an ML-DSA signature verification using the provided external message representative `mu`.
+    /// This implements FIPS 204 Algorithm 8 with line 7 removed; a modification that is allowed by both
+    /// FIPS 204 itself, as well as subsequent FAQ documents.
+    /// Optionally, takes a pre-expanded public matrix `A_hat`.
+    fn verify_mu(
         pk: &PK,
-        A_hat: &Matrix<k, l>,
+        A_hat: Option<&Matrix<k, l>>,
         mu: &[u8; 64],
         sig: &[u8; SIG_LEN],
-    ) -> bool;
+    ) -> Result<(), SignatureError>;
 }
 
 impl<
@@ -2067,9 +2150,7 @@ impl<
         let sig: &[u8; SIG_LEN] = sig.try_into().map_err(|_| {
             SignatureError::LengthError("Signature value is not the correct length.")
         })?;
-        Self::verify_mu_internal(pk, &pk.A_hat(), &mu, sig)
-            .then_some(())
-            .ok_or(SignatureError::SignatureVerificationFailed)
+        Self::verify_mu(pk, Some(&pk.A_hat()), &mu, sig)
     }
 
     fn verify_init(pk: &PK, ctx: Option<&[u8]>) -> Result<Self, SignatureError> {
@@ -2097,9 +2178,7 @@ impl<
         let sig: &[u8; SIG_LEN] = sig.try_into().map_err(|_| {
             SignatureError::LengthError("Signature value is not the correct length.")
         })?;
-        Self::verify_mu_internal(pk, &pk.A_hat(), &mu, sig)
-            .then_some(())
-            .ok_or(SignatureError::SignatureVerificationFailed)
+        Self::verify_mu(pk, Some(&pk.A_hat()), &mu, sig)
     }
 }
 
@@ -2112,6 +2191,7 @@ impl<
 /// does not benefit from allowing external construction of the message representative mu.
 /// You can get the same behaviour by computing the pre-hash `ph` with the appropriate hash function
 /// and providing that to HashMLDSA via [PHSigner::sign_ph].
+#[derive(Clone)]
 pub struct MuBuilder {
     h: H,
 }
@@ -2175,5 +2255,27 @@ impl MuBuilder {
         self.h.squeeze_out(&mut mu);
 
         mu
+    }
+}
+
+/// The length, in bytes, of a serialized state of a [MuBuilder] object.
+pub const MU_BUILDER_SERIALIZED_STATE_LEN: usize = SHA3_SERIALIZED_STATE_LEN;
+
+/// If you are processing a large input message into ML-DSA and want to pause the operation
+/// -- maybe while waiting for slow network IO), you'll need to use [SerializableState].
+/// Serialization of the state of an in-progress ML-DSA instance is really just serialization
+/// of the construction of the message representative mu, since no other part of the ML-DSA algorithm
+/// has a pausable state.
+// A [MuBuilder]'s (and by virtue, an ML-DSA instance's) entire mutable state is its inner SHAKE256 sponge,
+// so serialization delegates directly to [SHAKE256]'s [SerializableState] impl.
+impl SerializableState<SHA3_SERIALIZED_STATE_LEN> for MuBuilder {
+    fn serialize_state(self) -> [u8; SHA3_SERIALIZED_STATE_LEN] {
+        self.h.serialize_state()
+    }
+
+    fn from_serialized_state(
+        serialized_state: [u8; SHA3_SERIALIZED_STATE_LEN],
+    ) -> Result<Self, SerializedStateError> {
+        Ok(MuBuilder { h: H::from_serialized_state(serialized_state)? })
     }
 }

--- a/crypto/mldsa/src/mldsa.rs
+++ b/crypto/mldsa/src/mldsa.rs
@@ -485,7 +485,7 @@ use crate::{
     MLDSA44PrivateKey, MLDSA44PublicKey, MLDSA65PrivateKey, MLDSA65PublicKey, MLDSA87PrivateKey,
     MLDSA87PublicKey, MLDSAPrivateKeyExpanded, MLDSAPublicKeyExpanded,
 };
-use bouncycastle_core::errors::{RNGError, SerializedStateError, SignatureError};
+use bouncycastle_core::errors::{RNGError, SignatureError, SuspendableError};
 use bouncycastle_core::key_material::{KeyMaterial, KeyMaterial256, KeyMaterialTrait, KeyType};
 use bouncycastle_core::traits::{
     Algorithm, RNG, SecurityStrength, SignatureVerifier, Signer, Suspendable, XOF,
@@ -2275,7 +2275,7 @@ impl Suspendable<SUSPENDED_SHA3_STATE_LEN> for MuBuilder {
 
     fn from_suspended(
         serialized_state: [u8; SUSPENDED_SHA3_STATE_LEN],
-    ) -> Result<Self, SerializedStateError> {
+    ) -> Result<Self, SuspendableError> {
         Ok(MuBuilder { h: H::from_suspended(serialized_state)? })
     }
 }

--- a/crypto/mldsa/tests/mldsa_tests.rs
+++ b/crypto/mldsa/tests/mldsa_tests.rs
@@ -7,12 +7,11 @@ mod mldsa_tests {
         KeyMaterial256, KeyMaterialTrait, KeyType, do_hazardous_operations,
     };
     use bouncycastle_core::traits::{
-        RNG, SecurityStrength, SerializableState, SignaturePrivateKey, SignaturePublicKey,
-        SignatureVerifier, Signer,
+        RNG, SecurityStrength, SignaturePrivateKey, SignaturePublicKey, SignatureVerifier, Signer,
+        Suspendable,
     };
     use bouncycastle_core_test_framework::DUMMY_SEED_1024;
     use bouncycastle_core_test_framework::FixedSeedRNG;
-    use bouncycastle_core_test_framework::serializable_state::TestFrameworkSerializableState;
     use bouncycastle_core_test_framework::signature::*;
     use bouncycastle_hex as hex;
     use bouncycastle_mldsa::{
@@ -981,9 +980,9 @@ mod mldsa_tests {
 
         // serializing and resuming after init
         let mb = MuBuilder::do_init(&pk_expanded.compute_tr(), None).unwrap();
-        let serialized_state = mb.serialize_state();
+        let serialized_state = mb.suspend();
 
-        let mut mb_resumed = MuBuilder::from_serialized_state(serialized_state).unwrap();
+        let mut mb_resumed = MuBuilder::from_suspended(serialized_state).unwrap();
         mb_resumed.do_update(msg);
         let mu_resumed = mb_resumed.do_final();
         assert_eq!(mu_resumed, mu1);
@@ -995,8 +994,8 @@ mod mldsa_tests {
         let mut mb = MuBuilder::do_init(&pk_expanded.compute_tr(), None).unwrap();
         mb.do_update(msg1);
 
-        let serialized_state = mb.serialize_state();
-        let mut mb_resumed = MuBuilder::from_serialized_state(serialized_state).unwrap();
+        let serialized_state = mb.suspend();
+        let mut mb_resumed = MuBuilder::from_suspended(serialized_state).unwrap();
         mb_resumed.do_update(msg2);
         let mu_resumed2 = mb_resumed.do_final();
         assert_eq!(mu_resumed2, mu1);
@@ -1025,7 +1024,9 @@ mod mldsa_tests {
     }
 
     #[test]
-    fn mubuilder_serializable_state() {
+    fn mubuilder_suspendable_state() {
+        use bouncycastle_core_test_framework::suspendable_state::TestFrameworkSuspendableState;
+
         // `tr` is the 64-byte public-key hash that seeds mu computation; its exact value doesn't
         // matter for exercising serialization, only that it is fixed across the comparison.
         let tr = [0x42u8; 64];
@@ -1037,16 +1038,16 @@ mod mldsa_tests {
 
         // Generic trait-conformance tests (version header present, [0,0,0] and future versions
         // rejected).
-        TestFrameworkSerializableState::new().test(&mb);
+        TestFrameworkSuspendableState::new().test(&mb);
 
         // Serialize the in-progress state, then finish the original.
-        let serialized_state = mb.clone().serialize_state();
+        let serialized_state = mb.clone().suspend();
         mb.do_update(&msg[10..]);
         let expected_mu = mb.do_final();
 
         // Rebuild from the serialized state, feed it the identical remaining input, and confirm it
         // produces the same mu.
-        let mut from_state = MuBuilder::from_serialized_state(serialized_state).unwrap();
+        let mut from_state = MuBuilder::from_suspended(serialized_state).unwrap();
         from_state.do_update(&msg[10..]);
         assert_eq!(expected_mu, from_state.do_final());
 
@@ -1059,7 +1060,7 @@ mod mldsa_tests {
         // + bits_in_queue(8) + squeezing(1) -> the squeezing byte is at offset 3 + 1 + 400.
         let mut busted = serialized_state;
         busted[3 + 1 + 400] = 42;
-        match MuBuilder::from_serialized_state(busted) {
+        match MuBuilder::from_suspended(busted) {
             Err(SerializedStateError::InvalidData) => { /* good */ }
             _ => panic!("Expected an error for a corrupt squeezing byte"),
         }
@@ -1076,9 +1077,9 @@ mod mldsa_tests {
         // tag 6).
         let mut shake128 = SHAKE128::new();
         shake128.absorb(b"Colorless green ideas sleep furiously");
-        let serialized_128 = shake128.serialize_state();
+        let serialized_128 = shake128.suspend();
 
-        match MuBuilder::from_serialized_state(serialized_128) {
+        match MuBuilder::from_suspended(serialized_128) {
             Err(SerializedStateError::InvalidData) => { /* good */ }
             _ => panic!("Expected an error when loading a SHAKE128 state into a MuBuilder"),
         }

--- a/crypto/mldsa/tests/mldsa_tests.rs
+++ b/crypto/mldsa/tests/mldsa_tests.rs
@@ -2,7 +2,7 @@
 #[cfg(test)]
 mod mldsa_tests {
     use crate::{MLDSA44_KAT1, MLDSA65_KAT1, MLDSA87_KAT1};
-    use bouncycastle_core::errors::{RNGError, SerializedStateError, SignatureError};
+    use bouncycastle_core::errors::{RNGError, SignatureError, SuspendableError};
     use bouncycastle_core::key_material::{
         KeyMaterial256, KeyMaterialTrait, KeyType, do_hazardous_operations,
     };
@@ -1061,7 +1061,7 @@ mod mldsa_tests {
         let mut busted = serialized_state;
         busted[3 + 1 + 400] = 42;
         match MuBuilder::from_suspended(busted) {
-            Err(SerializedStateError::InvalidData) => { /* good */ }
+            Err(SuspendableError::InvalidData) => { /* good */ }
             _ => panic!("Expected an error for a corrupt squeezing byte"),
         }
     }
@@ -1080,7 +1080,7 @@ mod mldsa_tests {
         let serialized_128 = shake128.suspend();
 
         match MuBuilder::from_suspended(serialized_128) {
-            Err(SerializedStateError::InvalidData) => { /* good */ }
+            Err(SuspendableError::InvalidData) => { /* good */ }
             _ => panic!("Expected an error when loading a SHAKE128 state into a MuBuilder"),
         }
     }

--- a/crypto/mldsa/tests/mldsa_tests.rs
+++ b/crypto/mldsa/tests/mldsa_tests.rs
@@ -2,15 +2,17 @@
 #[cfg(test)]
 mod mldsa_tests {
     use crate::{MLDSA44_KAT1, MLDSA65_KAT1, MLDSA87_KAT1};
-    use bouncycastle_core::errors::{RNGError, SignatureError};
+    use bouncycastle_core::errors::{RNGError, SerializedStateError, SignatureError};
     use bouncycastle_core::key_material::{
         KeyMaterial256, KeyMaterialTrait, KeyType, do_hazardous_operations,
     };
     use bouncycastle_core::traits::{
-        RNG, SecurityStrength, SignaturePrivateKey, SignaturePublicKey, SignatureVerifier, Signer,
+        RNG, SecurityStrength, SerializableState, SignaturePrivateKey, SignaturePublicKey,
+        SignatureVerifier, Signer,
     };
     use bouncycastle_core_test_framework::DUMMY_SEED_1024;
     use bouncycastle_core_test_framework::FixedSeedRNG;
+    use bouncycastle_core_test_framework::serializable_state::TestFrameworkSerializableState;
     use bouncycastle_core_test_framework::signature::*;
     use bouncycastle_hex as hex;
     use bouncycastle_mldsa::{
@@ -974,6 +976,30 @@ mod mldsa_tests {
         mb.do_update(b"jumped over the lazy dog");
         let mu6 = mb.do_final();
         assert_eq!(mu1, mu6);
+
+        // test SerializedState for MuBuilder
+
+        // serializing and resuming after init
+        let mb = MuBuilder::do_init(&pk_expanded.compute_tr(), None).unwrap();
+        let serialized_state = mb.serialize_state();
+
+        let mut mb_resumed = MuBuilder::from_serialized_state(serialized_state).unwrap();
+        mb_resumed.do_update(msg);
+        let mu_resumed = mb_resumed.do_final();
+        assert_eq!(mu_resumed, mu1);
+
+        // serializing and resuming partway through message consumption
+        let msg1 = b"The quick brown fox";
+        let msg2 = b" jumped over the lazy dog";
+
+        let mut mb = MuBuilder::do_init(&pk_expanded.compute_tr(), None).unwrap();
+        mb.do_update(msg1);
+
+        let serialized_state = mb.serialize_state();
+        let mut mb_resumed = MuBuilder::from_serialized_state(serialized_state).unwrap();
+        mb_resumed.do_update(msg2);
+        let mu_resumed2 = mb_resumed.do_final();
+        assert_eq!(mu_resumed2, mu1);
     }
 
     #[test]
@@ -996,6 +1022,66 @@ mod mldsa_tests {
 
         MLDSA44::sign_mu_deterministic_out(&sk, None, &mu, [1u8; 32], &mut sig_buf).unwrap();
         MLDSA44::verify(&pk, msg, None, &sig_buf).unwrap();
+    }
+
+    #[test]
+    fn mubuilder_serializable_state() {
+        // `tr` is the 64-byte public-key hash that seeds mu computation; its exact value doesn't
+        // matter for exercising serialization, only that it is fixed across the comparison.
+        let tr = [0x42u8; 64];
+        let msg = b"Colorless green ideas sleep furiously";
+
+        // Put the builder into a mid-stream state (some, but not all, of the message absorbed).
+        let mut mb = MuBuilder::do_init(&tr, None).unwrap();
+        mb.do_update(&msg[..10]);
+
+        // Generic trait-conformance tests (version header present, [0,0,0] and future versions
+        // rejected).
+        TestFrameworkSerializableState::new().test(&mb);
+
+        // Serialize the in-progress state, then finish the original.
+        let serialized_state = mb.clone().serialize_state();
+        mb.do_update(&msg[10..]);
+        let expected_mu = mb.do_final();
+
+        // Rebuild from the serialized state, feed it the identical remaining input, and confirm it
+        // produces the same mu.
+        let mut from_state = MuBuilder::from_serialized_state(serialized_state).unwrap();
+        from_state.do_update(&msg[10..]);
+        assert_eq!(expected_mu, from_state.do_final());
+
+        // Anchor correctness to the existing one-shot path: streaming must match compute_mu.
+        let one_shot = MuBuilder::compute_mu(&tr, msg, None).unwrap();
+        assert_eq!(expected_mu, one_shot);
+
+        // A corrupt SHAKE256 `squeezing` byte must be rejected. Layout of the delegated SHAKE256
+        // state: 3 version bytes + variant tag(1) + [u64;25](200) + data_queue(192)
+        // + bits_in_queue(8) + squeezing(1) -> the squeezing byte is at offset 3 + 1 + 400.
+        let mut busted = serialized_state;
+        busted[3 + 1 + 400] = 42;
+        match MuBuilder::from_serialized_state(busted) {
+            Err(SerializedStateError::InvalidData) => { /* good */ }
+            _ => panic!("Expected an error for a corrupt squeezing byte"),
+        }
+    }
+
+    #[test]
+    fn serializable_state_mubuilder_rejects_wrong_variant() {
+        use bouncycastle_core::traits::XOF;
+        use bouncycastle_sha3::SHAKE128;
+
+        // A MuBuilder is always backed by SHAKE256. A serialized SHAKE128 state has the same length
+        // (both are SHA3-family states), so this would deserialize into the wrong sponge if the
+        // variant tag weren't checked -- SHAKE128 (tag 5) must be rejected by MuBuilder (SHAKE256,
+        // tag 6).
+        let mut shake128 = SHAKE128::new();
+        shake128.absorb(b"Colorless green ideas sleep furiously");
+        let serialized_128 = shake128.serialize_state();
+
+        match MuBuilder::from_serialized_state(serialized_128) {
+            Err(SerializedStateError::InvalidData) => { /* good */ }
+            _ => panic!("Expected an error when loading a SHAKE128 state into a MuBuilder"),
+        }
     }
 }
 

--- a/crypto/mldsa/tests/wycheproof.rs
+++ b/crypto/mldsa/tests/wycheproof.rs
@@ -353,17 +353,17 @@ impl MLDSASignNoSeedTestCase {
         let sig = MLDSA44::sign_mu_deterministic(&sk, None, &mu, [0u8; 32]).unwrap();
         assert_eq!(sig, hex::decode(&self.sig).unwrap().as_slice());
 
-        let res = MLDSA44::verify_mu_internal(
+        let res = MLDSA44::verify_mu(
             &pk,
-            &pk.A_hat(),
+            Some(&pk.A_hat()),
             &mu,
             &hex::decode(&self.sig).unwrap().try_into().unwrap(),
         );
 
         if self.result == "valid" {
-            assert!(res);
+            res.unwrap()
         } else {
-            assert!(!res);
+            assert!(res.is_err());
         };
     }
 
@@ -421,17 +421,17 @@ impl MLDSASignNoSeedTestCase {
         let sig = MLDSA65::sign_mu_deterministic(&sk, None, &mu, [0u8; 32]).unwrap();
         assert_eq!(sig, hex::decode(&self.sig).unwrap().as_slice());
 
-        let res = MLDSA65::verify_mu_internal(
+        let res = MLDSA65::verify_mu(
             &pk,
-            &pk.A_hat(),
+            Some(&pk.A_hat()),
             &mu,
             &hex::decode(&self.sig).unwrap().try_into().unwrap(),
         );
 
         if self.result == "valid" {
-            assert!(res);
+            res.unwrap()
         } else {
-            assert!(!res);
+            assert!(res.is_err());
         };
     }
 
@@ -489,17 +489,17 @@ impl MLDSASignNoSeedTestCase {
         let sig = MLDSA87::sign_mu_deterministic(&sk, None, &mu, [0u8; 32]).unwrap();
         assert_eq!(sig, hex::decode(&self.sig).unwrap().as_slice());
 
-        let res = MLDSA87::verify_mu_internal(
+        let res = MLDSA87::verify_mu(
             &pk,
-            &pk.A_hat(),
+            Some(&pk.A_hat()),
             &mu,
             &hex::decode(&self.sig).unwrap().try_into().unwrap(),
         );
 
         if self.result == "valid" {
-            assert!(res);
+            res.unwrap();
         } else {
-            assert!(!res);
+            assert!(res.is_err());
         };
     }
 }
@@ -650,17 +650,17 @@ impl MLDSASignSeedTestCase {
         let sig = MLDSA44::sign_mu_deterministic(&sk, None, &mu, [0u8; 32]).unwrap();
         assert_eq!(sig, hex::decode(&self.sig).unwrap().as_slice());
 
-        let res = MLDSA44::verify_mu_internal(
+        let res = MLDSA44::verify_mu(
             &pk,
-            &pk.A_hat(),
+            Some(&pk.A_hat()),
             &mu,
             &hex::decode(&self.sig).unwrap().try_into().unwrap(),
         );
 
         if self.result == "valid" {
-            assert!(res);
+            res.unwrap();
         } else {
-            assert!(!res);
+            assert!(res.is_err());
         };
     }
 
@@ -742,17 +742,17 @@ impl MLDSASignSeedTestCase {
         let sig = MLDSA65::sign_mu_deterministic(&sk, None, &mu, [0u8; 32]).unwrap();
         assert_eq!(sig, hex::decode(&self.sig).unwrap().as_slice());
 
-        let res = MLDSA65::verify_mu_internal(
+        let res = MLDSA65::verify_mu(
             &pk,
-            &pk.A_hat(),
+            Some(&pk.A_hat()),
             &mu,
             &hex::decode(&self.sig).unwrap().try_into().unwrap(),
         );
 
         if self.result == "valid" {
-            assert!(res);
+            res.unwrap();
         } else {
-            assert!(!res);
+            assert!(res.is_err());
         };
     }
 
@@ -834,17 +834,17 @@ impl MLDSASignSeedTestCase {
         let sig = MLDSA87::sign_mu_deterministic(&sk, None, &mu, [0u8; 32]).unwrap();
         assert_eq!(sig, hex::decode(&self.sig).unwrap().as_slice());
 
-        let res = MLDSA87::verify_mu_internal(
+        let res = MLDSA87::verify_mu(
             &pk,
-            &pk.A_hat(),
+            Some(&pk.A_hat()),
             &mu,
             &hex::decode(&self.sig).unwrap().try_into().unwrap(),
         );
 
         if self.result == "valid" {
-            assert!(res);
+            res.unwrap();
         } else {
-            assert!(!res);
+            assert!(res.is_err());
         };
     }
 }

--- a/crypto/mldsa/tests/wycheproof.rs
+++ b/crypto/mldsa/tests/wycheproof.rs
@@ -237,6 +237,8 @@ struct MLDSASignNoSeedTestCase {
     // testGroup-level fields, copied onto every test case in the group
     private_key: String,
     public_key: String,
+    // test-level `rnd`: present only on hedged/randomized cases; absent = deterministic (all-zero).
+    rnd: Option<String>,
     // test-level fields
     tc_id: u32,
     comment: String,
@@ -253,6 +255,7 @@ impl MLDSASignNoSeedTestCase {
             parameter_set,
             private_key: String::new(),
             public_key: String::new(),
+            rnd: None,
             tc_id: 0,
             comment: String::new(),
             msg: None,
@@ -282,6 +285,7 @@ impl MLDSASignNoSeedTestCase {
                     parameter_set: parameter_set.clone(),
                     private_key: private_key.clone(),
                     public_key: public_key.clone(),
+                    rnd: test["rnd"].as_str().map(|s| s.to_string()),
                     tc_id: test["tcId"].as_u64().expect("tcId missing") as u32,
                     comment: test["comment"].as_str().unwrap_or("").to_string(),
                     msg: match test["msg"].as_str() {
@@ -350,7 +354,14 @@ impl MLDSASignNoSeedTestCase {
         assert_eq!(mu, hex::decode(&self.mu).unwrap().as_slice());
 
         // generate the signature using an all-zero signing nonce
-        let sig = MLDSA44::sign_mu_deterministic(&sk, None, &mu, [0u8; 32]).unwrap();
+        // Use the vector's `rnd` when present (hedged/randomized cases); deterministic vectors omit
+        // it and are signed with the all-zero nonce.
+        let rnd: [u8; 32] = self
+            .rnd
+            .as_ref()
+            .map(|r| hex::decode(r).unwrap().try_into().unwrap())
+            .unwrap_or([0u8; 32]);
+        let sig = MLDSA44::sign_mu_deterministic(&sk, None, &mu, rnd).unwrap();
         assert_eq!(sig, hex::decode(&self.sig).unwrap().as_slice());
 
         let res = MLDSA44::verify_mu(
@@ -418,7 +429,14 @@ impl MLDSASignNoSeedTestCase {
         assert_eq!(mu, hex::decode(&self.mu).unwrap().as_slice());
 
         // generate the signature using an all-zero signing nonce
-        let sig = MLDSA65::sign_mu_deterministic(&sk, None, &mu, [0u8; 32]).unwrap();
+        // Use the vector's `rnd` when present (hedged/randomized cases); deterministic vectors omit
+        // it and are signed with the all-zero nonce.
+        let rnd: [u8; 32] = self
+            .rnd
+            .as_ref()
+            .map(|r| hex::decode(r).unwrap().try_into().unwrap())
+            .unwrap_or([0u8; 32]);
+        let sig = MLDSA65::sign_mu_deterministic(&sk, None, &mu, rnd).unwrap();
         assert_eq!(sig, hex::decode(&self.sig).unwrap().as_slice());
 
         let res = MLDSA65::verify_mu(
@@ -486,7 +504,14 @@ impl MLDSASignNoSeedTestCase {
         assert_eq!(mu, hex::decode(&self.mu).unwrap().as_slice());
 
         // generate the signature using an all-zero signing nonce
-        let sig = MLDSA87::sign_mu_deterministic(&sk, None, &mu, [0u8; 32]).unwrap();
+        // Use the vector's `rnd` when present (hedged/randomized cases); deterministic vectors omit
+        // it and are signed with the all-zero nonce.
+        let rnd: [u8; 32] = self
+            .rnd
+            .as_ref()
+            .map(|r| hex::decode(r).unwrap().try_into().unwrap())
+            .unwrap_or([0u8; 32]);
+        let sig = MLDSA87::sign_mu_deterministic(&sk, None, &mu, rnd).unwrap();
         assert_eq!(sig, hex::decode(&self.sig).unwrap().as_slice());
 
         let res = MLDSA87::verify_mu(
@@ -510,6 +535,8 @@ struct MLDSASignSeedTestCase {
     // testGroup-level fields, copied onto every test case in the group
     private_seed: String,
     public_key: String,
+    // test-level `rnd`: present only on hedged/randomized cases; absent = deterministic (all-zero).
+    rnd: Option<String>,
     // test-level fields
     tc_id: u32,
     comment: String,
@@ -526,6 +553,7 @@ impl MLDSASignSeedTestCase {
             parameter_set,
             private_seed: String::new(),
             public_key: String::new(),
+            rnd: None,
             tc_id: 0,
             comment: String::new(),
             msg: None,
@@ -555,6 +583,7 @@ impl MLDSASignSeedTestCase {
                     parameter_set: parameter_set.clone(),
                     private_seed: private_seed.clone(),
                     public_key: public_key.clone(),
+                    rnd: test["rnd"].as_str().map(|s| s.to_string()),
                     tc_id: test["tcId"].as_u64().expect("tcId missing") as u32,
                     comment: test["comment"].as_str().unwrap_or("").to_string(),
                     msg: match test["msg"].as_str() {
@@ -647,7 +676,14 @@ impl MLDSASignSeedTestCase {
         assert_eq!(mu, hex::decode(&self.mu).unwrap().as_slice());
 
         // generate the signature using an all-zero signing nonce
-        let sig = MLDSA44::sign_mu_deterministic(&sk, None, &mu, [0u8; 32]).unwrap();
+        // Use the vector's `rnd` when present (hedged/randomized cases); deterministic vectors omit
+        // it and are signed with the all-zero nonce.
+        let rnd: [u8; 32] = self
+            .rnd
+            .as_ref()
+            .map(|r| hex::decode(r).unwrap().try_into().unwrap())
+            .unwrap_or([0u8; 32]);
+        let sig = MLDSA44::sign_mu_deterministic(&sk, None, &mu, rnd).unwrap();
         assert_eq!(sig, hex::decode(&self.sig).unwrap().as_slice());
 
         let res = MLDSA44::verify_mu(
@@ -739,7 +775,14 @@ impl MLDSASignSeedTestCase {
         assert_eq!(mu, hex::decode(&self.mu).unwrap().as_slice());
 
         // generate the signature using an all-zero signing nonce
-        let sig = MLDSA65::sign_mu_deterministic(&sk, None, &mu, [0u8; 32]).unwrap();
+        // Use the vector's `rnd` when present (hedged/randomized cases); deterministic vectors omit
+        // it and are signed with the all-zero nonce.
+        let rnd: [u8; 32] = self
+            .rnd
+            .as_ref()
+            .map(|r| hex::decode(r).unwrap().try_into().unwrap())
+            .unwrap_or([0u8; 32]);
+        let sig = MLDSA65::sign_mu_deterministic(&sk, None, &mu, rnd).unwrap();
         assert_eq!(sig, hex::decode(&self.sig).unwrap().as_slice());
 
         let res = MLDSA65::verify_mu(
@@ -831,7 +874,14 @@ impl MLDSASignSeedTestCase {
         assert_eq!(mu, hex::decode(&self.mu).unwrap().as_slice());
 
         // generate the signature using an all-zero signing nonce
-        let sig = MLDSA87::sign_mu_deterministic(&sk, None, &mu, [0u8; 32]).unwrap();
+        // Use the vector's `rnd` when present (hedged/randomized cases); deterministic vectors omit
+        // it and are signed with the all-zero nonce.
+        let rnd: [u8; 32] = self
+            .rnd
+            .as_ref()
+            .map(|r| hex::decode(r).unwrap().try_into().unwrap())
+            .unwrap_or([0u8; 32]);
+        let sig = MLDSA87::sign_mu_deterministic(&sk, None, &mu, rnd).unwrap();
         assert_eq!(sig, hex::decode(&self.sig).unwrap().as_slice());
 
         let res = MLDSA87::verify_mu(

--- a/crypto/sha2/Cargo.toml
+++ b/crypto/sha2/Cargo.toml
@@ -6,7 +6,6 @@ edition.workspace = true
 [dependencies]
 bouncycastle-core.workspace = true
 bouncycastle-utils.workspace = true
-serde = { version = "1.0.228", features = ["derive"] }
 
 [dev-dependencies]
 criterion.workspace = true

--- a/crypto/sha2/Cargo.toml
+++ b/crypto/sha2/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 [dependencies]
 bouncycastle-core.workspace = true
 bouncycastle-utils.workspace = true
+serde = { version = "1.0.228", features = ["derive"] }
 
 [dev-dependencies]
 criterion.workspace = true

--- a/crypto/sha2/src/lib.rs
+++ b/crypto/sha2/src/lib.rs
@@ -18,8 +18,8 @@
 //! for example if input is received in chunks and not all available at the same time:
 //!
 //! ```
-//! use bouncycastle_core::traits::Hash;
 //! use bouncycastle_sha2 as sha2;
+//! use bouncycastle_core::traits::Hash;
 //!
 //! let data: &[u8] = b"\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0A\x0B\x0C\x0D\x0E\x0F
 //!                     \x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1A\x1B\x1C\x1D\x1E\x1F
@@ -32,6 +32,36 @@
 //! }
 //!
 //! let output: Vec<u8> = sha2.do_final();
+//! ```
+//!
+//! # Suspending and resuming execution via SerializableState
+//!
+//! When hashing a large message, it can be advantageous to be able to suspend the operation
+//! to a cache and resume it later; for example if waiting for the message to stream over a slow network
+//! connection.
+//!
+//! For this reason, all SHA2 algorithms impl [SerializableState].
+//!
+//! ```rust
+//! use bouncycastle_sha2 as sha2;
+//! use bouncycastle_core::traits::{Hash, SerializableState};
+//!
+//! let msg_part1 = b"The quick brown fox";
+//! let msg_part2 = b" jumped over the lazy dog";
+//!
+//! let mut sha2 = sha2::SHA256::new();
+//! sha2.do_update(msg_part1);
+//!
+//! // here, we'll suspend while "waiting" for the second part of the message
+//! let serialized_state = sha2.serialize_state();
+//!
+//! // ...
+//! // do other things in the meantime
+//! // ...
+//!
+//! let mut sha2_resumed = sha2::SHA256::from_serialized_state(serialized_state).unwrap();
+//! sha2_resumed.do_update(msg_part2);
+//! let h: Vec<u8> = sha2_resumed.do_final();
 //! ```
 
 #![forbid(unsafe_code)]
@@ -68,6 +98,7 @@ impl HashAlgParams for SHA224 {
     const OUTPUT_LEN: usize = 28;
     const BLOCK_LEN: usize = 64;
 }
+#[derive(Clone)]
 pub struct SHA224Params;
 impl Algorithm for SHA224Params {
     const ALG_NAME: &'static str = SHA224_NAME;
@@ -87,6 +118,7 @@ impl HashAlgParams for SHA256 {
     const OUTPUT_LEN: usize = 32;
     const BLOCK_LEN: usize = 64;
 }
+#[derive(Clone)]
 pub struct SHA256Params;
 impl Algorithm for SHA256Params {
     const ALG_NAME: &'static str = SHA256_NAME;
@@ -106,6 +138,7 @@ impl HashAlgParams for SHA384 {
     const OUTPUT_LEN: usize = 48;
     const BLOCK_LEN: usize = 128;
 }
+#[derive(Clone)]
 pub struct SHA384Params;
 impl Algorithm for SHA384Params {
     const ALG_NAME: &'static str = SHA384_NAME;
@@ -117,6 +150,7 @@ impl HashAlgParams for SHA384Params {
 }
 impl SHA2Params for SHA384Params {}
 
+#[derive(Clone)]
 pub struct SHA512Params;
 impl Algorithm for SHA512 {
     const ALG_NAME: &'static str = SHA512_NAME;
@@ -135,3 +169,6 @@ impl HashAlgParams for SHA512Params {
     const BLOCK_LEN: usize = 128;
 }
 impl SHA2Params for SHA512Params {}
+
+pub use sha256::SHA256_SERIALIZED_STATE_LEN;
+pub use sha512::SHA512_SERIALIZED_STATE_LEN;

--- a/crypto/sha2/src/lib.rs
+++ b/crypto/sha2/src/lib.rs
@@ -34,17 +34,17 @@
 //! let output: Vec<u8> = sha2.do_final();
 //! ```
 //!
-//! # Suspending and resuming execution via SerializableState
+//! # Suspending and resuming execution
 //!
 //! When hashing a large message, it can be advantageous to be able to suspend the operation
 //! to a cache and resume it later; for example if waiting for the message to stream over a slow network
 //! connection.
 //!
-//! For this reason, all SHA2 algorithms impl [SerializableState].
+//! For this reason, all SHA2 algorithms impl [Suspendable].
 //!
 //! ```rust
 //! use bouncycastle_sha2 as sha2;
-//! use bouncycastle_core::traits::{Hash, SerializableState};
+//! use bouncycastle_core::traits::{Hash, Suspendable};
 //!
 //! let msg_part1 = b"The quick brown fox";
 //! let msg_part2 = b" jumped over the lazy dog";
@@ -52,14 +52,15 @@
 //! let mut sha2 = sha2::SHA256::new();
 //! sha2.do_update(msg_part1);
 //!
-//! // here, we'll suspend while "waiting" for the second part of the message
-//! let serialized_state = sha2.serialize_state();
+//! // suspend the in-progress extract while "waiting" for the second part of the message.
+//! let serialized_state = sha2.suspend();
 //!
 //! // ...
 //! // do other things in the meantime
 //! // ...
 //!
-//! let mut sha2_resumed = sha2::SHA256::from_serialized_state(serialized_state).unwrap();
+//! // ... later, possibly on another host: resume from the serialized state.
+//! let mut sha2_resumed = sha2::SHA256::from_suspended(serialized_state).unwrap();
 //! sha2_resumed.do_update(msg_part2);
 //! let h: Vec<u8> = sha2_resumed.do_final();
 //! ```
@@ -73,6 +74,10 @@ mod sha512;
 pub use self::sha256::SHA256Internal;
 pub use self::sha512::SHA512Internal;
 use bouncycastle_core::traits::{Algorithm, HashAlgParams, SecurityStrength};
+
+/*** Imports needed for docs ***/
+#[allow(unused_imports)]
+use bouncycastle_core::traits::Suspendable;
 
 /*** String constants ***/
 pub const SHA224_NAME: &str = "SHA224";
@@ -170,5 +175,5 @@ impl HashAlgParams for SHA512Params {
 }
 impl SHA2Params for SHA512Params {}
 
-pub use sha256::SHA256_SERIALIZED_STATE_LEN;
-pub use sha512::SHA512_SERIALIZED_STATE_LEN;
+pub use sha256::SUSPENDED_SHA256_STATE_LEN;
+pub use sha512::SUSPENDED_SHA512_STATE_LEN;

--- a/crypto/sha2/src/lib.rs
+++ b/crypto/sha2/src/lib.rs
@@ -95,10 +95,6 @@ pub type SHA512 = SHA512Internal<SHA512Params>;
 
 trait SHA2Params: HashAlgParams {}
 
-impl Algorithm for SHA224 {
-    const ALG_NAME: &'static str = SHA224_NAME;
-    const MAX_SECURITY_STRENGTH: SecurityStrength = SecurityStrength::_112bit;
-}
 impl HashAlgParams for SHA224 {
     const OUTPUT_LEN: usize = 28;
     const BLOCK_LEN: usize = 64;
@@ -115,10 +111,6 @@ impl HashAlgParams for SHA224Params {
 }
 impl SHA2Params for SHA224Params {}
 
-impl Algorithm for SHA256 {
-    const ALG_NAME: &'static str = SHA256_NAME;
-    const MAX_SECURITY_STRENGTH: SecurityStrength = SecurityStrength::_128bit;
-}
 impl HashAlgParams for SHA256 {
     const OUTPUT_LEN: usize = 32;
     const BLOCK_LEN: usize = 64;
@@ -135,10 +127,6 @@ impl HashAlgParams for SHA256Params {
 }
 impl SHA2Params for SHA256Params {}
 
-impl Algorithm for SHA384 {
-    const ALG_NAME: &'static str = SHA384_NAME;
-    const MAX_SECURITY_STRENGTH: SecurityStrength = SecurityStrength::_192bit;
-}
 impl HashAlgParams for SHA384 {
     const OUTPUT_LEN: usize = 48;
     const BLOCK_LEN: usize = 128;
@@ -157,10 +145,6 @@ impl SHA2Params for SHA384Params {}
 
 #[derive(Clone)]
 pub struct SHA512Params;
-impl Algorithm for SHA512 {
-    const ALG_NAME: &'static str = SHA512_NAME;
-    const MAX_SECURITY_STRENGTH: SecurityStrength = SecurityStrength::_256bit;
-}
 impl HashAlgParams for SHA512 {
     const OUTPUT_LEN: usize = 64;
     const BLOCK_LEN: usize = 128;

--- a/crypto/sha2/src/lib.rs
+++ b/crypto/sha2/src/lib.rs
@@ -41,7 +41,7 @@ mod sha256;
 mod sha512;
 
 pub use self::sha256::SHA256Internal;
-pub use self::sha512::Sha512Internal;
+pub use self::sha512::SHA512Internal;
 use bouncycastle_core::traits::{Algorithm, HashAlgParams, SecurityStrength};
 
 /*** String constants ***/
@@ -53,8 +53,8 @@ pub const SHA512_NAME: &str = "SHA512";
 /*** pub types ***/
 pub type SHA224 = SHA256Internal<SHA224Params>;
 pub type SHA256 = SHA256Internal<SHA256Params>;
-pub type SHA384 = Sha512Internal<SHA384Params>;
-pub type SHA512 = Sha512Internal<SHA512Params>;
+pub type SHA384 = SHA512Internal<SHA384Params>;
+pub type SHA512 = SHA512Internal<SHA512Params>;
 
 /*** Param traits ***/
 

--- a/crypto/sha2/src/sha256.rs
+++ b/crypto/sha2/src/sha256.rs
@@ -1,6 +1,7 @@
 use crate::SHA2Params;
-use bouncycastle_core::errors::HashError;
-use bouncycastle_core::traits::{Hash, SecurityStrength};
+use bouncycastle_core::errors::{CoreError, HashError};
+use bouncycastle_core::serializable_state::{add_lib_ver, check_lib_ver};
+use bouncycastle_core::traits::{Hash, SecurityStrength, SerializableState};
 use bouncycastle_utils::min;
 use core::slice;
 
@@ -45,11 +46,9 @@ fn theta1(x: u32) -> u32 {
     x.rotate_right(17) ^ x.rotate_right(19) ^ (x >> 10)
 }
 
-// todo -- cleanup
-// #[derive(Clone, Copy)]
 #[derive(Clone)]
 pub(crate) struct Sha256State<PARAMS: SHA2Params> {
-    _params: std::marker::PhantomData<PARAMS>,
+    _params: core::marker::PhantomData<PARAMS>,
     h: [u32; 8],
 }
 
@@ -63,7 +62,7 @@ impl<PARAMS: SHA2Params> Sha256State<PARAMS> {
     pub(crate) fn new() -> Self {
         match PARAMS::OUTPUT_LEN * 8 {
             224 => Self {
-                _params: std::marker::PhantomData,
+                _params: core::marker::PhantomData,
                 h: [
                     0xC1059ED8, 0x367CD507, 0x3070DD17, 0xF70E5939, 0xFFC00B31, 0x68581511,
                     0x64F98FA7, 0xBEFA4FA4,
@@ -145,11 +144,9 @@ impl<PARAMS: SHA2Params> Sha256State<PARAMS> {
     }
 }
 
-// todo -- cleanup
-// #[derive(Clone, Copy)]
 #[derive(Clone)]
 pub struct SHA256Internal<PARAMS: SHA2Params> {
-    _params: std::marker::PhantomData<PARAMS>,
+    _params: core::marker::PhantomData<PARAMS>,
     state: Sha256State<PARAMS>,
     byte_count: u64,
     x_buf: [u8; 64],
@@ -166,7 +163,7 @@ impl<PARAMS: SHA2Params> Drop for SHA256Internal<PARAMS> {
 impl<PARAMS: SHA2Params> SHA256Internal<PARAMS> {
     pub fn new() -> Self {
         Self {
-            _params: std::marker::PhantomData,
+            _params: core::marker::PhantomData,
             state: Sha256State::<PARAMS>::new(),
             byte_count: 0,
             x_buf: [0; 64],
@@ -304,5 +301,69 @@ impl<PARAMS: SHA2Params> Hash for SHA256Internal<PARAMS> {
 
     fn max_security_strength(&self) -> SecurityStrength {
         SecurityStrength::from_bytes(PARAMS::OUTPUT_LEN / 2)
+    }
+}
+
+impl<PARAMS: SHA2Params> SerializableState<108> for SHA256Internal<PARAMS> {
+    fn serialize_state(&self) -> [u8; 108] {
+        let mut out_to_return = [0u8; 108];
+
+        // insert the version tag
+        let out: &mut [u8; 105] = add_lib_ver(&mut out_to_return).try_into().unwrap();
+
+        // state.h: [u32; 8]
+        // 4 * 8 = 32
+        for i in 0..8 {
+            out[i * 4..(i * 4) + 4].copy_from_slice(&self.state.h[i].to_le_bytes());
+        }
+
+        // byte_count: u64
+        out[32..40].copy_from_slice(&self.byte_count.to_le_bytes());
+
+        // x_buf: [u8; 64]
+        out[40..104].copy_from_slice(&self.x_buf);
+
+        // x_buf_off: usize
+        // in general, a usize should be serialized into a u64, but in this case, it can't ever be larger than 64
+        debug_assert!(self.x_buf_off < 64);
+        out[104] = self.x_buf_off as u8;
+
+        out_to_return
+    }
+
+    fn from_serialized_state(serialized_state: [u8; 108]) -> Result<Self, CoreError> {
+        // check the version tag
+        // At the moment, we have no not_before version to specify.
+        let input: &[u8; 105] = check_lib_ver(&serialized_state, None)?.try_into().unwrap();
+
+        // state.h: [u32; 8]
+        // 4 * 8 = 32
+        let mut h = [0u32; 8];
+        for i in 0..8 {
+            h[i] = u32::from_le_bytes(input[i * 4..(i * 4) + 4].try_into().unwrap());
+        }
+
+        // byte_count: u64
+        let byte_count: u64 = u64::from_le_bytes(input[32..40].try_into().unwrap());
+
+        // x_buf: [u8; 64]
+        let x_buf: [u8; 64] = input[40..104].try_into().unwrap();
+
+        // x_buf_off: usize
+        // in general, a usize should be serialized into a u64, but in this case, it can't ever be larger than 64
+        let x_buf_off: usize = input[104] as usize;
+        if x_buf_off >= 64 {
+            return Err(CoreError::InvalidData);
+        }
+
+        // Construct the object
+        let state = Sha256State { _params: core::marker::PhantomData, h };
+        Ok(SHA256Internal {
+            _params: core::marker::PhantomData,
+            state,
+            byte_count,
+            x_buf,
+            x_buf_off,
+        })
     }
 }

--- a/crypto/sha2/src/sha256.rs
+++ b/crypto/sha2/src/sha256.rs
@@ -1,7 +1,7 @@
 use crate::SHA2Params;
-use bouncycastle_core::errors::{HashError, SerializedStateError};
+use bouncycastle_core::errors::{HashError, SuspendableError};
 use bouncycastle_core::serializable_state::{add_lib_ver, check_lib_ver};
-use bouncycastle_core::traits::{Hash, SecurityStrength, Suspendable};
+use bouncycastle_core::traits::{Algorithm, Hash, SecurityStrength, Suspendable};
 use bouncycastle_utils::min;
 use core::slice;
 
@@ -178,6 +178,11 @@ impl<PARAMS: SHA2Params> Default for SHA256Internal<PARAMS> {
     }
 }
 
+impl<PARAMS: SHA2Params> Algorithm for SHA256Internal<PARAMS> {
+    const ALG_NAME: &'static str = PARAMS::ALG_NAME;
+    const MAX_SECURITY_STRENGTH: SecurityStrength = PARAMS::MAX_SECURITY_STRENGTH;
+}
+
 impl<PARAMS: SHA2Params> Hash for SHA256Internal<PARAMS> {
     /// As per FIPS 180-4 Figure 1
     fn block_bitlen(&self) -> usize {
@@ -338,7 +343,7 @@ impl<PARAMS: SHA2Params> Suspendable<SUSPENDED_SHA256_STATE_LEN> for SHA256Inter
 
     fn from_suspended(
         serialized_state: [u8; SUSPENDED_SHA256_STATE_LEN],
-    ) -> Result<Self, SerializedStateError> {
+    ) -> Result<Self, SuspendableError> {
         debug_assert_eq!(SUSPENDED_SHA256_STATE_LEN, 108);
 
         // check the version tag
@@ -362,7 +367,7 @@ impl<PARAMS: SHA2Params> Suspendable<SUSPENDED_SHA256_STATE_LEN> for SHA256Inter
         // in general, a usize should be serialized into a u64, but in this case, it can't ever be larger than 64
         let x_buf_off: usize = input[104] as usize;
         if x_buf_off >= 64 {
-            return Err(SerializedStateError::InvalidData);
+            return Err(SuspendableError::InvalidData);
         }
 
         // Construct the object

--- a/crypto/sha2/src/sha256.rs
+++ b/crypto/sha2/src/sha256.rs
@@ -1,7 +1,7 @@
 use crate::SHA2Params;
 use bouncycastle_core::errors::{HashError, SerializedStateError};
 use bouncycastle_core::serializable_state::{add_lib_ver, check_lib_ver};
-use bouncycastle_core::traits::{Hash, SecurityStrength, SerializableState};
+use bouncycastle_core::traits::{Hash, SecurityStrength, Suspendable};
 use bouncycastle_utils::min;
 use core::slice;
 
@@ -304,15 +304,14 @@ impl<PARAMS: SHA2Params> Hash for SHA256Internal<PARAMS> {
     }
 }
 
-/// The number of bytes produced by [SerializableState::serialize_state] for any SHA224 or SHA256
-/// object.
-pub const SHA256_SERIALIZED_STATE_LEN: usize = 108;
+/// Length in bytes of the serialized state of SHA224 and SHA256.
+pub const SUSPENDED_SHA256_STATE_LEN: usize = 108;
 
-impl<PARAMS: SHA2Params> SerializableState<SHA256_SERIALIZED_STATE_LEN> for SHA256Internal<PARAMS> {
-    fn serialize_state(self) -> [u8; SHA256_SERIALIZED_STATE_LEN] {
-        debug_assert_eq!(SHA256_SERIALIZED_STATE_LEN, 108);
+impl<PARAMS: SHA2Params> Suspendable<SUSPENDED_SHA256_STATE_LEN> for SHA256Internal<PARAMS> {
+    fn suspend(self) -> [u8; SUSPENDED_SHA256_STATE_LEN] {
+        debug_assert_eq!(SUSPENDED_SHA256_STATE_LEN, 108);
 
-        let mut out_to_return = [0u8; SHA256_SERIALIZED_STATE_LEN];
+        let mut out_to_return = [0u8; SUSPENDED_SHA256_STATE_LEN];
 
         // insert the version tag
         let out: &mut [u8; 105] = add_lib_ver(&mut out_to_return).try_into().unwrap();
@@ -337,10 +336,10 @@ impl<PARAMS: SHA2Params> SerializableState<SHA256_SERIALIZED_STATE_LEN> for SHA2
         out_to_return
     }
 
-    fn from_serialized_state(
-        serialized_state: [u8; SHA256_SERIALIZED_STATE_LEN],
+    fn from_suspended(
+        serialized_state: [u8; SUSPENDED_SHA256_STATE_LEN],
     ) -> Result<Self, SerializedStateError> {
-        debug_assert_eq!(SHA256_SERIALIZED_STATE_LEN, 108);
+        debug_assert_eq!(SUSPENDED_SHA256_STATE_LEN, 108);
 
         // check the version tag
         // At the moment, we have no not_before version to specify.

--- a/crypto/sha2/src/sha256.rs
+++ b/crypto/sha2/src/sha256.rs
@@ -1,5 +1,5 @@
 use crate::SHA2Params;
-use bouncycastle_core::errors::{CoreError, HashError};
+use bouncycastle_core::errors::{HashError, SerializedStateError};
 use bouncycastle_core::serializable_state::{add_lib_ver, check_lib_ver};
 use bouncycastle_core::traits::{Hash, SecurityStrength, SerializableState};
 use bouncycastle_utils::min;
@@ -304,9 +304,15 @@ impl<PARAMS: SHA2Params> Hash for SHA256Internal<PARAMS> {
     }
 }
 
-impl<PARAMS: SHA2Params> SerializableState<108> for SHA256Internal<PARAMS> {
-    fn serialize_state(&self) -> [u8; 108] {
-        let mut out_to_return = [0u8; 108];
+/// The number of bytes produced by [SerializableState::serialize_state] for any SHA224 or SHA256
+/// object.
+pub const SHA256_SERIALIZED_STATE_LEN: usize = 108;
+
+impl<PARAMS: SHA2Params> SerializableState<SHA256_SERIALIZED_STATE_LEN> for SHA256Internal<PARAMS> {
+    fn serialize_state(self) -> [u8; SHA256_SERIALIZED_STATE_LEN] {
+        debug_assert_eq!(SHA256_SERIALIZED_STATE_LEN, 108);
+
+        let mut out_to_return = [0u8; SHA256_SERIALIZED_STATE_LEN];
 
         // insert the version tag
         let out: &mut [u8; 105] = add_lib_ver(&mut out_to_return).try_into().unwrap();
@@ -331,7 +337,11 @@ impl<PARAMS: SHA2Params> SerializableState<108> for SHA256Internal<PARAMS> {
         out_to_return
     }
 
-    fn from_serialized_state(serialized_state: [u8; 108]) -> Result<Self, CoreError> {
+    fn from_serialized_state(
+        serialized_state: [u8; SHA256_SERIALIZED_STATE_LEN],
+    ) -> Result<Self, SerializedStateError> {
+        debug_assert_eq!(SHA256_SERIALIZED_STATE_LEN, 108);
+
         // check the version tag
         // At the moment, we have no not_before version to specify.
         let input: &[u8; 105] = check_lib_ver(&serialized_state, None)?.try_into().unwrap();
@@ -353,7 +363,7 @@ impl<PARAMS: SHA2Params> SerializableState<108> for SHA256Internal<PARAMS> {
         // in general, a usize should be serialized into a u64, but in this case, it can't ever be larger than 64
         let x_buf_off: usize = input[104] as usize;
         if x_buf_off >= 64 {
-            return Err(CoreError::InvalidData);
+            return Err(SerializedStateError::InvalidData);
         }
 
         // Construct the object

--- a/crypto/sha2/src/sha256.rs
+++ b/crypto/sha2/src/sha256.rs
@@ -1,6 +1,6 @@
 use crate::SHA2Params;
 use bouncycastle_core::errors::{HashError, SuspendableError};
-use bouncycastle_core::serializable_state::{add_lib_ver, check_lib_ver};
+use bouncycastle_core::suspendable_state::{add_lib_ver, check_lib_ver};
 use bouncycastle_core::traits::{Algorithm, Hash, SecurityStrength, Suspendable};
 use bouncycastle_utils::min;
 use core::slice;

--- a/crypto/sha2/src/sha256.rs
+++ b/crypto/sha2/src/sha256.rs
@@ -319,6 +319,7 @@ impl<PARAMS: SHA2Params> Suspendable<SUSPENDED_SHA256_STATE_LEN> for SHA256Inter
         let mut out_to_return = [0u8; SUSPENDED_SHA256_STATE_LEN];
 
         // insert the version tag
+        // infallible: add_lib_ver returns a slice of exactly SUSPENDED_SHA256_STATE_LEN - 3 = 105 bytes.
         let out: &mut [u8; 105] = add_lib_ver(&mut out_to_return).try_into().unwrap();
 
         // state.h: [u32; 8]
@@ -348,6 +349,7 @@ impl<PARAMS: SHA2Params> Suspendable<SUSPENDED_SHA256_STATE_LEN> for SHA256Inter
 
         // check the version tag
         // At the moment, we have no not_before version to specify.
+        // infallible: check_lib_ver returns a slice of exactly SUSPENDED_SHA256_STATE_LEN - 3 = 105 bytes.
         let input: &[u8; 105] = check_lib_ver(&serialized_state, None)?.try_into().unwrap();
 
         // state.h: [u32; 8]

--- a/crypto/sha2/src/sha512.rs
+++ b/crypto/sha2/src/sha512.rs
@@ -1,7 +1,7 @@
 use crate::SHA2Params;
-use bouncycastle_core::errors::{HashError, SerializedStateError};
+use bouncycastle_core::errors::{HashError, SuspendableError};
 use bouncycastle_core::serializable_state::{add_lib_ver, check_lib_ver};
-use bouncycastle_core::traits::{Hash, SecurityStrength, Suspendable};
+use bouncycastle_core::traits::{Algorithm, Hash, SecurityStrength, Suspendable};
 use bouncycastle_utils::min;
 use core::slice;
 
@@ -193,6 +193,11 @@ impl<PARAMS: SHA2Params> Default for SHA512Internal<PARAMS> {
     }
 }
 
+impl<PARAMS: SHA2Params> Algorithm for SHA512Internal<PARAMS> {
+    const ALG_NAME: &'static str = PARAMS::ALG_NAME;
+    const MAX_SECURITY_STRENGTH: SecurityStrength = PARAMS::MAX_SECURITY_STRENGTH;
+}
+
 impl<PARAMS: SHA2Params> Hash for SHA512Internal<PARAMS> {
     /// As per FIPS 180-4 Figure 1
     fn block_bitlen(&self) -> usize {
@@ -353,7 +358,7 @@ impl<PARAMS: SHA2Params> Suspendable<SUSPENDED_SHA512_STATE_LEN> for SHA512Inter
 
     fn from_suspended(
         serialized_state: [u8; SUSPENDED_SHA512_STATE_LEN],
-    ) -> Result<Self, SerializedStateError> {
+    ) -> Result<Self, SuspendableError> {
         // check the version tag
         // At the moment, we have no not_before version to specify.
         let input: &[u8; 201] = check_lib_ver(&serialized_state, None)?.try_into().unwrap();
@@ -375,7 +380,7 @@ impl<PARAMS: SHA2Params> Suspendable<SUSPENDED_SHA512_STATE_LEN> for SHA512Inter
         // in general, a usize should be serialized into a u64, but in this case, it can't ever be larger than 128
         let x_buf_off: usize = input[200] as usize;
         if x_buf_off >= 128 {
-            return Err(SerializedStateError::InvalidData);
+            return Err(SuspendableError::InvalidData);
         }
 
         // Construct the object

--- a/crypto/sha2/src/sha512.rs
+++ b/crypto/sha2/src/sha512.rs
@@ -1,4 +1,4 @@
-use crate::{SHA2Params};
+use crate::SHA2Params;
 use bouncycastle_core::errors::{CoreError, HashError};
 use bouncycastle_core::serializable_state::{add_lib_ver, check_lib_ver};
 use bouncycastle_core::traits::{Hash, SecurityStrength, SerializableState};

--- a/crypto/sha2/src/sha512.rs
+++ b/crypto/sha2/src/sha512.rs
@@ -1,5 +1,5 @@
 use crate::SHA2Params;
-use bouncycastle_core::errors::{CoreError, HashError};
+use bouncycastle_core::errors::{HashError, SerializedStateError};
 use bouncycastle_core::serializable_state::{add_lib_ver, check_lib_ver};
 use bouncycastle_core::traits::{Hash, SecurityStrength, SerializableState};
 use bouncycastle_utils::min;
@@ -319,9 +319,15 @@ impl<PARAMS: SHA2Params> Hash for SHA512Internal<PARAMS> {
     }
 }
 
-impl<PARAMS: SHA2Params> SerializableState<204> for SHA512Internal<PARAMS> {
-    fn serialize_state(&self) -> [u8; 204] {
-        let mut out_to_return = [0u8; 204];
+/// The number of bytes produced by [SerializableState::serialize_state] for any SHA384 or SHA512
+/// object.
+pub const SHA512_SERIALIZED_STATE_LEN: usize = 204;
+
+impl<PARAMS: SHA2Params> SerializableState<SHA512_SERIALIZED_STATE_LEN> for SHA512Internal<PARAMS> {
+    fn serialize_state(self) -> [u8; SHA512_SERIALIZED_STATE_LEN] {
+        debug_assert_eq!(SHA512_SERIALIZED_STATE_LEN, 204);
+
+        let mut out_to_return = [0u8; SHA512_SERIALIZED_STATE_LEN];
 
         // insert the version tag
         let out: &mut [u8; 201] = add_lib_ver(&mut out_to_return).try_into().unwrap();
@@ -346,7 +352,9 @@ impl<PARAMS: SHA2Params> SerializableState<204> for SHA512Internal<PARAMS> {
         out_to_return
     }
 
-    fn from_serialized_state(serialized_state: [u8; 204]) -> Result<Self, CoreError> {
+    fn from_serialized_state(
+        serialized_state: [u8; SHA512_SERIALIZED_STATE_LEN],
+    ) -> Result<Self, SerializedStateError> {
         // check the version tag
         // At the moment, we have no not_before version to specify.
         let input: &[u8; 201] = check_lib_ver(&serialized_state, None)?.try_into().unwrap();
@@ -368,7 +376,7 @@ impl<PARAMS: SHA2Params> SerializableState<204> for SHA512Internal<PARAMS> {
         // in general, a usize should be serialized into a u64, but in this case, it can't ever be larger than 128
         let x_buf_off: usize = input[200] as usize;
         if x_buf_off >= 128 {
-            return Err(CoreError::InvalidData);
+            return Err(SerializedStateError::InvalidData);
         }
 
         // Construct the object

--- a/crypto/sha2/src/sha512.rs
+++ b/crypto/sha2/src/sha512.rs
@@ -1,6 +1,7 @@
-use crate::SHA2Params;
-use bouncycastle_core::errors::HashError;
-use bouncycastle_core::traits::{Hash, SecurityStrength};
+use crate::{SHA2Params};
+use bouncycastle_core::errors::{CoreError, HashError};
+use bouncycastle_core::serializable_state::{add_lib_ver, check_lib_ver};
+use bouncycastle_core::traits::{Hash, SecurityStrength, SerializableState};
 use bouncycastle_utils::min;
 use core::slice;
 
@@ -160,7 +161,7 @@ impl<PARAMS: SHA2Params> Sha512State<PARAMS> {
 // todo -- cleanup
 // #[derive(Clone, Copy)]
 #[derive(Clone)]
-pub struct Sha512Internal<PARAMS: SHA2Params> {
+pub struct SHA512Internal<PARAMS: SHA2Params> {
     _params: std::marker::PhantomData<PARAMS>,
     state: Sha512State<PARAMS>,
     byte_count: u64, // NOTE We only support 2^67 bits, not the full 2^128
@@ -168,13 +169,13 @@ pub struct Sha512Internal<PARAMS: SHA2Params> {
     x_buf_off: usize,
 }
 
-impl<PARAMS: SHA2Params> Drop for Sha512Internal<PARAMS> {
+impl<PARAMS: SHA2Params> Drop for SHA512Internal<PARAMS> {
     fn drop(&mut self) {
         self.x_buf.fill(0);
     }
 }
 
-impl<PARAMS: SHA2Params> Sha512Internal<PARAMS> {
+impl<PARAMS: SHA2Params> SHA512Internal<PARAMS> {
     pub fn new() -> Self {
         Self {
             _params: std::marker::PhantomData,
@@ -186,13 +187,13 @@ impl<PARAMS: SHA2Params> Sha512Internal<PARAMS> {
     }
 }
 
-impl<PARAMS: SHA2Params> Default for Sha512Internal<PARAMS> {
+impl<PARAMS: SHA2Params> Default for SHA512Internal<PARAMS> {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl<PARAMS: SHA2Params> Hash for Sha512Internal<PARAMS> {
+impl<PARAMS: SHA2Params> Hash for SHA512Internal<PARAMS> {
     /// As per FIPS 180-4 Figure 1
     fn block_bitlen(&self) -> usize {
         1024
@@ -315,5 +316,69 @@ impl<PARAMS: SHA2Params> Hash for Sha512Internal<PARAMS> {
 
     fn max_security_strength(&self) -> SecurityStrength {
         SecurityStrength::from_bytes(PARAMS::OUTPUT_LEN / 2)
+    }
+}
+
+impl<PARAMS: SHA2Params> SerializableState<204> for SHA512Internal<PARAMS> {
+    fn serialize_state(&self) -> [u8; 204] {
+        let mut out_to_return = [0u8; 204];
+
+        // insert the version tag
+        let out: &mut [u8; 201] = add_lib_ver(&mut out_to_return).try_into().unwrap();
+
+        // state.h: [u64; 8]
+        // 8 * 8 = 64
+        for i in 0..8 {
+            out[i * 8..(i * 8) + 8].copy_from_slice(&self.state.h[i].to_le_bytes());
+        }
+
+        // byte_count: u64
+        out[64..72].copy_from_slice(&self.byte_count.to_le_bytes());
+
+        // x_buf: [u8; 128]
+        out[72..200].copy_from_slice(&self.x_buf);
+
+        // x_buf_off: usize
+        // in general, a usize should be serialized into a u64, but in this case, it can't ever be larger than 128
+        debug_assert!(self.x_buf_off < 128);
+        out[200] = self.x_buf_off as u8;
+
+        out_to_return
+    }
+
+    fn from_serialized_state(serialized_state: [u8; 204]) -> Result<Self, CoreError> {
+        // check the version tag
+        // At the moment, we have no not_before version to specify.
+        let input: &[u8; 201] = check_lib_ver(&serialized_state, None)?.try_into().unwrap();
+
+        // state.h: [u64; 8]
+        // 8 * 8 = 64
+        let mut h = [0u64; 8];
+        for i in 0..8 {
+            h[i] = u64::from_le_bytes(input[i * 8..(i * 8) + 8].try_into().unwrap());
+        }
+
+        // byte_count: u64
+        let byte_count: u64 = u64::from_le_bytes(input[64..72].try_into().unwrap());
+
+        // x_buf: [u8; 128]
+        let x_buf: [u8; 128] = input[72..200].try_into().unwrap();
+
+        // x_buf_off: usize
+        // in general, a usize should be serialized into a u64, but in this case, it can't ever be larger than 128
+        let x_buf_off: usize = input[200] as usize;
+        if x_buf_off >= 128 {
+            return Err(CoreError::InvalidData);
+        }
+
+        // Construct the object
+        let state = Sha512State { _params: core::marker::PhantomData, h };
+        Ok(SHA512Internal {
+            _params: core::marker::PhantomData,
+            state,
+            byte_count,
+            x_buf,
+            x_buf_off,
+        })
     }
 }

--- a/crypto/sha2/src/sha512.rs
+++ b/crypto/sha2/src/sha512.rs
@@ -1,7 +1,7 @@
 use crate::SHA2Params;
 use bouncycastle_core::errors::{HashError, SerializedStateError};
 use bouncycastle_core::serializable_state::{add_lib_ver, check_lib_ver};
-use bouncycastle_core::traits::{Hash, SecurityStrength, SerializableState};
+use bouncycastle_core::traits::{Hash, SecurityStrength, Suspendable};
 use bouncycastle_utils::min;
 use core::slice;
 
@@ -319,15 +319,14 @@ impl<PARAMS: SHA2Params> Hash for SHA512Internal<PARAMS> {
     }
 }
 
-/// The number of bytes produced by [SerializableState::serialize_state] for any SHA384 or SHA512
-/// object.
-pub const SHA512_SERIALIZED_STATE_LEN: usize = 204;
+/// Length in bytes of the serialized state of SHA384 and SHA512.
+pub const SUSPENDED_SHA512_STATE_LEN: usize = 204;
 
-impl<PARAMS: SHA2Params> SerializableState<SHA512_SERIALIZED_STATE_LEN> for SHA512Internal<PARAMS> {
-    fn serialize_state(self) -> [u8; SHA512_SERIALIZED_STATE_LEN] {
-        debug_assert_eq!(SHA512_SERIALIZED_STATE_LEN, 204);
+impl<PARAMS: SHA2Params> Suspendable<SUSPENDED_SHA512_STATE_LEN> for SHA512Internal<PARAMS> {
+    fn suspend(self) -> [u8; SUSPENDED_SHA512_STATE_LEN] {
+        debug_assert_eq!(SUSPENDED_SHA512_STATE_LEN, 204);
 
-        let mut out_to_return = [0u8; SHA512_SERIALIZED_STATE_LEN];
+        let mut out_to_return = [0u8; SUSPENDED_SHA512_STATE_LEN];
 
         // insert the version tag
         let out: &mut [u8; 201] = add_lib_ver(&mut out_to_return).try_into().unwrap();
@@ -352,8 +351,8 @@ impl<PARAMS: SHA2Params> SerializableState<SHA512_SERIALIZED_STATE_LEN> for SHA5
         out_to_return
     }
 
-    fn from_serialized_state(
-        serialized_state: [u8; SHA512_SERIALIZED_STATE_LEN],
+    fn from_suspended(
+        serialized_state: [u8; SUSPENDED_SHA512_STATE_LEN],
     ) -> Result<Self, SerializedStateError> {
         // check the version tag
         // At the moment, we have no not_before version to specify.

--- a/crypto/sha2/src/sha512.rs
+++ b/crypto/sha2/src/sha512.rs
@@ -1,6 +1,6 @@
 use crate::SHA2Params;
 use bouncycastle_core::errors::{HashError, SuspendableError};
-use bouncycastle_core::serializable_state::{add_lib_ver, check_lib_ver};
+use bouncycastle_core::suspendable_state::{add_lib_ver, check_lib_ver};
 use bouncycastle_core::traits::{Algorithm, Hash, SecurityStrength, Suspendable};
 use bouncycastle_utils::min;
 use core::slice;

--- a/crypto/sha2/src/sha512.rs
+++ b/crypto/sha2/src/sha512.rs
@@ -334,6 +334,7 @@ impl<PARAMS: SHA2Params> Suspendable<SUSPENDED_SHA512_STATE_LEN> for SHA512Inter
         let mut out_to_return = [0u8; SUSPENDED_SHA512_STATE_LEN];
 
         // insert the version tag
+        // infallible: add_lib_ver returns a slice of exactly SUSPENDED_SHA512_STATE_LEN - 3 = 201 bytes.
         let out: &mut [u8; 201] = add_lib_ver(&mut out_to_return).try_into().unwrap();
 
         // state.h: [u64; 8]
@@ -361,6 +362,7 @@ impl<PARAMS: SHA2Params> Suspendable<SUSPENDED_SHA512_STATE_LEN> for SHA512Inter
     ) -> Result<Self, SuspendableError> {
         // check the version tag
         // At the moment, we have no not_before version to specify.
+        // infallible: check_lib_ver returns a slice of exactly SUSPENDED_SHA512_STATE_LEN - 3 = 201 bytes.
         let input: &[u8; 201] = check_lib_ver(&serialized_state, None)?.try_into().unwrap();
 
         // state.h: [u64; 8]

--- a/crypto/sha2/tests/sha2_tests.rs
+++ b/crypto/sha2/tests/sha2_tests.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod sha2_tests {
-    use bouncycastle_core::errors::CoreError;
+    use bouncycastle_core::errors::SerializedStateError;
     use bouncycastle_core::traits::{Algorithm, Hash, HashAlgParams, SecurityStrength};
     use bouncycastle_core_test_framework::DUMMY_SEED_512;
     use bouncycastle_core_test_framework::hash::TestFrameworkHash;
@@ -107,7 +107,7 @@ mod sha2_tests {
         test_framework.test(&sha256);
 
         // now let's serialize the in-progress state
-        let serialized_state = sha256.serialize_state();
+        let serialized_state = sha256.clone().serialize_state();
 
         // finish the hash
         let output = sha256.do_final();
@@ -121,7 +121,7 @@ mod sha2_tests {
         let mut busted_state = serialized_state.clone();
         busted_state[3 + 104] = 65;
         match SHA256::from_serialized_state(busted_state) {
-            Err(CoreError::InvalidData) => { /* good */ }
+            Err(SerializedStateError::InvalidData) => { /* good */ }
             _ => panic!("Expected an error"),
         }
 
@@ -134,7 +134,7 @@ mod sha2_tests {
         test_framework.test(&sha512);
 
         // now let's serialize the in-progress state
-        let serialized_state = sha512.serialize_state();
+        let serialized_state = sha512.clone().serialize_state();
 
         // finish the hash
         let output = sha512.do_final();
@@ -148,7 +148,7 @@ mod sha2_tests {
         let mut busted_state = serialized_state.clone();
         busted_state[3 + 200] = 129;
         match SHA512::from_serialized_state(busted_state) {
-            Err(CoreError::InvalidData) => { /* good */ }
+            Err(SerializedStateError::InvalidData) => { /* good */ }
             _ => panic!("Expected an error"),
         }
     }

--- a/crypto/sha2/tests/sha2_tests.rs
+++ b/crypto/sha2/tests/sha2_tests.rs
@@ -92,9 +92,9 @@ mod sha2_tests {
     }
 
     #[test]
-    fn test_serializable_state() {
-        use bouncycastle_core::traits::SerializableState;
-        use bouncycastle_core_test_framework::serializable_state::TestFrameworkSerializableState;
+    fn suspendable_state() {
+        use bouncycastle_core::traits::Suspendable;
+        use bouncycastle_core_test_framework::suspendable_state::TestFrameworkSuspendableState;
 
         let str = "Colorless green ideas sleep furiously";
 
@@ -103,24 +103,25 @@ mod sha2_tests {
         sha256.do_update(str.as_bytes());
 
         // do the default tests
-        let test_framework = TestFrameworkSerializableState::new();
+        let test_framework = TestFrameworkSuspendableState::new();
         test_framework.test(&sha256);
 
         // now let's serialize the in-progress state
-        let serialized_state = sha256.clone().serialize_state();
+        let serialized_state = sha256.clone().suspend();
+        assert_eq!(serialized_state.len(), SUSPENDED_SHA256_STATE_LEN);
 
         // finish the hash
         let output = sha256.do_final();
 
         // then load from state and finish the hash and make sure we get the same thing
-        let sha2_from_state = SHA256::from_serialized_state(serialized_state).unwrap();
+        let sha2_from_state = SHA256::from_suspended(serialized_state).unwrap();
         let output2 = sha2_from_state.do_final();
         assert_eq!(output, output2);
 
         // also, give it a busted x_buf_off, just to satisfy mutants that that's been tested
         let mut busted_state = serialized_state.clone();
         busted_state[3 + 104] = 65;
-        match SHA256::from_serialized_state(busted_state) {
+        match SHA256::from_suspended(busted_state) {
             Err(SerializedStateError::InvalidData) => { /* good */ }
             _ => panic!("Expected an error"),
         }
@@ -130,24 +131,25 @@ mod sha2_tests {
         sha512.do_update(str.as_bytes());
 
         // do the default tests
-        let test_framework = TestFrameworkSerializableState::new();
+        let test_framework = TestFrameworkSuspendableState::new();
         test_framework.test(&sha512);
 
         // now let's serialize the in-progress state
-        let serialized_state = sha512.clone().serialize_state();
+        let serialized_state = sha512.clone().suspend();
+        assert_eq!(serialized_state.len(), SUSPENDED_SHA512_STATE_LEN);
 
         // finish the hash
         let output = sha512.do_final();
 
         // then load from state and finish the hash and make sure we get the same thing
-        let sha2_from_state = SHA512::from_serialized_state(serialized_state).unwrap();
+        let sha2_from_state = SHA512::from_suspended(serialized_state).unwrap();
         let output2 = sha2_from_state.do_final();
         assert_eq!(output, output2);
 
         // also, give it a busted x_buf_off, just to satisfy mutants that that's been tested
         let mut busted_state = serialized_state.clone();
         busted_state[3 + 200] = 129;
-        match SHA512::from_serialized_state(busted_state) {
+        match SHA512::from_suspended(busted_state) {
             Err(SerializedStateError::InvalidData) => { /* good */ }
             _ => panic!("Expected an error"),
         }

--- a/crypto/sha2/tests/sha2_tests.rs
+++ b/crypto/sha2/tests/sha2_tests.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod sha2_tests {
-    use bouncycastle_core::errors::SerializedStateError;
+    use bouncycastle_core::errors::SuspendableError;
     use bouncycastle_core::traits::{Algorithm, Hash, HashAlgParams, SecurityStrength};
     use bouncycastle_core_test_framework::DUMMY_SEED_512;
     use bouncycastle_core_test_framework::hash::TestFrameworkHash;
@@ -122,7 +122,7 @@ mod sha2_tests {
         let mut busted_state = serialized_state.clone();
         busted_state[3 + 104] = 65;
         match SHA256::from_suspended(busted_state) {
-            Err(SerializedStateError::InvalidData) => { /* good */ }
+            Err(SuspendableError::InvalidData) => { /* good */ }
             _ => panic!("Expected an error"),
         }
 
@@ -150,7 +150,7 @@ mod sha2_tests {
         let mut busted_state = serialized_state.clone();
         busted_state[3 + 200] = 129;
         match SHA512::from_suspended(busted_state) {
-            Err(SerializedStateError::InvalidData) => { /* good */ }
+            Err(SuspendableError::InvalidData) => { /* good */ }
             _ => panic!("Expected an error"),
         }
     }

--- a/crypto/sha2/tests/sha2_tests.rs
+++ b/crypto/sha2/tests/sha2_tests.rs
@@ -1,5 +1,6 @@
 #[cfg(test)]
 mod sha2_tests {
+    use bouncycastle_core::errors::CoreError;
     use bouncycastle_core::traits::{Algorithm, Hash, HashAlgParams, SecurityStrength};
     use bouncycastle_core_test_framework::DUMMY_SEED_512;
     use bouncycastle_core_test_framework::hash::TestFrameworkHash;
@@ -88,5 +89,67 @@ mod sha2_tests {
         assert_eq!(SHA256::default().max_security_strength(), SecurityStrength::_128bit);
         assert_eq!(SHA384::default().max_security_strength(), SecurityStrength::_192bit);
         assert_eq!(SHA512::default().max_security_strength(), SecurityStrength::_256bit);
+    }
+
+    #[test]
+    fn test_serializable_state() {
+        use bouncycastle_core::traits::SerializableState;
+        use bouncycastle_core_test_framework::serializable_state::TestFrameworkSerializableState;
+
+        let str = "Colorless green ideas sleep furiously";
+
+        // SHA256
+        let mut sha256 = SHA256::new();
+        sha256.do_update(str.as_bytes());
+
+        // do the default tests
+        let test_framework = TestFrameworkSerializableState::new();
+        test_framework.test(&sha256);
+
+        // now let's serialize the in-progress state
+        let serialized_state = sha256.serialize_state();
+
+        // finish the hash
+        let output = sha256.do_final();
+
+        // then load from state and finish the hash and make sure we get the same thing
+        let sha2_from_state = SHA256::from_serialized_state(serialized_state).unwrap();
+        let output2 = sha2_from_state.do_final();
+        assert_eq!(output, output2);
+
+        // also, give it a busted x_buf_off, just to satisfy mutants that that's been tested
+        let mut busted_state = serialized_state.clone();
+        busted_state[3 + 104] = 65;
+        match SHA256::from_serialized_state(busted_state) {
+            Err(CoreError::InvalidData) => { /* good */ }
+            _ => panic!("Expected an error"),
+        }
+
+        // SHA512
+        let mut sha512 = SHA512::new();
+        sha512.do_update(str.as_bytes());
+
+        // do the default tests
+        let test_framework = TestFrameworkSerializableState::new();
+        test_framework.test(&sha512);
+
+        // now let's serialize the in-progress state
+        let serialized_state = sha512.serialize_state();
+
+        // finish the hash
+        let output = sha512.do_final();
+
+        // then load from state and finish the hash and make sure we get the same thing
+        let sha2_from_state = SHA512::from_serialized_state(serialized_state).unwrap();
+        let output2 = sha2_from_state.do_final();
+        assert_eq!(output, output2);
+
+        // also, give it a busted x_buf_off, just to satisfy mutants that that's been tested
+        let mut busted_state = serialized_state.clone();
+        busted_state[3 + 200] = 129;
+        match SHA512::from_serialized_state(busted_state) {
+            Err(CoreError::InvalidData) => { /* good */ }
+            _ => panic!("Expected an error"),
+        }
     }
 }

--- a/crypto/sha3/src/keccak.rs
+++ b/crypto/sha3/src/keccak.rs
@@ -1,7 +1,6 @@
-use bouncycastle_core::errors::{CoreError, HashError};
+use bouncycastle_core::errors::{HashError, SerializedStateError};
 use bouncycastle_core::key_material::KeyType;
 use bouncycastle_core::traits::SecurityStrength;
-use crate::{SHA3_224Params, SHA3_256Params, SHA3_384Params, SHA3_512Params, SHAKE128Params, SHAKE256Params, SHA3, SHAKE};
 
 const KECCAK_ROUND_CONSTANTS: [u64; 24] = [
     0x0000000000000001, 0x0000000000008082, 0x800000000000808A, 0x8000000080008000,
@@ -190,13 +189,14 @@ impl Drop for KeccakState {
     }
 }
 
+// This is pub(crate) so that the SerializableState handlers can unpack it.
 #[derive(Clone)]
-pub(super) struct KeccakDigest {
+pub(crate) struct KeccakDigest {
     state: KeccakState,
     pub data_queue: [u8; 192],
     rate: usize,
     pub bits_in_queue: usize,
-    pub(super) squeezing: bool,
+    pub squeezing: bool,
 }
 
 #[derive(Clone)]
@@ -372,12 +372,10 @@ const KECCAK_SERIALIZED_LEN: usize = 200 + 192 + 8 + 1;
 ///   [.. + 1)                              kdf_key_type          (1 byte enum tag)
 ///   [.. + 1)                              kdf_security_strength (1 byte enum tag)
 ///   [.. + 8)                              kdf_entropy           usize serialized as u64
-pub(super) const SHA3_FAMILY_STATE_LEN: usize = 1 + KECCAK_SERIALIZED_LEN + 10;
+pub(crate) const SHA3_FAMILY_STATE_LEN: usize = 1 + KECCAK_SERIALIZED_LEN + 10;
 
-/// Total number of bytes in a serialized SHA3-family state, including the 3-byte library version
-/// header prepended by [add_lib_ver]. This is the const generic used by the `SerializableState`
-/// impls for SHA3 and SHAKE.
-pub(super) const SHA3_FAMILY_SERIALIZED_STATE_LEN: usize = 3 + SHA3_FAMILY_STATE_LEN;
+/// Total number of bytes in a serialized state of a SHA3 or SHAKE instance.
+pub const SHA3_SERIALIZED_STATE_LEN: usize = 3 + SHA3_FAMILY_STATE_LEN;
 
 impl KeccakDigest {
     /// Serializes this digest's mutable state into `out`. The `rate` is deliberately omitted; see
@@ -407,7 +405,7 @@ impl KeccakDigest {
     fn from_serialized_state(
         input: &[u8; KECCAK_SERIALIZED_LEN],
         rate: usize,
-    ) -> Result<Self, CoreError> {
+    ) -> Result<Self, SerializedStateError> {
         // state.buf: [u64; 25]
         let mut buf = [0u64; 25];
         for i in 0..25 {
@@ -421,14 +419,14 @@ impl KeccakDigest {
         // bytes, well within data_queue's 192-byte capacity).
         let bits_in_queue = u64::from_le_bytes(input[392..400].try_into().unwrap()) as usize;
         if bits_in_queue > rate {
-            return Err(CoreError::InvalidData);
+            return Err(SerializedStateError::InvalidData);
         }
 
         // squeezing: bool
         let squeezing = match input[400] {
             0 => false,
             1 => true,
-            _ => return Err(CoreError::InvalidData),
+            _ => return Err(SerializedStateError::InvalidData),
         };
 
         Ok(Self { state: KeccakState { buf, rate }, data_queue, rate, bits_in_queue, squeezing })
@@ -437,7 +435,7 @@ impl KeccakDigest {
 
 /// Serializes the state shared by all SHA3-family objects (the `variant_tag`, a [KeccakDigest], plus
 /// the three KDF metadata fields) into `out`. See [SHA3_FAMILY_STATE_LEN] for the layout.
-pub(super) fn serialize_sha3_family_state(
+pub(crate) fn serialize_sha3_family_state(
     out: &mut [u8; SHA3_FAMILY_STATE_LEN],
     variant_tag: u8,
     keccak: &KeccakDigest,
@@ -463,13 +461,13 @@ pub(super) fn serialize_sha3_family_state(
 /// tag is checked against the serialized one first: this is what prevents a state from one variant
 /// being loaded into another (e.g. SHA3-256 vs SHAKE256, which share a rate but differ in domain
 /// separation). Only once the tag matches is `rate` guaranteed to be the correct one to rebuild with.
-pub(super) fn deserialize_sha3_family_state(
+pub(crate) fn deserialize_sha3_family_state(
     input: &[u8; SHA3_FAMILY_STATE_LEN],
     expected_variant_tag: u8,
     rate: usize,
-) -> Result<(KeccakDigest, KeyType, SecurityStrength, usize), CoreError> {
+) -> Result<(KeccakDigest, KeyType, SecurityStrength, usize), SerializedStateError> {
     if input[0] != expected_variant_tag {
-        return Err(CoreError::InvalidData);
+        return Err(SerializedStateError::InvalidData);
     }
 
     let keccak_in: &[u8; KECCAK_SERIALIZED_LEN] =

--- a/crypto/sha3/src/keccak.rs
+++ b/crypto/sha3/src/keccak.rs
@@ -1,4 +1,4 @@
-use bouncycastle_core::errors::{HashError, SerializedStateError};
+use bouncycastle_core::errors::{HashError, SuspendableError};
 use bouncycastle_core::key_material::KeyType;
 use bouncycastle_core::traits::SecurityStrength;
 
@@ -405,7 +405,7 @@ impl KeccakDigest {
     fn from_serialized_state(
         input: &[u8; KECCAK_SERIALIZED_LEN],
         rate: usize,
-    ) -> Result<Self, SerializedStateError> {
+    ) -> Result<Self, SuspendableError> {
         // state.buf: [u64; 25]
         let mut buf = [0u64; 25];
         for i in 0..25 {
@@ -419,14 +419,14 @@ impl KeccakDigest {
         // bytes, well within data_queue's 192-byte capacity).
         let bits_in_queue = u64::from_le_bytes(input[392..400].try_into().unwrap()) as usize;
         if bits_in_queue > rate {
-            return Err(SerializedStateError::InvalidData);
+            return Err(SuspendableError::InvalidData);
         }
 
         // squeezing: bool
         let squeezing = match input[400] {
             0 => false,
             1 => true,
-            _ => return Err(SerializedStateError::InvalidData),
+            _ => return Err(SuspendableError::InvalidData),
         };
 
         Ok(Self { state: KeccakState { buf, rate }, data_queue, rate, bits_in_queue, squeezing })
@@ -465,9 +465,9 @@ pub(crate) fn deserialize_sha3_family_state(
     input: &[u8; SHA3_FAMILY_STATE_LEN],
     expected_variant_tag: u8,
     rate: usize,
-) -> Result<(KeccakDigest, KeyType, SecurityStrength, usize), SerializedStateError> {
+) -> Result<(KeccakDigest, KeyType, SecurityStrength, usize), SuspendableError> {
     if input[0] != expected_variant_tag {
-        return Err(SerializedStateError::InvalidData);
+        return Err(SuspendableError::InvalidData);
     }
 
     let keccak_in: &[u8; KECCAK_SERIALIZED_LEN] =

--- a/crypto/sha3/src/keccak.rs
+++ b/crypto/sha3/src/keccak.rs
@@ -374,8 +374,8 @@ const KECCAK_SERIALIZED_LEN: usize = 200 + 192 + 8 + 1;
 ///   [.. + 8)                              kdf_entropy           usize serialized as u64
 pub(crate) const SHA3_FAMILY_STATE_LEN: usize = 1 + KECCAK_SERIALIZED_LEN + 10;
 
-/// Total number of bytes in a serialized state of a SHA3 or SHAKE instance.
-pub const SHA3_SERIALIZED_STATE_LEN: usize = 3 + SHA3_FAMILY_STATE_LEN;
+/// Length in bytes of the serialized state of a SHA3 or SHAKE instance.
+pub const SUSPENDED_SHA3_STATE_LEN: usize = 3 + SHA3_FAMILY_STATE_LEN;
 
 impl KeccakDigest {
     /// Serializes this digest's mutable state into `out`. The `rate` is deliberately omitted; see

--- a/crypto/sha3/src/keccak.rs
+++ b/crypto/sha3/src/keccak.rs
@@ -1,4 +1,7 @@
-use bouncycastle_core::errors::HashError;
+use bouncycastle_core::errors::{CoreError, HashError};
+use bouncycastle_core::key_material::KeyType;
+use bouncycastle_core::traits::SecurityStrength;
+use crate::{SHA3_224Params, SHA3_256Params, SHA3_384Params, SHA3_512Params, SHAKE128Params, SHAKE256Params, SHA3, SHAKE};
 
 const KECCAK_ROUND_CONSTANTS: [u64; 24] = [
     0x0000000000000001, 0x0000000000008082, 0x800000000000808A, 0x8000000080008000,
@@ -210,11 +213,6 @@ impl KeccakDigest {
     pub(super) fn new(size: KeccakSize) -> Self {
         let rate = 1600 - ((size as usize) << 1);
 
-        // todo I think this check is not needed since the fixed set of allowed sizes can't yield an invalid rate, but I'll leave this here for now.
-        // if rate == 0 || rate >= 1600 || (rate & 63) != 0 {
-        //     return Err(HashError::InvalidLength("invalid rate value"));
-        // }
-
         Self {
             state: KeccakState::new(rate),
             data_queue: [0u8; 192],
@@ -341,6 +339,151 @@ impl KeccakDigest {
         self.bits_in_queue = 0;
         self.squeezing = true;
     }
+}
+
+/*** State serialization ***/
+//
+// The SHA3 and SHAKE public objects have identical state: a [KeccakDigest] plus three pieces of
+// KDF metadata. The helpers below serialize that shared state so the `SerializableState` impls in
+// `sha3.rs` and `shake.rs` are just thin wrappers that add/check the library version header.
+
+/// Number of bytes needed to serialize a [KeccakDigest]'s mutable state.
+///
+/// The `rate` is intentionally NOT serialized: it is fully determined by the SHA3/SHAKE variant and
+/// is re-supplied at deserialization time (see [KeccakDigest::from_serialized_state]).
+///
+/// Layout (all integers little-endian):
+///   [0   .. 200)  state.buf     [u64; 25]
+///   [200 .. 392)  data_queue    [u8; 192]
+///   [392 .. 400)  bits_in_queue usize serialized as u64
+///   [400 .. 401)  squeezing     bool  (0 or 1)
+const KECCAK_SERIALIZED_LEN: usize = 200 + 192 + 8 + 1;
+
+/// Number of bytes needed to serialize the shared SHA3-family state (a variant tag, a [KeccakDigest],
+/// plus the three KDF metadata fields), excluding the library version header.
+///
+/// The leading variant tag distinguishes every SHA3/SHAKE variant — crucially including same-rate
+/// pairs such as SHA3-256 and SHAKE256 — so a serialized state can never be deserialized into a
+/// different algorithm (which would silently apply the wrong domain separation).
+///
+/// Layout (all integers little-endian):
+///   [0 .. 1)                              variant tag           (see `STATE_TAG` on the param traits)
+///   [1 .. 1 + KECCAK_SERIALIZED_LEN)      keccak digest state
+///   [.. + 1)                              kdf_key_type          (1 byte enum tag)
+///   [.. + 1)                              kdf_security_strength (1 byte enum tag)
+///   [.. + 8)                              kdf_entropy           usize serialized as u64
+pub(super) const SHA3_FAMILY_STATE_LEN: usize = 1 + KECCAK_SERIALIZED_LEN + 10;
+
+/// Total number of bytes in a serialized SHA3-family state, including the 3-byte library version
+/// header prepended by [add_lib_ver]. This is the const generic used by the `SerializableState`
+/// impls for SHA3 and SHAKE.
+pub(super) const SHA3_FAMILY_SERIALIZED_STATE_LEN: usize = 3 + SHA3_FAMILY_STATE_LEN;
+
+impl KeccakDigest {
+    /// Serializes this digest's mutable state into `out`. The `rate` is deliberately omitted; see
+    /// [KECCAK_SERIALIZED_LEN].
+    fn serialize_state(&self, out: &mut [u8; KECCAK_SERIALIZED_LEN]) {
+        // state.buf: [u64; 25]
+        for i in 0..25 {
+            out[i * 8..(i * 8) + 8].copy_from_slice(&self.state.buf[i].to_le_bytes());
+        }
+
+        // data_queue: [u8; 192]
+        out[200..392].copy_from_slice(&self.data_queue);
+
+        // bits_in_queue: usize
+        out[392..400].copy_from_slice(&(self.bits_in_queue as u64).to_le_bytes());
+
+        // squeezing: bool
+        out[400] = self.squeezing as u8;
+    }
+
+    /// Reconstructs a [KeccakDigest] from a state produced by [KeccakDigest::serialize_state].
+    ///
+    /// `rate` is supplied by the caller (derived from its algorithm parameters) rather than read
+    /// from the serialized bytes, since the rate is fully determined by the SHA3/SHAKE variant. The
+    /// caller is responsible for having already verified the variant tag so that this `rate` is the
+    /// correct one for the serialized state.
+    fn from_serialized_state(
+        input: &[u8; KECCAK_SERIALIZED_LEN],
+        rate: usize,
+    ) -> Result<Self, CoreError> {
+        // state.buf: [u64; 25]
+        let mut buf = [0u64; 25];
+        for i in 0..25 {
+            buf[i] = u64::from_le_bytes(input[i * 8..(i * 8) + 8].try_into().unwrap());
+        }
+
+        // data_queue: [u8; 192]
+        let data_queue: [u8; 192] = input[200..392].try_into().unwrap();
+
+        // bits_in_queue: usize. It can never legitimately exceed the rate (which is at most 168
+        // bytes, well within data_queue's 192-byte capacity).
+        let bits_in_queue = u64::from_le_bytes(input[392..400].try_into().unwrap()) as usize;
+        if bits_in_queue > rate {
+            return Err(CoreError::InvalidData);
+        }
+
+        // squeezing: bool
+        let squeezing = match input[400] {
+            0 => false,
+            1 => true,
+            _ => return Err(CoreError::InvalidData),
+        };
+
+        Ok(Self { state: KeccakState { buf, rate }, data_queue, rate, bits_in_queue, squeezing })
+    }
+}
+
+/// Serializes the state shared by all SHA3-family objects (the `variant_tag`, a [KeccakDigest], plus
+/// the three KDF metadata fields) into `out`. See [SHA3_FAMILY_STATE_LEN] for the layout.
+pub(super) fn serialize_sha3_family_state(
+    out: &mut [u8; SHA3_FAMILY_STATE_LEN],
+    variant_tag: u8,
+    keccak: &KeccakDigest,
+    kdf_key_type: KeyType,
+    kdf_security_strength: SecurityStrength,
+    kdf_entropy: usize,
+) {
+    out[0] = variant_tag;
+
+    let keccak_out: &mut [u8; KECCAK_SERIALIZED_LEN] =
+        (&mut out[1..1 + KECCAK_SERIALIZED_LEN]).try_into().unwrap();
+    keccak.serialize_state(keccak_out);
+
+    out[1 + KECCAK_SERIALIZED_LEN] = kdf_key_type as u8;
+    out[1 + KECCAK_SERIALIZED_LEN + 1] = kdf_security_strength as u8;
+    out[1 + KECCAK_SERIALIZED_LEN + 2..1 + KECCAK_SERIALIZED_LEN + 10]
+        .copy_from_slice(&(kdf_entropy as u64).to_le_bytes());
+}
+
+/// Reconstructs the shared SHA3-family state from a buffer produced by [serialize_sha3_family_state].
+///
+/// `expected_variant_tag` and `rate` are both derived from the caller's algorithm parameters. The
+/// tag is checked against the serialized one first: this is what prevents a state from one variant
+/// being loaded into another (e.g. SHA3-256 vs SHAKE256, which share a rate but differ in domain
+/// separation). Only once the tag matches is `rate` guaranteed to be the correct one to rebuild with.
+pub(super) fn deserialize_sha3_family_state(
+    input: &[u8; SHA3_FAMILY_STATE_LEN],
+    expected_variant_tag: u8,
+    rate: usize,
+) -> Result<(KeccakDigest, KeyType, SecurityStrength, usize), CoreError> {
+    if input[0] != expected_variant_tag {
+        return Err(CoreError::InvalidData);
+    }
+
+    let keccak_in: &[u8; KECCAK_SERIALIZED_LEN] =
+        input[1..1 + KECCAK_SERIALIZED_LEN].try_into().unwrap();
+    let keccak = KeccakDigest::from_serialized_state(keccak_in, rate)?;
+
+    // KeyType and SecurityStrength each own their canonical 1-byte encoding (`as u8` / `TryFrom<u8>`).
+    let kdf_key_type = KeyType::try_from(input[1 + KECCAK_SERIALIZED_LEN])?;
+    let kdf_security_strength = SecurityStrength::try_from(input[1 + KECCAK_SERIALIZED_LEN + 1])?;
+    let kdf_entropy = u64::from_le_bytes(
+        input[1 + KECCAK_SERIALIZED_LEN + 2..1 + KECCAK_SERIALIZED_LEN + 10].try_into().unwrap(),
+    ) as usize;
+
+    Ok((keccak, kdf_key_type, kdf_security_strength, kdf_entropy))
 }
 
 #[cfg(test)]

--- a/crypto/sha3/src/keccak.rs
+++ b/crypto/sha3/src/keccak.rs
@@ -433,7 +433,8 @@ impl KeccakDigest {
         // debug_assert in pad_and_switch_to_squeezing_phase(). Reject it here as InvalidData rather
         // than deferring to a downstream panic.
         let bits_in_queue = u64::from_le_bytes(input[392..400].try_into().unwrap()) as usize;
-        if bits_in_queue > rate || (!squeezing && (bits_in_queue % 8 != 0 || bits_in_queue == rate)) {
+        if bits_in_queue > rate || (!squeezing && (bits_in_queue % 8 != 0 || bits_in_queue == rate))
+        {
             return Err(SuspendableError::InvalidData);
         }
 

--- a/crypto/sha3/src/keccak.rs
+++ b/crypto/sha3/src/keccak.rs
@@ -422,16 +422,8 @@ impl KeccakDigest {
             _ => return Err(SuspendableError::InvalidData),
         };
 
-        // bits_in_queue: usize. It can never legitimately exceed the rate (which is at most 168
-        // bytes, well within data_queue's 192-byte capacity).
-        //
-        // While absorbing (not yet squeezing) the queue is always a whole number of bytes strictly
-        // below the rate -- it is flushed to 0 the instant it reaches the rate, and absorb_bits()
-        // switches to squeezing the moment a sub-byte quantity is added. So a non-squeezing state
-        // whose bits_in_queue is not byte-aligned, or is == rate, is corrupt: left unchecked it would
-        // later panic in absorb() ("attempt to absorb with odd length queue") or trip the
-        // debug_assert in pad_and_switch_to_squeezing_phase(). Reject it here as InvalidData rather
-        // than deferring to a downstream panic.
+        // bits_in_queue: usize. It can never legitimately exceed the rate.
+        // Reject it here as InvalidData rather than deferring to a downstream panic.
         let bits_in_queue = u64::from_le_bytes(input[392..400].try_into().unwrap()) as usize;
         if bits_in_queue > rate || (!squeezing && (bits_in_queue % 8 != 0 || bits_in_queue == rate))
         {
@@ -512,10 +504,10 @@ mod keccak_tests {
         println!("n2: {:x?}", &out);
     }
 
-    // Regression test for from_serialized_state's validation of a not-yet-squeezing queue: a corrupt
-    // state whose bits_in_queue is not byte-aligned, or equals the rate, must be rejected as
-    // InvalidData rather than deserialized into a value that later panics in absorb() /
-    // pad_and_switch_to_squeezing_phase().
+    /// Regression test for from_serialized_state's validation of a not-yet-squeezing queue: a corrupt
+    /// state whose bits_in_queue is not byte-aligned, or equals the rate, must be rejected as
+    /// InvalidData rather than deserialized into a value that later panics in absorb() /
+    /// pad_and_switch_to_squeezing_phase().
     #[test]
     fn from_serialized_state_rejects_corrupt_bits_in_queue() {
         let rate = 1600 - ((KeccakSize::_256 as usize) << 1);

--- a/crypto/sha3/src/keccak.rs
+++ b/crypto/sha3/src/keccak.rs
@@ -415,19 +415,27 @@ impl KeccakDigest {
         // data_queue: [u8; 192]
         let data_queue: [u8; 192] = input[200..392].try_into().unwrap();
 
-        // bits_in_queue: usize. It can never legitimately exceed the rate (which is at most 168
-        // bytes, well within data_queue's 192-byte capacity).
-        let bits_in_queue = u64::from_le_bytes(input[392..400].try_into().unwrap()) as usize;
-        if bits_in_queue > rate {
-            return Err(SuspendableError::InvalidData);
-        }
-
         // squeezing: bool
         let squeezing = match input[400] {
             0 => false,
             1 => true,
             _ => return Err(SuspendableError::InvalidData),
         };
+
+        // bits_in_queue: usize. It can never legitimately exceed the rate (which is at most 168
+        // bytes, well within data_queue's 192-byte capacity).
+        //
+        // While absorbing (not yet squeezing) the queue is always a whole number of bytes strictly
+        // below the rate -- it is flushed to 0 the instant it reaches the rate, and absorb_bits()
+        // switches to squeezing the moment a sub-byte quantity is added. So a non-squeezing state
+        // whose bits_in_queue is not byte-aligned, or is == rate, is corrupt: left unchecked it would
+        // later panic in absorb() ("attempt to absorb with odd length queue") or trip the
+        // debug_assert in pad_and_switch_to_squeezing_phase(). Reject it here as InvalidData rather
+        // than deferring to a downstream panic.
+        let bits_in_queue = u64::from_le_bytes(input[392..400].try_into().unwrap()) as usize;
+        if bits_in_queue > rate || (!squeezing && (bits_in_queue % 8 != 0 || bits_in_queue == rate)) {
+            return Err(SuspendableError::InvalidData);
+        }
 
         Ok(Self { state: KeccakState { buf, rate }, data_queue, rate, bits_in_queue, squeezing })
     }
@@ -501,5 +509,52 @@ mod keccak_tests {
 
         d.squeeze(&mut out);
         println!("n2: {:x?}", &out);
+    }
+
+    // Regression test for from_serialized_state's validation of a not-yet-squeezing queue: a corrupt
+    // state whose bits_in_queue is not byte-aligned, or equals the rate, must be rejected as
+    // InvalidData rather than deserialized into a value that later panics in absorb() /
+    // pad_and_switch_to_squeezing_phase().
+    #[test]
+    fn from_serialized_state_rejects_corrupt_bits_in_queue() {
+        let rate = 1600 - ((KeccakSize::_256 as usize) << 1);
+
+        // A valid, mid-absorb (not squeezing) serialized state.
+        let mut d = KeccakDigest::new(KeccakSize::_256);
+        d.absorb(b"message");
+        assert!(!d.squeezing);
+        let mut good = [0u8; KECCAK_SERIALIZED_LEN];
+        d.serialize_state(&mut good);
+        assert!(KeccakDigest::from_serialized_state(&good, rate).is_ok());
+
+        // bits_in_queue lives at [392..400) as a little-endian u64 with squeezing at [400].
+        assert_eq!(good[400], 0, "test setup expects a non-squeezing state");
+        let set_biq = |state: &mut [u8; KECCAK_SERIALIZED_LEN], v: u64| {
+            state[392..400].copy_from_slice(&v.to_le_bytes());
+        };
+
+        // > rate -> rejected.
+        let mut corrupt = good;
+        set_biq(&mut corrupt, rate as u64 + 8);
+        assert!(matches!(
+            KeccakDigest::from_serialized_state(&corrupt, rate),
+            Err(SuspendableError::InvalidData)
+        ));
+
+        // == rate while not squeezing -> rejected (would trip the pad_and_switch debug_assert).
+        let mut corrupt = good;
+        set_biq(&mut corrupt, rate as u64);
+        assert!(matches!(
+            KeccakDigest::from_serialized_state(&corrupt, rate),
+            Err(SuspendableError::InvalidData)
+        ));
+
+        // Not byte-aligned while not squeezing -> rejected (would panic in absorb()).
+        let mut corrupt = good;
+        set_biq(&mut corrupt, 9);
+        assert!(matches!(
+            KeccakDigest::from_serialized_state(&corrupt, rate),
+            Err(SuspendableError::InvalidData)
+        ));
     }
 }

--- a/crypto/sha3/src/lib.rs
+++ b/crypto/sha3/src/lib.rs
@@ -183,11 +183,6 @@ trait SHA3Params: HashAlgParams {
     const STATE_TAG: u8;
 }
 
-// TODO: more elegant to macro this?
-impl Algorithm for SHA3_224 {
-    const ALG_NAME: &'static str = SHA3_224_NAME;
-    const MAX_SECURITY_STRENGTH: SecurityStrength = SecurityStrength::_112bit;
-}
 impl HashAlgParams for SHA3_224 {
     const OUTPUT_LEN: usize = 28;
     // const BLOCK_LEN: usize = 64;
@@ -209,10 +204,6 @@ impl SHA3Params for SHA3_224Params {
     const STATE_TAG: u8 = 1;
 }
 
-impl Algorithm for SHA3_256 {
-    const ALG_NAME: &'static str = SHA3_256_NAME;
-    const MAX_SECURITY_STRENGTH: SecurityStrength = SecurityStrength::_128bit;
-}
 impl HashAlgParams for SHA3_256 {
     const OUTPUT_LEN: usize = 32;
     // const BLOCK_LEN: usize = 64;
@@ -236,10 +227,6 @@ impl SHA3Params for SHA3_256Params {
 
 #[derive(Clone)]
 pub struct SHA3_384Params;
-impl Algorithm for SHA3_384 {
-    const ALG_NAME: &'static str = SHA3_384_NAME;
-    const MAX_SECURITY_STRENGTH: SecurityStrength = SecurityStrength::_192bit;
-}
 impl HashAlgParams for SHA3_384 {
     const OUTPUT_LEN: usize = 48;
     // const BLOCK_LEN: usize = 128;
@@ -261,10 +248,6 @@ impl SHA3Params for SHA3_384Params {
 
 #[derive(Clone)]
 pub struct SHA3_512Params;
-impl Algorithm for SHA3_512 {
-    const ALG_NAME: &'static str = SHA3_512_NAME;
-    const MAX_SECURITY_STRENGTH: SecurityStrength = SecurityStrength::_256bit;
-}
 impl HashAlgParams for SHA3_512 {
     const OUTPUT_LEN: usize = 64;
     // const BLOCK_LEN: usize = 128;

--- a/crypto/sha3/src/lib.rs
+++ b/crypto/sha3/src/lib.rs
@@ -103,6 +103,36 @@
 //! This would also be the case even if the input had type
 //! [KeyType::CryptographicRandom] since the input [KeyMaterial] is 16 bytes but [SHA3_256] needs at least 32 bytes of
 //! full-entropy input key material in order to be able to produce full entropy output key material.
+//!
+//! # Suspending and resuming execution via SerializableState
+//!
+//! When hashing a large message, it can be advantageous to be able to suspend the operation
+//! to a cache and resume it later; for example if waiting for the message to stream over a slow network
+//! connection.
+//!
+//! For this reason, all SHA3 algorithms impl [SerializableState].
+//!
+//!```rust
+//! use bouncycastle_sha3 as sha3;
+//! use bouncycastle_core::traits::{Hash, SerializableState};
+//!
+//! let msg_part1 = b"The quick brown fox";
+//! let msg_part2 = b" jumped over the lazy dog";
+//!
+//! let mut sha3 = sha3::SHA3_256::new();
+//! sha3.do_update(msg_part1);
+//!
+//! // here, we'll suspend while "waiting" for the second part of the message
+//! let serialized_state = sha3.serialize_state();
+//!
+//! // ...
+//! // do other things in the meantime
+//! // ...
+//!
+//! let mut sha3_resumed = sha3::SHA3_256::from_serialized_state(serialized_state).unwrap();
+//! sha3_resumed.do_update(msg_part2);
+//! let h: Vec<u8> = sha3_resumed.do_final();
+//! ```
 
 #![forbid(unsafe_code)]
 #![allow(private_bounds)]
@@ -132,6 +162,10 @@ pub const SHAKE256_NAME: &str = "SHAKE256";
 /*** pub types ***/
 pub use sha3::SHA3;
 pub use shake::SHAKE;
+
+/// The number of bytes produced by [SerializableState::serialize_state] for any SHA3 or SHAKE
+/// object.
+pub use keccak::SHA3_SERIALIZED_STATE_LEN;
 pub type SHA3_224 = SHA3<SHA3_224Params>;
 pub type SHA3_256 = SHA3<SHA3_256Params>;
 pub type SHA3_384 = SHA3<SHA3_384Params>;
@@ -160,6 +194,7 @@ impl HashAlgParams for SHA3_224 {
     // const BLOCK_LEN: usize = 64;
     const BLOCK_LEN: usize = 144; // FIPS 202 Table 3
 }
+#[derive(Clone)]
 pub struct SHA3_224Params;
 impl Algorithm for SHA3_224Params {
     const ALG_NAME: &'static str = SHA3_224_NAME;
@@ -184,6 +219,7 @@ impl HashAlgParams for SHA3_256 {
     // const BLOCK_LEN: usize = 64;
     const BLOCK_LEN: usize = 136; // FIPS 202 Table 3
 }
+#[derive(Clone)]
 pub struct SHA3_256Params;
 impl Algorithm for SHA3_256Params {
     const ALG_NAME: &'static str = SHA3_256_NAME;
@@ -199,6 +235,7 @@ impl SHA3Params for SHA3_256Params {
     const STATE_TAG: u8 = 2;
 }
 
+#[derive(Clone)]
 pub struct SHA3_384Params;
 impl Algorithm for SHA3_384 {
     const ALG_NAME: &'static str = SHA3_384_NAME;
@@ -223,6 +260,7 @@ impl SHA3Params for SHA3_384Params {
     const STATE_TAG: u8 = 3;
 }
 
+#[derive(Clone)]
 pub struct SHA3_512Params;
 impl Algorithm for SHA3_512 {
     const ALG_NAME: &'static str = SHA3_512_NAME;
@@ -252,6 +290,7 @@ trait SHAKEParams: Algorithm {
     /// See [SHA3Params::STATE_TAG]. Must be distinct from every SHA3 *and* SHAKE variant's tag.
     const STATE_TAG: u8;
 }
+#[derive(Clone)]
 pub struct SHAKE128Params;
 impl Algorithm for SHAKE128Params {
     const ALG_NAME: &'static str = SHAKE128_NAME;
@@ -262,6 +301,7 @@ impl SHAKEParams for SHAKE128Params {
     const STATE_TAG: u8 = 5;
 }
 
+#[derive(Clone)]
 pub struct SHAKE256Params;
 impl Algorithm for SHAKE256Params {
     const ALG_NAME: &'static str = SHAKE256_NAME;

--- a/crypto/sha3/src/lib.rs
+++ b/crypto/sha3/src/lib.rs
@@ -104,17 +104,17 @@
 //! [KeyType::CryptographicRandom] since the input [KeyMaterial] is 16 bytes but [SHA3_256] needs at least 32 bytes of
 //! full-entropy input key material in order to be able to produce full entropy output key material.
 //!
-//! # Suspending and resuming execution via SerializableState
+//! # Suspending and resuming execution
 //!
 //! When hashing a large message, it can be advantageous to be able to suspend the operation
 //! to a cache and resume it later; for example if waiting for the message to stream over a slow network
 //! connection.
 //!
-//! For this reason, all SHA3 algorithms impl [SerializableState].
+//! For this reason, all SHA3 algorithms impl [Suspendable].
 //!
 //!```rust
 //! use bouncycastle_sha3 as sha3;
-//! use bouncycastle_core::traits::{Hash, SerializableState};
+//! use bouncycastle_core::traits::{Hash, Suspendable};
 //!
 //! let msg_part1 = b"The quick brown fox";
 //! let msg_part2 = b" jumped over the lazy dog";
@@ -122,14 +122,15 @@
 //! let mut sha3 = sha3::SHA3_256::new();
 //! sha3.do_update(msg_part1);
 //!
-//! // here, we'll suspend while "waiting" for the second part of the message
-//! let serialized_state = sha3.serialize_state();
+//! // suspend the in-progress extract while "waiting" for the second part of the message.
+//! let serialized_state = sha3.suspend();
 //!
 //! // ...
 //! // do other things in the meantime
 //! // ...
 //!
-//! let mut sha3_resumed = sha3::SHA3_256::from_serialized_state(serialized_state).unwrap();
+//! // ... later, possibly on another host: resume from the serialized state.
+//! let mut sha3_resumed = sha3::SHA3_256::from_suspended(serialized_state).unwrap();
 //! sha3_resumed.do_update(msg_part2);
 //! let h: Vec<u8> = sha3_resumed.do_final();
 //! ```
@@ -144,7 +145,7 @@ use bouncycastle_core::traits::{Algorithm, HashAlgParams, SecurityStrength};
 #[allow(unused_imports)]
 use bouncycastle_core::key_material::{KeyMaterial, KeyType};
 #[allow(unused_imports)]
-use bouncycastle_core::traits::{Hash, KDF, XOF};
+use bouncycastle_core::traits::{Hash, KDF, Suspendable, XOF};
 // end of doc-only imports
 
 mod keccak;
@@ -163,9 +164,7 @@ pub const SHAKE256_NAME: &str = "SHAKE256";
 pub use sha3::SHA3;
 pub use shake::SHAKE;
 
-/// The number of bytes produced by [SerializableState::serialize_state] for any SHA3 or SHAKE
-/// object.
-pub use keccak::SHA3_SERIALIZED_STATE_LEN;
+pub use keccak::SUSPENDED_SHA3_STATE_LEN;
 pub type SHA3_224 = SHA3<SHA3_224Params>;
 pub type SHA3_256 = SHA3<SHA3_256Params>;
 pub type SHA3_384 = SHA3<SHA3_384Params>;

--- a/crypto/sha3/src/lib.rs
+++ b/crypto/sha3/src/lib.rs
@@ -144,6 +144,10 @@ pub type SHAKE256 = SHAKE<SHAKE256Params>;
 /// Private trait on purpose so that only the NIST-approved params can be used.
 trait SHA3Params: HashAlgParams {
     const SIZE: KeccakSize;
+    /// A tag, unique across all SHA3 *and* SHAKE variants, identifying which variant produced a
+    /// serialized state. Distinguishing same-rate variants (e.g. SHA3-256 vs SHAKE256) requires
+    /// this to be distinct from every value used by [SHAKEParams::STATE_TAG]. Never reuse a value.
+    const STATE_TAG: u8;
 }
 
 // TODO: more elegant to macro this?
@@ -168,6 +172,7 @@ impl HashAlgParams for SHA3_224Params {
 }
 impl SHA3Params for SHA3_224Params {
     const SIZE: KeccakSize = KeccakSize::_224;
+    const STATE_TAG: u8 = 1;
 }
 
 impl Algorithm for SHA3_256 {
@@ -191,6 +196,7 @@ impl HashAlgParams for SHA3_256Params {
 }
 impl SHA3Params for SHA3_256Params {
     const SIZE: KeccakSize = KeccakSize::_256;
+    const STATE_TAG: u8 = 2;
 }
 
 pub struct SHA3_384Params;
@@ -214,6 +220,7 @@ impl HashAlgParams for SHA3_384Params {
 }
 impl SHA3Params for SHA3_384Params {
     const SIZE: KeccakSize = KeccakSize::_384;
+    const STATE_TAG: u8 = 3;
 }
 
 pub struct SHA3_512Params;
@@ -237,10 +244,13 @@ impl HashAlgParams for SHA3_512Params {
 }
 impl SHA3Params for SHA3_512Params {
     const SIZE: KeccakSize = KeccakSize::_512;
+    const STATE_TAG: u8 = 4;
 }
 
 trait SHAKEParams: Algorithm {
     const SIZE: KeccakSize;
+    /// See [SHA3Params::STATE_TAG]. Must be distinct from every SHA3 *and* SHAKE variant's tag.
+    const STATE_TAG: u8;
 }
 pub struct SHAKE128Params;
 impl Algorithm for SHAKE128Params {
@@ -249,6 +259,7 @@ impl Algorithm for SHAKE128Params {
 }
 impl SHAKEParams for SHAKE128Params {
     const SIZE: KeccakSize = KeccakSize::_128;
+    const STATE_TAG: u8 = 5;
 }
 
 pub struct SHAKE256Params;
@@ -258,4 +269,5 @@ impl Algorithm for SHAKE256Params {
 }
 impl SHAKEParams for SHAKE256Params {
     const SIZE: KeccakSize = KeccakSize::_256;
+    const STATE_TAG: u8 = 6;
 }

--- a/crypto/sha3/src/sha3.rs
+++ b/crypto/sha3/src/sha3.rs
@@ -1,13 +1,13 @@
 use crate::SHA3Params;
 use crate::keccak::{
-    KeccakDigest, SHA3_FAMILY_STATE_LEN, SHA3_SERIALIZED_STATE_LEN, deserialize_sha3_family_state,
+    KeccakDigest, SHA3_FAMILY_STATE_LEN, SUSPENDED_SHA3_STATE_LEN, deserialize_sha3_family_state,
     serialize_sha3_family_state,
 };
 use bouncycastle_core::errors::{HashError, KDFError, SerializedStateError};
 use bouncycastle_core::key_material;
 use bouncycastle_core::key_material::{KeyMaterial, KeyMaterialTrait, KeyType};
 use bouncycastle_core::serializable_state::{add_lib_ver, check_lib_ver};
-use bouncycastle_core::traits::{Hash, KDF, SecurityStrength, SerializableState};
+use bouncycastle_core::traits::{Hash, KDF, SecurityStrength, Suspendable};
 use bouncycastle_utils::{max, min};
 
 #[derive(Clone)]
@@ -221,49 +221,6 @@ impl<PARAMS: SHA3Params> Hash for SHA3<PARAMS> {
     }
 }
 
-impl<PARAMS: SHA3Params> SerializableState<SHA3_SERIALIZED_STATE_LEN> for SHA3<PARAMS> {
-    fn serialize_state(self) -> [u8; SHA3_SERIALIZED_STATE_LEN] {
-        let mut out_to_return = [0u8; SHA3_SERIALIZED_STATE_LEN];
-
-        // insert the version tag
-        let out: &mut [u8; SHA3_FAMILY_STATE_LEN] =
-            add_lib_ver(&mut out_to_return).try_into().unwrap();
-
-        serialize_sha3_family_state(
-            out,
-            PARAMS::STATE_TAG,
-            &self.keccak,
-            self.kdf_key_type,
-            self.kdf_security_strength,
-            self.kdf_entropy,
-        );
-
-        out_to_return
-    }
-
-    fn from_serialized_state(
-        serialized_state: [u8; SHA3_SERIALIZED_STATE_LEN],
-    ) -> Result<Self, SerializedStateError> {
-        // check the version tag. At the moment, we have no not_before version to specify.
-        let input: &[u8; SHA3_FAMILY_STATE_LEN] =
-            check_lib_ver(&serialized_state, None)?.try_into().unwrap();
-
-        // The variant tag rejects states from any other SHA3/SHAKE variant; the rate is then the
-        // correct one to rebuild with (both are fully determined by the algorithm parameters).
-        let rate = 1600 - ((PARAMS::SIZE as usize) << 1);
-        let (keccak, kdf_key_type, kdf_security_strength, kdf_entropy) =
-            deserialize_sha3_family_state(input, PARAMS::STATE_TAG, rate)?;
-
-        Ok(SHA3 {
-            _params: std::marker::PhantomData,
-            keccak,
-            kdf_key_type,
-            kdf_security_strength,
-            kdf_entropy,
-        })
-    }
-}
-
 /// SHA3 is allowed to be used as a KDF in the form HASH(X) as per NIST SP 800-56C.
 impl<PARAMS: SHA3Params> KDF for SHA3<PARAMS> {
     /// Returns a [KeyMaterial].
@@ -315,5 +272,48 @@ impl<PARAMS: SHA3Params> KDF for SHA3<PARAMS> {
 
     fn max_security_strength(&self) -> SecurityStrength {
         SecurityStrength::from_bytes(PARAMS::OUTPUT_LEN / 2)
+    }
+}
+
+impl<PARAMS: SHA3Params> Suspendable<SUSPENDED_SHA3_STATE_LEN> for SHA3<PARAMS> {
+    fn suspend(self) -> [u8; SUSPENDED_SHA3_STATE_LEN] {
+        let mut out_to_return = [0u8; SUSPENDED_SHA3_STATE_LEN];
+
+        // insert the version tag
+        let out: &mut [u8; SHA3_FAMILY_STATE_LEN] =
+            add_lib_ver(&mut out_to_return).try_into().unwrap();
+
+        serialize_sha3_family_state(
+            out,
+            PARAMS::STATE_TAG,
+            &self.keccak,
+            self.kdf_key_type,
+            self.kdf_security_strength,
+            self.kdf_entropy,
+        );
+
+        out_to_return
+    }
+
+    fn from_suspended(
+        serialized_state: [u8; SUSPENDED_SHA3_STATE_LEN],
+    ) -> Result<Self, SerializedStateError> {
+        // check the version tag. At the moment, we have no not_before version to specify.
+        let input: &[u8; SHA3_FAMILY_STATE_LEN] =
+            check_lib_ver(&serialized_state, None)?.try_into().unwrap();
+
+        // The variant tag rejects states from any other SHA3/SHAKE variant; the rate is then the
+        // correct one to rebuild with (both are fully determined by the algorithm parameters).
+        let rate = 1600 - ((PARAMS::SIZE as usize) << 1);
+        let (keccak, kdf_key_type, kdf_security_strength, kdf_entropy) =
+            deserialize_sha3_family_state(input, PARAMS::STATE_TAG, rate)?;
+
+        Ok(SHA3 {
+            _params: std::marker::PhantomData,
+            keccak,
+            kdf_key_type,
+            kdf_security_strength,
+            kdf_entropy,
+        })
     }
 }

--- a/crypto/sha3/src/sha3.rs
+++ b/crypto/sha3/src/sha3.rs
@@ -1,9 +1,9 @@
 use crate::SHA3Params;
 use crate::keccak::{
-    KeccakDigest, SHA3_FAMILY_SERIALIZED_STATE_LEN, SHA3_FAMILY_STATE_LEN,
-    deserialize_sha3_family_state, serialize_sha3_family_state,
+    KeccakDigest, SHA3_FAMILY_STATE_LEN, SHA3_SERIALIZED_STATE_LEN, deserialize_sha3_family_state,
+    serialize_sha3_family_state,
 };
-use bouncycastle_core::errors::{CoreError, HashError, KDFError};
+use bouncycastle_core::errors::{HashError, KDFError, SerializedStateError};
 use bouncycastle_core::key_material;
 use bouncycastle_core::key_material::{KeyMaterial, KeyMaterialTrait, KeyType};
 use bouncycastle_core::serializable_state::{add_lib_ver, check_lib_ver};
@@ -221,9 +221,9 @@ impl<PARAMS: SHA3Params> Hash for SHA3<PARAMS> {
     }
 }
 
-impl<PARAMS: SHA3Params> SerializableState<SHA3_FAMILY_SERIALIZED_STATE_LEN> for SHA3<PARAMS> {
-    fn serialize_state(&self) -> [u8; SHA3_FAMILY_SERIALIZED_STATE_LEN] {
-        let mut out_to_return = [0u8; SHA3_FAMILY_SERIALIZED_STATE_LEN];
+impl<PARAMS: SHA3Params> SerializableState<SHA3_SERIALIZED_STATE_LEN> for SHA3<PARAMS> {
+    fn serialize_state(self) -> [u8; SHA3_SERIALIZED_STATE_LEN] {
+        let mut out_to_return = [0u8; SHA3_SERIALIZED_STATE_LEN];
 
         // insert the version tag
         let out: &mut [u8; SHA3_FAMILY_STATE_LEN] =
@@ -242,8 +242,8 @@ impl<PARAMS: SHA3Params> SerializableState<SHA3_FAMILY_SERIALIZED_STATE_LEN> for
     }
 
     fn from_serialized_state(
-        serialized_state: [u8; SHA3_FAMILY_SERIALIZED_STATE_LEN],
-    ) -> Result<Self, CoreError> {
+        serialized_state: [u8; SHA3_SERIALIZED_STATE_LEN],
+    ) -> Result<Self, SerializedStateError> {
         // check the version tag. At the moment, we have no not_before version to specify.
         let input: &[u8; SHA3_FAMILY_STATE_LEN] =
             check_lib_ver(&serialized_state, None)?.try_into().unwrap();

--- a/crypto/sha3/src/sha3.rs
+++ b/crypto/sha3/src/sha3.rs
@@ -6,7 +6,7 @@ use crate::keccak::{
 use bouncycastle_core::errors::{HashError, KDFError, SuspendableError};
 use bouncycastle_core::key_material;
 use bouncycastle_core::key_material::{KeyMaterial, KeyMaterialTrait, KeyType};
-use bouncycastle_core::serializable_state::{add_lib_ver, check_lib_ver};
+use bouncycastle_core::suspendable_state::{add_lib_ver, check_lib_ver};
 use bouncycastle_core::traits::{Algorithm, Hash, KDF, SecurityStrength, Suspendable};
 use bouncycastle_utils::{max, min};
 

--- a/crypto/sha3/src/sha3.rs
+++ b/crypto/sha3/src/sha3.rs
@@ -3,11 +3,11 @@ use crate::keccak::{
     KeccakDigest, SHA3_FAMILY_STATE_LEN, SUSPENDED_SHA3_STATE_LEN, deserialize_sha3_family_state,
     serialize_sha3_family_state,
 };
-use bouncycastle_core::errors::{HashError, KDFError, SerializedStateError};
+use bouncycastle_core::errors::{HashError, KDFError, SuspendableError};
 use bouncycastle_core::key_material;
 use bouncycastle_core::key_material::{KeyMaterial, KeyMaterialTrait, KeyType};
 use bouncycastle_core::serializable_state::{add_lib_ver, check_lib_ver};
-use bouncycastle_core::traits::{Hash, KDF, SecurityStrength, Suspendable};
+use bouncycastle_core::traits::{Algorithm, Hash, KDF, SecurityStrength, Suspendable};
 use bouncycastle_utils::{max, min};
 
 #[derive(Clone)]
@@ -122,6 +122,11 @@ impl<PARAMS: SHA3Params> Default for SHA3<PARAMS> {
     fn default() -> Self {
         Self::new()
     }
+}
+
+impl<PARAMS: SHA3Params> Algorithm for SHA3<PARAMS> {
+    const ALG_NAME: &'static str = PARAMS::ALG_NAME;
+    const MAX_SECURITY_STRENGTH: SecurityStrength = PARAMS::MAX_SECURITY_STRENGTH;
 }
 
 impl<PARAMS: SHA3Params> Hash for SHA3<PARAMS> {
@@ -297,7 +302,7 @@ impl<PARAMS: SHA3Params> Suspendable<SUSPENDED_SHA3_STATE_LEN> for SHA3<PARAMS> 
 
     fn from_suspended(
         serialized_state: [u8; SUSPENDED_SHA3_STATE_LEN],
-    ) -> Result<Self, SerializedStateError> {
+    ) -> Result<Self, SuspendableError> {
         // check the version tag. At the moment, we have no not_before version to specify.
         let input: &[u8; SHA3_FAMILY_STATE_LEN] =
             check_lib_ver(&serialized_state, None)?.try_into().unwrap();

--- a/crypto/sha3/src/sha3.rs
+++ b/crypto/sha3/src/sha3.rs
@@ -1,9 +1,13 @@
 use crate::SHA3Params;
-use crate::keccak::KeccakDigest;
-use bouncycastle_core::errors::{HashError, KDFError};
+use crate::keccak::{
+    KeccakDigest, SHA3_FAMILY_SERIALIZED_STATE_LEN, SHA3_FAMILY_STATE_LEN,
+    deserialize_sha3_family_state, serialize_sha3_family_state,
+};
+use bouncycastle_core::errors::{CoreError, HashError, KDFError};
 use bouncycastle_core::key_material;
 use bouncycastle_core::key_material::{KeyMaterial, KeyMaterialTrait, KeyType};
-use bouncycastle_core::traits::{Hash, KDF, SecurityStrength};
+use bouncycastle_core::serializable_state::{add_lib_ver, check_lib_ver};
+use bouncycastle_core::traits::{Hash, KDF, SecurityStrength, SerializableState};
 use bouncycastle_utils::{max, min};
 
 #[derive(Clone)]
@@ -214,6 +218,49 @@ impl<PARAMS: SHA3Params> Hash for SHA3<PARAMS> {
 
     fn max_security_strength(&self) -> SecurityStrength {
         SecurityStrength::from_bytes(PARAMS::OUTPUT_LEN / 2)
+    }
+}
+
+impl<PARAMS: SHA3Params> SerializableState<SHA3_FAMILY_SERIALIZED_STATE_LEN> for SHA3<PARAMS> {
+    fn serialize_state(&self) -> [u8; SHA3_FAMILY_SERIALIZED_STATE_LEN] {
+        let mut out_to_return = [0u8; SHA3_FAMILY_SERIALIZED_STATE_LEN];
+
+        // insert the version tag
+        let out: &mut [u8; SHA3_FAMILY_STATE_LEN] =
+            add_lib_ver(&mut out_to_return).try_into().unwrap();
+
+        serialize_sha3_family_state(
+            out,
+            PARAMS::STATE_TAG,
+            &self.keccak,
+            self.kdf_key_type,
+            self.kdf_security_strength,
+            self.kdf_entropy,
+        );
+
+        out_to_return
+    }
+
+    fn from_serialized_state(
+        serialized_state: [u8; SHA3_FAMILY_SERIALIZED_STATE_LEN],
+    ) -> Result<Self, CoreError> {
+        // check the version tag. At the moment, we have no not_before version to specify.
+        let input: &[u8; SHA3_FAMILY_STATE_LEN] =
+            check_lib_ver(&serialized_state, None)?.try_into().unwrap();
+
+        // The variant tag rejects states from any other SHA3/SHAKE variant; the rate is then the
+        // correct one to rebuild with (both are fully determined by the algorithm parameters).
+        let rate = 1600 - ((PARAMS::SIZE as usize) << 1);
+        let (keccak, kdf_key_type, kdf_security_strength, kdf_entropy) =
+            deserialize_sha3_family_state(input, PARAMS::STATE_TAG, rate)?;
+
+        Ok(SHA3 {
+            _params: std::marker::PhantomData,
+            keccak,
+            kdf_key_type,
+            kdf_security_strength,
+            kdf_entropy,
+        })
     }
 }
 

--- a/crypto/sha3/src/shake.rs
+++ b/crypto/sha3/src/shake.rs
@@ -1,9 +1,9 @@
 use crate::SHAKEParams;
 use crate::keccak::{
-    KeccakDigest, KeccakSize, SHA3_FAMILY_SERIALIZED_STATE_LEN, SHA3_FAMILY_STATE_LEN,
+    KeccakDigest, KeccakSize, SHA3_FAMILY_STATE_LEN, SHA3_SERIALIZED_STATE_LEN,
     deserialize_sha3_family_state, serialize_sha3_family_state,
 };
-use bouncycastle_core::errors::{CoreError, HashError, KDFError};
+use bouncycastle_core::errors::{HashError, KDFError, SerializedStateError};
 use bouncycastle_core::key_material;
 use bouncycastle_core::key_material::{KeyMaterial, KeyMaterialTrait, KeyType};
 use bouncycastle_core::serializable_state::{add_lib_ver, check_lib_ver};
@@ -142,9 +142,9 @@ impl<PARAMS: SHAKEParams> SHAKE<PARAMS> {
     }
 }
 
-impl<PARAMS: SHAKEParams> SerializableState<SHA3_FAMILY_SERIALIZED_STATE_LEN> for SHAKE<PARAMS> {
-    fn serialize_state(&self) -> [u8; SHA3_FAMILY_SERIALIZED_STATE_LEN] {
-        let mut out_to_return = [0u8; SHA3_FAMILY_SERIALIZED_STATE_LEN];
+impl<PARAMS: SHAKEParams> SerializableState<SHA3_SERIALIZED_STATE_LEN> for SHAKE<PARAMS> {
+    fn serialize_state(self) -> [u8; SHA3_SERIALIZED_STATE_LEN] {
+        let mut out_to_return = [0u8; SHA3_SERIALIZED_STATE_LEN];
 
         // insert the version tag
         let out: &mut [u8; SHA3_FAMILY_STATE_LEN] =
@@ -163,8 +163,8 @@ impl<PARAMS: SHAKEParams> SerializableState<SHA3_FAMILY_SERIALIZED_STATE_LEN> fo
     }
 
     fn from_serialized_state(
-        serialized_state: [u8; SHA3_FAMILY_SERIALIZED_STATE_LEN],
-    ) -> Result<Self, CoreError> {
+        serialized_state: [u8; SHA3_SERIALIZED_STATE_LEN],
+    ) -> Result<Self, SerializedStateError> {
         // check the version tag. At the moment, we have no not_before version to specify.
         let input: &[u8; SHA3_FAMILY_STATE_LEN] =
             check_lib_ver(&serialized_state, None)?.try_into().unwrap();

--- a/crypto/sha3/src/shake.rs
+++ b/crypto/sha3/src/shake.rs
@@ -3,7 +3,7 @@ use crate::keccak::{
     KeccakDigest, KeccakSize, SHA3_FAMILY_STATE_LEN, SUSPENDED_SHA3_STATE_LEN,
     deserialize_sha3_family_state, serialize_sha3_family_state,
 };
-use bouncycastle_core::errors::{HashError, KDFError, SerializedStateError};
+use bouncycastle_core::errors::{HashError, KDFError, SuspendableError};
 use bouncycastle_core::key_material;
 use bouncycastle_core::key_material::{KeyMaterial, KeyMaterialTrait, KeyType};
 use bouncycastle_core::serializable_state::{add_lib_ver, check_lib_ver};
@@ -164,7 +164,7 @@ impl<PARAMS: SHAKEParams> Suspendable<SUSPENDED_SHA3_STATE_LEN> for SHAKE<PARAMS
 
     fn from_suspended(
         serialized_state: [u8; SUSPENDED_SHA3_STATE_LEN],
-    ) -> Result<Self, SerializedStateError> {
+    ) -> Result<Self, SuspendableError> {
         // check the version tag. At the moment, we have no not_before version to specify.
         let input: &[u8; SHA3_FAMILY_STATE_LEN] =
             check_lib_ver(&serialized_state, None)?.try_into().unwrap();

--- a/crypto/sha3/src/shake.rs
+++ b/crypto/sha3/src/shake.rs
@@ -6,7 +6,7 @@ use crate::keccak::{
 use bouncycastle_core::errors::{HashError, KDFError, SuspendableError};
 use bouncycastle_core::key_material;
 use bouncycastle_core::key_material::{KeyMaterial, KeyMaterialTrait, KeyType};
-use bouncycastle_core::serializable_state::{add_lib_ver, check_lib_ver};
+use bouncycastle_core::suspendable_state::{add_lib_ver, check_lib_ver};
 use bouncycastle_core::traits::{Algorithm, KDF, SecurityStrength, Suspendable, XOF};
 use bouncycastle_utils::{max, min};
 

--- a/crypto/sha3/src/shake.rs
+++ b/crypto/sha3/src/shake.rs
@@ -1,9 +1,13 @@
 use crate::SHAKEParams;
-use crate::keccak::{KeccakDigest, KeccakSize};
-use bouncycastle_core::errors::{HashError, KDFError};
+use crate::keccak::{
+    KeccakDigest, KeccakSize, SHA3_FAMILY_SERIALIZED_STATE_LEN, SHA3_FAMILY_STATE_LEN,
+    deserialize_sha3_family_state, serialize_sha3_family_state,
+};
+use bouncycastle_core::errors::{CoreError, HashError, KDFError};
 use bouncycastle_core::key_material;
 use bouncycastle_core::key_material::{KeyMaterial, KeyMaterialTrait, KeyType};
-use bouncycastle_core::traits::{Algorithm, KDF, SecurityStrength, XOF};
+use bouncycastle_core::serializable_state::{add_lib_ver, check_lib_ver};
+use bouncycastle_core::traits::{Algorithm, KDF, SecurityStrength, SerializableState, XOF};
 use bouncycastle_utils::{max, min};
 
 /// Note: FIPS 202 section 7 states:
@@ -135,6 +139,49 @@ impl<PARAMS: SHAKEParams> SHAKE<PARAMS> {
             )
         })?;
         Ok(bytes_written)
+    }
+}
+
+impl<PARAMS: SHAKEParams> SerializableState<SHA3_FAMILY_SERIALIZED_STATE_LEN> for SHAKE<PARAMS> {
+    fn serialize_state(&self) -> [u8; SHA3_FAMILY_SERIALIZED_STATE_LEN] {
+        let mut out_to_return = [0u8; SHA3_FAMILY_SERIALIZED_STATE_LEN];
+
+        // insert the version tag
+        let out: &mut [u8; SHA3_FAMILY_STATE_LEN] =
+            add_lib_ver(&mut out_to_return).try_into().unwrap();
+
+        serialize_sha3_family_state(
+            out,
+            PARAMS::STATE_TAG,
+            &self.keccak,
+            self.kdf_key_type,
+            self.kdf_security_strength,
+            self.kdf_entropy,
+        );
+
+        out_to_return
+    }
+
+    fn from_serialized_state(
+        serialized_state: [u8; SHA3_FAMILY_SERIALIZED_STATE_LEN],
+    ) -> Result<Self, CoreError> {
+        // check the version tag. At the moment, we have no not_before version to specify.
+        let input: &[u8; SHA3_FAMILY_STATE_LEN] =
+            check_lib_ver(&serialized_state, None)?.try_into().unwrap();
+
+        // The variant tag rejects states from any other SHA3/SHAKE variant; the rate is then the
+        // correct one to rebuild with (both are fully determined by the algorithm parameters).
+        let rate = 1600 - ((PARAMS::SIZE as usize) << 1);
+        let (keccak, kdf_key_type, kdf_security_strength, kdf_entropy) =
+            deserialize_sha3_family_state(input, PARAMS::STATE_TAG, rate)?;
+
+        Ok(SHAKE {
+            _phantomdata: std::marker::PhantomData,
+            keccak,
+            kdf_key_type,
+            kdf_security_strength,
+            kdf_entropy,
+        })
     }
 }
 

--- a/crypto/sha3/src/shake.rs
+++ b/crypto/sha3/src/shake.rs
@@ -1,13 +1,13 @@
 use crate::SHAKEParams;
 use crate::keccak::{
-    KeccakDigest, KeccakSize, SHA3_FAMILY_STATE_LEN, SHA3_SERIALIZED_STATE_LEN,
+    KeccakDigest, KeccakSize, SHA3_FAMILY_STATE_LEN, SUSPENDED_SHA3_STATE_LEN,
     deserialize_sha3_family_state, serialize_sha3_family_state,
 };
 use bouncycastle_core::errors::{HashError, KDFError, SerializedStateError};
 use bouncycastle_core::key_material;
 use bouncycastle_core::key_material::{KeyMaterial, KeyMaterialTrait, KeyType};
 use bouncycastle_core::serializable_state::{add_lib_ver, check_lib_ver};
-use bouncycastle_core::traits::{Algorithm, KDF, SecurityStrength, SerializableState, XOF};
+use bouncycastle_core::traits::{Algorithm, KDF, SecurityStrength, Suspendable, XOF};
 use bouncycastle_utils::{max, min};
 
 /// Note: FIPS 202 section 7 states:
@@ -142,9 +142,9 @@ impl<PARAMS: SHAKEParams> SHAKE<PARAMS> {
     }
 }
 
-impl<PARAMS: SHAKEParams> SerializableState<SHA3_SERIALIZED_STATE_LEN> for SHAKE<PARAMS> {
-    fn serialize_state(self) -> [u8; SHA3_SERIALIZED_STATE_LEN] {
-        let mut out_to_return = [0u8; SHA3_SERIALIZED_STATE_LEN];
+impl<PARAMS: SHAKEParams> Suspendable<SUSPENDED_SHA3_STATE_LEN> for SHAKE<PARAMS> {
+    fn suspend(self) -> [u8; SUSPENDED_SHA3_STATE_LEN] {
+        let mut out_to_return = [0u8; SUSPENDED_SHA3_STATE_LEN];
 
         // insert the version tag
         let out: &mut [u8; SHA3_FAMILY_STATE_LEN] =
@@ -162,8 +162,8 @@ impl<PARAMS: SHAKEParams> SerializableState<SHA3_SERIALIZED_STATE_LEN> for SHAKE
         out_to_return
     }
 
-    fn from_serialized_state(
-        serialized_state: [u8; SHA3_SERIALIZED_STATE_LEN],
+    fn from_suspended(
+        serialized_state: [u8; SUSPENDED_SHA3_STATE_LEN],
     ) -> Result<Self, SerializedStateError> {
         // check the version tag. At the moment, we have no not_before version to specify.
         let input: &[u8; SHA3_FAMILY_STATE_LEN] =

--- a/crypto/sha3/tests/sha3_tests.rs
+++ b/crypto/sha3/tests/sha3_tests.rs
@@ -396,21 +396,21 @@ mod sha3_tests {
 
     #[test]
     fn test_serializable_state() {
-        use bouncycastle_core::errors::CoreError;
+        use bouncycastle_core::errors::SerializedStateError;
         use bouncycastle_core::traits::SerializableState;
         use bouncycastle_core_test_framework::serializable_state::TestFrameworkSerializableState;
 
         let str = "Colorless green ideas sleep furiously";
 
         // A helper that exercises the full round-trip for one SHA3 variant.
-        fn round_trip<const N: usize, H: Hash + SerializableState<N>>(mut hash: H, input: &[u8]) {
+        fn round_trip<const N: usize, H: Hash + SerializableState<N> + Clone>(mut hash: H, input: &[u8]) {
             hash.do_update(input);
 
             // do the default trait-conformance tests
             TestFrameworkSerializableState::new().test(&hash);
 
             // serialize the in-progress state, then finish the original
-            let serialized_state = hash.serialize_state();
+            let serialized_state = hash.clone().serialize_state();
             let expected = hash.do_final();
 
             // rebuild from the serialized state and confirm it produces the same digest
@@ -423,7 +423,7 @@ mod sha3_tests {
             let mut busted = serialized_state;
             busted[3 + 1 + 400] = 42;
             match H::from_serialized_state(busted) {
-                Err(CoreError::InvalidData) => { /* good */ }
+                Err(SerializedStateError::InvalidData) => { /* good */ }
                 _ => panic!("Expected an error for a corrupt squeezing byte"),
             }
         }
@@ -440,11 +440,11 @@ mod sha3_tests {
         sha3_256.do_update(str.as_bytes());
         let serialized_256 = sha3_256.serialize_state();
         match SHA3_512::from_serialized_state(serialized_256) {
-            Err(CoreError::InvalidData) => { /* good */ }
+            Err(SerializedStateError::InvalidData) => { /* good */ }
             _ => panic!("Expected an error when loading a SHA3-256 state into SHA3-512"),
         }
         match SHAKE256::from_serialized_state(serialized_256) {
-            Err(CoreError::InvalidData) => { /* good */ }
+            Err(SerializedStateError::InvalidData) => { /* good */ }
             _ => panic!("Expected an error when loading a SHA3-256 state into SHAKE256"),
         }
     }

--- a/crypto/sha3/tests/sha3_tests.rs
+++ b/crypto/sha3/tests/sha3_tests.rs
@@ -9,7 +9,7 @@ mod sha3_tests {
     use bouncycastle_core_test_framework::DUMMY_SEED_512;
     use bouncycastle_core_test_framework::hash::TestFrameworkHash;
     use bouncycastle_core_test_framework::kdf::TestFrameworkKDF;
-    use bouncycastle_sha3::{SHA3_224, SHA3_256, SHA3_384, SHA3_512};
+    use bouncycastle_sha3::{SHA3_224, SHA3_256, SHA3_384, SHA3_512, SHAKE256};
 
     #[test]
     fn test_constants() {
@@ -392,6 +392,61 @@ mod sha3_tests {
     #[test]
     fn run_kats() {
         run_test_vectors(read_test_vectors("tests/data/SHA3TestVectors.txt"));
+    }
+
+    #[test]
+    fn test_serializable_state() {
+        use bouncycastle_core::errors::CoreError;
+        use bouncycastle_core::traits::SerializableState;
+        use bouncycastle_core_test_framework::serializable_state::TestFrameworkSerializableState;
+
+        let str = "Colorless green ideas sleep furiously";
+
+        // A helper that exercises the full round-trip for one SHA3 variant.
+        fn round_trip<const N: usize, H: Hash + SerializableState<N>>(mut hash: H, input: &[u8]) {
+            hash.do_update(input);
+
+            // do the default trait-conformance tests
+            TestFrameworkSerializableState::new().test(&hash);
+
+            // serialize the in-progress state, then finish the original
+            let serialized_state = hash.serialize_state();
+            let expected = hash.do_final();
+
+            // rebuild from the serialized state and confirm it produces the same digest
+            let from_state = H::from_serialized_state(serialized_state).unwrap();
+            assert_eq!(expected, from_state.do_final());
+
+            // a corrupt `squeezing` byte (last byte of the keccak state) must be rejected.
+            // Layout: 3 version bytes + variant tag(1) + [u64;25](200) + data_queue(192)
+            //         + bits_in_queue(8) + squeezing(1)
+            let mut busted = serialized_state;
+            busted[3 + 1 + 400] = 42;
+            match H::from_serialized_state(busted) {
+                Err(CoreError::InvalidData) => { /* good */ }
+                _ => panic!("Expected an error for a corrupt squeezing byte"),
+            }
+        }
+
+        round_trip(SHA3_224::new(), str.as_bytes());
+        round_trip(SHA3_256::new(), str.as_bytes());
+        round_trip(SHA3_384::new(), str.as_bytes());
+        round_trip(SHA3_512::new(), str.as_bytes());
+
+        // A state serialized by one variant must be rejected by a different variant (mismatched
+        // variant tag). SHA3-256 and SHAKE256 share the same rate (1088), so this cross-family case
+        // is only caught by the tag, not the rate -- it is the exact bug the tag exists to prevent.
+        let mut sha3_256 = SHA3_256::new();
+        sha3_256.do_update(str.as_bytes());
+        let serialized_256 = sha3_256.serialize_state();
+        match SHA3_512::from_serialized_state(serialized_256) {
+            Err(CoreError::InvalidData) => { /* good */ }
+            _ => panic!("Expected an error when loading a SHA3-256 state into SHA3-512"),
+        }
+        match SHAKE256::from_serialized_state(serialized_256) {
+            Err(CoreError::InvalidData) => { /* good */ }
+            _ => panic!("Expected an error when loading a SHA3-256 state into SHAKE256"),
+        }
     }
 
     fn run_test_vectors(test_vectors: Vec<TestCase>) {

--- a/crypto/sha3/tests/sha3_tests.rs
+++ b/crypto/sha3/tests/sha3_tests.rs
@@ -398,7 +398,7 @@ mod sha3_tests {
 
     #[test]
     fn serializable_state() {
-        use bouncycastle_core::errors::SerializedStateError;
+        use bouncycastle_core::errors::SuspendableError;
         use bouncycastle_core::traits::Suspendable;
         use bouncycastle_core_test_framework::suspendable_state::TestFrameworkSuspendableState;
 
@@ -427,7 +427,7 @@ mod sha3_tests {
             let mut busted = serialized_state;
             busted[3 + 1 + 400] = 42;
             match H::from_suspended(busted) {
-                Err(SerializedStateError::InvalidData) => { /* good */ }
+                Err(SuspendableError::InvalidData) => { /* good */ }
                 _ => panic!("Expected an error for a corrupt squeezing byte"),
             }
         }
@@ -444,11 +444,11 @@ mod sha3_tests {
         sha3_256.do_update(str.as_bytes());
         let serialized_256 = sha3_256.suspend();
         match SHA3_512::from_suspended(serialized_256) {
-            Err(SerializedStateError::InvalidData) => { /* good */ }
+            Err(SuspendableError::InvalidData) => { /* good */ }
             _ => panic!("Expected an error when loading a SHA3-256 state into SHA3-512"),
         }
         match SHAKE256::from_suspended(serialized_256) {
-            Err(SerializedStateError::InvalidData) => { /* good */ }
+            Err(SuspendableError::InvalidData) => { /* good */ }
             _ => panic!("Expected an error when loading a SHA3-256 state into SHAKE256"),
         }
     }

--- a/crypto/sha3/tests/sha3_tests.rs
+++ b/crypto/sha3/tests/sha3_tests.rs
@@ -9,7 +9,9 @@ mod sha3_tests {
     use bouncycastle_core_test_framework::DUMMY_SEED_512;
     use bouncycastle_core_test_framework::hash::TestFrameworkHash;
     use bouncycastle_core_test_framework::kdf::TestFrameworkKDF;
-    use bouncycastle_sha3::{SHA3_224, SHA3_256, SHA3_384, SHA3_512, SHAKE256};
+    use bouncycastle_sha3::{
+        SHA3_224, SHA3_256, SHA3_384, SHA3_512, SHAKE256, SUSPENDED_SHA3_STATE_LEN,
+    };
 
     #[test]
     fn test_constants() {
@@ -395,29 +397,28 @@ mod sha3_tests {
     }
 
     #[test]
-    fn test_serializable_state() {
+    fn serializable_state() {
         use bouncycastle_core::errors::SerializedStateError;
-        use bouncycastle_core::traits::SerializableState;
-        use bouncycastle_core_test_framework::serializable_state::TestFrameworkSerializableState;
+        use bouncycastle_core::traits::Suspendable;
+        use bouncycastle_core_test_framework::suspendable_state::TestFrameworkSuspendableState;
 
         let str = "Colorless green ideas sleep furiously";
 
         // A helper that exercises the full round-trip for one SHA3 variant.
-        fn round_trip<const N: usize, H: Hash + SerializableState<N> + Clone>(
-            mut hash: H,
-            input: &[u8],
-        ) {
+        fn round_trip<const N: usize, H: Hash + Suspendable<N> + Clone>(mut hash: H, input: &[u8]) {
             hash.do_update(input);
 
             // do the default trait-conformance tests
-            TestFrameworkSerializableState::new().test(&hash);
+            TestFrameworkSuspendableState::new().test(&hash);
 
             // serialize the in-progress state, then finish the original
-            let serialized_state = hash.clone().serialize_state();
+            let serialized_state = hash.clone().suspend();
+            assert_eq!(serialized_state.len(), SUSPENDED_SHA3_STATE_LEN);
+
             let expected = hash.do_final();
 
             // rebuild from the serialized state and confirm it produces the same digest
-            let from_state = H::from_serialized_state(serialized_state).unwrap();
+            let from_state = H::from_suspended(serialized_state).unwrap();
             assert_eq!(expected, from_state.do_final());
 
             // a corrupt `squeezing` byte (last byte of the keccak state) must be rejected.
@@ -425,7 +426,7 @@ mod sha3_tests {
             //         + bits_in_queue(8) + squeezing(1)
             let mut busted = serialized_state;
             busted[3 + 1 + 400] = 42;
-            match H::from_serialized_state(busted) {
+            match H::from_suspended(busted) {
                 Err(SerializedStateError::InvalidData) => { /* good */ }
                 _ => panic!("Expected an error for a corrupt squeezing byte"),
             }
@@ -441,12 +442,12 @@ mod sha3_tests {
         // is only caught by the tag, not the rate -- it is the exact bug the tag exists to prevent.
         let mut sha3_256 = SHA3_256::new();
         sha3_256.do_update(str.as_bytes());
-        let serialized_256 = sha3_256.serialize_state();
-        match SHA3_512::from_serialized_state(serialized_256) {
+        let serialized_256 = sha3_256.suspend();
+        match SHA3_512::from_suspended(serialized_256) {
             Err(SerializedStateError::InvalidData) => { /* good */ }
             _ => panic!("Expected an error when loading a SHA3-256 state into SHA3-512"),
         }
-        match SHAKE256::from_serialized_state(serialized_256) {
+        match SHAKE256::from_suspended(serialized_256) {
             Err(SerializedStateError::InvalidData) => { /* good */ }
             _ => panic!("Expected an error when loading a SHA3-256 state into SHAKE256"),
         }

--- a/crypto/sha3/tests/sha3_tests.rs
+++ b/crypto/sha3/tests/sha3_tests.rs
@@ -403,7 +403,10 @@ mod sha3_tests {
         let str = "Colorless green ideas sleep furiously";
 
         // A helper that exercises the full round-trip for one SHA3 variant.
-        fn round_trip<const N: usize, H: Hash + SerializableState<N> + Clone>(mut hash: H, input: &[u8]) {
+        fn round_trip<const N: usize, H: Hash + SerializableState<N> + Clone>(
+            mut hash: H,
+            input: &[u8],
+        ) {
             hash.do_update(input);
 
             // do the default trait-conformance tests

--- a/crypto/sha3/tests/shake_tests.rs
+++ b/crypto/sha3/tests/shake_tests.rs
@@ -226,7 +226,7 @@ mod shake_tests {
     }
 
     #[test]
-    fn test_security_strength() {
+    fn security_strength() {
         assert_eq!(KDF::max_security_strength(&SHAKE128::default()), SecurityStrength::_128bit);
         assert_eq!(XOF::max_security_strength(&SHAKE128::default()), SecurityStrength::_128bit);
         assert_eq!(KDF::max_security_strength(&SHAKE256::default()), SecurityStrength::_256bit);
@@ -239,29 +239,26 @@ mod shake_tests {
     }
 
     #[test]
-    fn test_serializable_state() {
+    fn suspendable_state() {
         use bouncycastle_core::errors::SerializedStateError;
-        use bouncycastle_core::traits::SerializableState;
-        use bouncycastle_core_test_framework::serializable_state::TestFrameworkSerializableState;
+        use bouncycastle_core::traits::Suspendable;
+        use bouncycastle_core_test_framework::suspendable_state::TestFrameworkSuspendableState;
 
         let str = "Colorless green ideas sleep furiously";
 
         // A helper that exercises the full round-trip for one SHAKE variant.
-        fn round_trip<const N: usize, X: XOF + SerializableState<N> + Clone>(
-            mut shake: X,
-            input: &[u8],
-        ) {
+        fn round_trip<const N: usize, X: XOF + Suspendable<N> + Clone>(mut shake: X, input: &[u8]) {
             shake.absorb(input);
 
             // do the default trait-conformance tests
-            TestFrameworkSerializableState::new().test(&shake);
+            TestFrameworkSuspendableState::new().test(&shake);
 
             // serialize the in-progress (absorbing) state, then squeeze from the original
-            let serialized_state = shake.clone().serialize_state();
+            let serialized_state = shake.clone().suspend();
             let expected = shake.squeeze(64);
 
             // rebuild from the serialized state and confirm it produces the same output
-            let mut from_state = X::from_serialized_state(serialized_state).unwrap();
+            let mut from_state = X::from_suspended(serialized_state).unwrap();
             assert_eq!(expected, from_state.squeeze(64));
 
             // a corrupt `squeezing` byte (last byte of the keccak state) must be rejected.
@@ -269,7 +266,7 @@ mod shake_tests {
             //         + bits_in_queue(8) + squeezing(1)
             let mut busted = serialized_state;
             busted[3 + 1 + 400] = 42;
-            match X::from_serialized_state(busted) {
+            match X::from_suspended(busted) {
                 Err(SerializedStateError::InvalidData) => { /* good */ }
                 _ => panic!("Expected an error for a corrupt squeezing byte"),
             }
@@ -283,16 +280,16 @@ mod shake_tests {
         // (1088), so only the variant tag distinguishes them.
         let mut shake128 = SHAKE128::new();
         shake128.absorb(str.as_bytes());
-        let serialized_128 = shake128.serialize_state();
-        match SHAKE256::from_serialized_state(serialized_128) {
+        let serialized_128 = shake128.suspend();
+        match SHAKE256::from_suspended(serialized_128) {
             Err(SerializedStateError::InvalidData) => { /* good */ }
             _ => panic!("Expected an error when loading a SHAKE128 state into SHAKE256"),
         }
 
         let mut shake256 = SHAKE256::new();
         shake256.absorb(str.as_bytes());
-        let serialized_256 = shake256.serialize_state();
-        match SHA3_256::from_serialized_state(serialized_256) {
+        let serialized_256 = shake256.suspend();
+        match SHA3_256::from_suspended(serialized_256) {
             Err(SerializedStateError::InvalidData) => { /* good */ }
             _ => panic!("Expected an error when loading a SHAKE256 state into SHA3-256"),
         }

--- a/crypto/sha3/tests/shake_tests.rs
+++ b/crypto/sha3/tests/shake_tests.rs
@@ -9,7 +9,7 @@ mod shake_tests {
     use bouncycastle_core::traits::{KDF, SecurityStrength, XOF};
     use bouncycastle_core_test_framework::DUMMY_SEED_512;
     use bouncycastle_core_test_framework::kdf::TestFrameworkKDF;
-    use bouncycastle_sha3::{SHAKE128, SHAKE256};
+    use bouncycastle_sha3::{SHA3_256, SHAKE128, SHAKE256};
 
     #[test]
     fn test_xof_partial_bit_output() {
@@ -236,6 +236,63 @@ mod shake_tests {
     #[test]
     fn run_kats() {
         run_test_vectors(read_test_vectors("tests/data/SHAKETestVectors.txt"));
+    }
+
+    #[test]
+    fn test_serializable_state() {
+        use bouncycastle_core::errors::CoreError;
+        use bouncycastle_core::traits::SerializableState;
+        use bouncycastle_core_test_framework::serializable_state::TestFrameworkSerializableState;
+
+        let str = "Colorless green ideas sleep furiously";
+
+        // A helper that exercises the full round-trip for one SHAKE variant.
+        fn round_trip<const N: usize, X: XOF + SerializableState<N>>(mut shake: X, input: &[u8]) {
+            shake.absorb(input);
+
+            // do the default trait-conformance tests
+            TestFrameworkSerializableState::new().test(&shake);
+
+            // serialize the in-progress (absorbing) state, then squeeze from the original
+            let serialized_state = shake.serialize_state();
+            let expected = shake.squeeze(64);
+
+            // rebuild from the serialized state and confirm it produces the same output
+            let mut from_state = X::from_serialized_state(serialized_state).unwrap();
+            assert_eq!(expected, from_state.squeeze(64));
+
+            // a corrupt `squeezing` byte (last byte of the keccak state) must be rejected.
+            // Layout: 3 version bytes + variant tag(1) + [u64;25](200) + data_queue(192)
+            //         + bits_in_queue(8) + squeezing(1)
+            let mut busted = serialized_state;
+            busted[3 + 1 + 400] = 42;
+            match X::from_serialized_state(busted) {
+                Err(CoreError::InvalidData) => { /* good */ }
+                _ => panic!("Expected an error for a corrupt squeezing byte"),
+            }
+        }
+
+        round_trip(SHAKE128::new(), str.as_bytes());
+        round_trip(SHAKE256::new(), str.as_bytes());
+
+        // A state serialized by one variant must be rejected by a different variant (mismatched
+        // variant tag). The SHAKE256 -> SHA3-256 case is the important one: they share the same rate
+        // (1088), so only the variant tag distinguishes them.
+        let mut shake128 = SHAKE128::new();
+        shake128.absorb(str.as_bytes());
+        let serialized_128 = shake128.serialize_state();
+        match SHAKE256::from_serialized_state(serialized_128) {
+            Err(CoreError::InvalidData) => { /* good */ }
+            _ => panic!("Expected an error when loading a SHAKE128 state into SHAKE256"),
+        }
+
+        let mut shake256 = SHAKE256::new();
+        shake256.absorb(str.as_bytes());
+        let serialized_256 = shake256.serialize_state();
+        match SHA3_256::from_serialized_state(serialized_256) {
+            Err(CoreError::InvalidData) => { /* good */ }
+            _ => panic!("Expected an error when loading a SHAKE256 state into SHA3-256"),
+        }
     }
 
     fn run_test_vectors(test_vectors: Vec<TestCase>) {

--- a/crypto/sha3/tests/shake_tests.rs
+++ b/crypto/sha3/tests/shake_tests.rs
@@ -247,7 +247,10 @@ mod shake_tests {
         let str = "Colorless green ideas sleep furiously";
 
         // A helper that exercises the full round-trip for one SHAKE variant.
-        fn round_trip<const N: usize, X: XOF + SerializableState<N> + Clone>(mut shake: X, input: &[u8]) {
+        fn round_trip<const N: usize, X: XOF + SerializableState<N> + Clone>(
+            mut shake: X,
+            input: &[u8],
+        ) {
             shake.absorb(input);
 
             // do the default trait-conformance tests

--- a/crypto/sha3/tests/shake_tests.rs
+++ b/crypto/sha3/tests/shake_tests.rs
@@ -240,7 +240,7 @@ mod shake_tests {
 
     #[test]
     fn suspendable_state() {
-        use bouncycastle_core::errors::SerializedStateError;
+        use bouncycastle_core::errors::SuspendableError;
         use bouncycastle_core::traits::Suspendable;
         use bouncycastle_core_test_framework::suspendable_state::TestFrameworkSuspendableState;
 
@@ -253,7 +253,17 @@ mod shake_tests {
             // do the default trait-conformance tests
             TestFrameworkSuspendableState::new().test(&shake);
 
-            // serialize the in-progress (absorbing) state, then squeeze from the original
+            // Test #1
+            // serialize the in-progress (absorbing) state, then squeeze from the original and compare
+            let serialized_state = shake.clone().suspend();
+            let expected = shake.squeeze(64);
+
+            // rebuild from the serialized state and confirm it produces the same output
+            let mut from_state = X::from_suspended(serialized_state).unwrap();
+            assert_eq!(expected, from_state.squeeze(64));
+
+            // Test #2
+            // serialize the in-progress (squeezing) state, then squeeze more from the original and compare
             let serialized_state = shake.clone().suspend();
             let expected = shake.squeeze(64);
 
@@ -267,7 +277,7 @@ mod shake_tests {
             let mut busted = serialized_state;
             busted[3 + 1 + 400] = 42;
             match X::from_suspended(busted) {
-                Err(SerializedStateError::InvalidData) => { /* good */ }
+                Err(SuspendableError::InvalidData) => { /* good */ }
                 _ => panic!("Expected an error for a corrupt squeezing byte"),
             }
         }
@@ -282,7 +292,7 @@ mod shake_tests {
         shake128.absorb(str.as_bytes());
         let serialized_128 = shake128.suspend();
         match SHAKE256::from_suspended(serialized_128) {
-            Err(SerializedStateError::InvalidData) => { /* good */ }
+            Err(SuspendableError::InvalidData) => { /* good */ }
             _ => panic!("Expected an error when loading a SHAKE128 state into SHAKE256"),
         }
 
@@ -290,7 +300,7 @@ mod shake_tests {
         shake256.absorb(str.as_bytes());
         let serialized_256 = shake256.suspend();
         match SHA3_256::from_suspended(serialized_256) {
-            Err(SerializedStateError::InvalidData) => { /* good */ }
+            Err(SuspendableError::InvalidData) => { /* good */ }
             _ => panic!("Expected an error when loading a SHAKE256 state into SHA3-256"),
         }
     }

--- a/crypto/sha3/tests/shake_tests.rs
+++ b/crypto/sha3/tests/shake_tests.rs
@@ -240,21 +240,21 @@ mod shake_tests {
 
     #[test]
     fn test_serializable_state() {
-        use bouncycastle_core::errors::CoreError;
+        use bouncycastle_core::errors::SerializedStateError;
         use bouncycastle_core::traits::SerializableState;
         use bouncycastle_core_test_framework::serializable_state::TestFrameworkSerializableState;
 
         let str = "Colorless green ideas sleep furiously";
 
         // A helper that exercises the full round-trip for one SHAKE variant.
-        fn round_trip<const N: usize, X: XOF + SerializableState<N>>(mut shake: X, input: &[u8]) {
+        fn round_trip<const N: usize, X: XOF + SerializableState<N> + Clone>(mut shake: X, input: &[u8]) {
             shake.absorb(input);
 
             // do the default trait-conformance tests
             TestFrameworkSerializableState::new().test(&shake);
 
             // serialize the in-progress (absorbing) state, then squeeze from the original
-            let serialized_state = shake.serialize_state();
+            let serialized_state = shake.clone().serialize_state();
             let expected = shake.squeeze(64);
 
             // rebuild from the serialized state and confirm it produces the same output
@@ -267,7 +267,7 @@ mod shake_tests {
             let mut busted = serialized_state;
             busted[3 + 1 + 400] = 42;
             match X::from_serialized_state(busted) {
-                Err(CoreError::InvalidData) => { /* good */ }
+                Err(SerializedStateError::InvalidData) => { /* good */ }
                 _ => panic!("Expected an error for a corrupt squeezing byte"),
             }
         }
@@ -282,7 +282,7 @@ mod shake_tests {
         shake128.absorb(str.as_bytes());
         let serialized_128 = shake128.serialize_state();
         match SHAKE256::from_serialized_state(serialized_128) {
-            Err(CoreError::InvalidData) => { /* good */ }
+            Err(SerializedStateError::InvalidData) => { /* good */ }
             _ => panic!("Expected an error when loading a SHAKE128 state into SHAKE256"),
         }
 
@@ -290,7 +290,7 @@ mod shake_tests {
         shake256.absorb(str.as_bytes());
         let serialized_256 = shake256.serialize_state();
         match SHA3_256::from_serialized_state(serialized_256) {
-            Err(CoreError::InvalidData) => { /* good */ }
+            Err(SerializedStateError::InvalidData) => { /* good */ }
             _ => panic!("Expected an error when loading a SHAKE256 state into SHA3-256"),
         }
     }


### PR DESCRIPTION
Closes #24 

This was a feature requested by Simo to be able to pause an operation -- particularly in the middle of a `do_update()` ... `do_update()` ... `do_final()` flow -- stick the serialized crypto operation into a cache, and then resume it later. This is an important feature for implementing TLS loadbalancers that want to be able to cache out the HKDF state and resume it from a different box when the next flight of TCP messages come in.

The only "creative" thing I've added here is that all serialized states are prefixed with a 3-byte semantic version of the library and it's checked on load back in. The idea is that if we ever need to change the serialization of some object, then we can add a guard to refuse to load a serialized object from before the guard (or keep both versions of the deserializer and switch based on the version tag, or whatever ... #futureProofing).