### PR TITLE
SHAKE absorb-after-squeeze

### DIFF
--- a/cli/src/sha3_cmd.rs
+++ b/cli/src/sha3_cmd.rs
@@ -49,7 +49,7 @@ fn do_shake(mut shake: impl XOF, output_len: usize, output_hex: bool) {
     // read from stdin
     let mut bytes_read = io::stdin().read(&mut buf).expect("Failed to read from stdin");
     while bytes_read != 0 {
-        shake.absorb(&buf[..bytes_read]);
+        shake.absorb(&buf[..bytes_read]).expect("absorb before squeeze is infallible");
         bytes_read = io::stdin().read(&mut buf).expect("Failed to read from stdin");
     }
 

--- a/crypto/core/src/traits.rs
+++ b/crypto/core/src/traits.rs
@@ -1078,7 +1078,7 @@ pub trait XOF: Default {
     fn hash_xof_out(self, data: &[u8], output: &mut [u8]) -> usize;
 
     /// Absorb some amount of input.
-    fn absorb(&mut self, data: &[u8]);
+    fn absorb(&mut self, data: &[u8]) -> Result<(), HashError>;
 
     /// Switches to squeezing.
     fn absorb_last_partial_byte(

--- a/crypto/factory/src/xof_factory.rs
+++ b/crypto/factory/src/xof_factory.rs
@@ -99,7 +99,7 @@ impl XOF for XOFFactory {
         }
     }
 
-    fn absorb(&mut self, data: &[u8]) {
+    fn absorb(&mut self, data: &[u8]) -> Result<(), HashError> {
         match self {
             Self::SHAKE128(h) => h.absorb(data),
             Self::SHAKE256(h) => h.absorb(data),

--- a/crypto/mldsa-lowmemory/src/aux_functions.rs
+++ b/crypto/mldsa-lowmemory/src/aux_functions.rs
@@ -457,7 +457,7 @@ pub(crate) fn sample_in_ball<const LAMBDA_over_4: usize, const TAU: i32>(
     // 3: ctx ← H.Absorb(ctx, 𝜌)
     // 4: (ctx, 𝑠) ← H.Squeeze(ctx, 8)
     let mut h = H::new();
-    h.absorb(rho);
+    h.absorb(rho).expect("absorb before squeeze is infallible");
     let mut s = [0u8; 8];
     h.squeeze_out(&mut s);
 
@@ -520,8 +520,8 @@ pub(crate) fn rej_ntt_poly(rho: &[u8; 32], nonce: &[u8; 2]) -> Polynomial {
     let mut w_hat = Polynomial::new();
     let mut j: usize = 0;
     let mut g = G::new();
-    g.absorb(rho);
-    g.absorb(nonce);
+    g.absorb(rho).expect("absorb before squeeze is infallible");
+    g.absorb(nonce).expect("absorb before squeeze is infallible");
 
     // SHAKE is fairly inefficient if you just squeeze 3 bytes at a time, so we'll do a block.
     // size doesn't really matter, so long as it's a multiple of 3.
@@ -565,8 +565,8 @@ pub(crate) fn rej_bounded_poly<const ETA: usize>(rho: &[u8; 64], nonce: &[u8; 2]
     let mut a = Polynomial::new();
     let mut j: usize = 0;
     let mut h = H::new();
-    h.absorb(rho);
-    h.absorb(nonce);
+    h.absorb(rho).expect("absorb before squeeze is infallible");
+    h.absorb(nonce).expect("absorb before squeeze is infallible");
 
     // SHAKE is fairly inefficient if you just squeeze 3 bytes at a time, so we'll do a block.
     // size doesn't really matter
@@ -614,8 +614,8 @@ pub(crate) fn expand_mask_poly<const GAMMA1: i32, const GAMMA1_MASK_LEN: usize>(
     // 32c = GAMMA1_MASK_LEN;
     // 4: 𝑣 ← H(𝜌′, 32𝑐)
     let mut h = H::new();
-    h.absorb(rho);
-    h.absorb(&nonce.to_le_bytes());
+    h.absorb(rho).expect("absorb before squeeze is infallible");
+    h.absorb(&nonce.to_le_bytes()).expect("absorb before squeeze is infallible");
     let mut v = [0u8; GAMMA1_MASK_LEN];
     h.squeeze_out(&mut v);
     bit_unpack_gamma1::<GAMMA1>(&v)

--- a/crypto/mldsa-lowmemory/src/hash_mldsa.rs
+++ b/crypto/mldsa-lowmemory/src/hash_mldsa.rs
@@ -643,16 +643,16 @@ impl<
         // Algorithm 7
         // 6: 𝜇 ← H(BytesToBits(𝑡𝑟)||𝑀', 64)
         let mut h = H::new();
-        h.absorb(&sk.tr());
+        h.absorb(&sk.tr()).expect("absorb before squeeze is infallible");
 
         // Algorithm 4
         // 23: 𝑀' ← BytesToBits(IntegerToBytes(1, 1) ∥ IntegerToBytes(|𝑐𝑡𝑥|, 1) ∥ 𝑐𝑡𝑥 ∥ OID ∥ PH𝑀)
         // all done together
-        h.absorb(&[1u8]);
-        h.absorb(&[ctx.len() as u8]);
-        h.absorb(ctx);
-        h.absorb(HASH::OID_DER);
-        h.absorb(ph);
+        h.absorb(&[1u8]).expect("absorb before squeeze is infallible");
+        h.absorb(&[ctx.len() as u8]).expect("absorb before squeeze is infallible");
+        h.absorb(ctx).expect("absorb before squeeze is infallible");
+        h.absorb(HASH::OID_DER).expect("absorb before squeeze is infallible");
+        h.absorb(ph).expect("absorb before squeeze is infallible");
         let mut mu = [0u8; MLDSA_MU_LEN];
         let bytes_written = h.squeeze_out(&mut mu);
         debug_assert_eq!(bytes_written, MLDSA_MU_LEN);
@@ -1221,16 +1221,16 @@ impl<
         // Algorithm 7
         // 6: 𝜇 ← H(BytesToBits(𝑡𝑟)||𝑀', 64)
         let mut h = H::new();
-        h.absorb(&pk.compute_tr());
+        h.absorb(&pk.compute_tr()).expect("absorb before squeeze is infallible");
 
         // Algorithm 4
         // 23: 𝑀 ← BytesToBits(IntegerToBytes(1, 1) ∥ IntegerToBytes(|𝑐𝑡𝑥|, 1) ∥ 𝑐𝑡𝑥 ∥ OID ∥ PH𝑀)
         // all done together
-        h.absorb(&[1u8]);
-        h.absorb(&[ctx.len() as u8]);
-        h.absorb(ctx);
-        h.absorb(HASH::OID_DER);
-        h.absorb(ph);
+        h.absorb(&[1u8]).expect("absorb before squeeze is infallible");
+        h.absorb(&[ctx.len() as u8]).expect("absorb before squeeze is infallible");
+        h.absorb(ctx).expect("absorb before squeeze is infallible");
+        h.absorb(HASH::OID_DER).expect("absorb before squeeze is infallible");
+        h.absorb(ph).expect("absorb before squeeze is infallible");
         let mut mu = [0u8; MLDSA_MU_LEN];
         _ = h.squeeze_out(&mut mu);
 

--- a/crypto/mldsa-lowmemory/src/mldsa.rs
+++ b/crypto/mldsa-lowmemory/src/mldsa.rs
@@ -1096,9 +1096,9 @@ impl<
         // Alg 7; 7: 𝜌″ ← H(𝐾||𝑟𝑛𝑑||𝜇, 64)
         let rho_p_p: [u8; 64] = {
             let mut h = H::new();
-            h.absorb(sk.K());
-            h.absorb(&rnd);
-            h.absorb(mu);
+            h.absorb(sk.K()).expect("absorb before squeeze is infallible");
+            h.absorb(&rnd).expect("absorb before squeeze is infallible");
+            h.absorb(mu).expect("absorb before squeeze is infallible");
             let mut rho_p_p = [0u8; 64];
             h.squeeze_out(&mut rho_p_p);
 
@@ -1126,7 +1126,7 @@ impl<
             let sig_val_c_tilde = {
                 // scope for hash
                 let mut hash = H::new();
-                hash.absorb(mu);
+                hash.absorb(mu).expect("absorb before squeeze is infallible");
                 for row in 0..k {
                     let mut w = compute_w_row::<l, GAMMA1, GAMMA1_MASK_LEN>(
                         &sk.rho(),
@@ -1135,7 +1135,8 @@ impl<
                         row,
                     );
                     w.high_bits::<GAMMA2>();
-                    hash.absorb(&w.w1_encode::<POLY_W1_PACKED_LEN>());
+                    hash.absorb(&w.w1_encode::<POLY_W1_PACKED_LEN>())
+                        .expect("absorb before squeeze is infallible");
                 }
                 let mut sig_val_c_tilde = [0u8; LAMBDA_over_4];
                 hash.squeeze_out(&mut sig_val_c_tilde);
@@ -1326,7 +1327,7 @@ impl<
         // 12: 𝑐_tilde_p ← H(𝜇||w1Encode(𝐰1'), 𝜆/4)
         // ▷ hash it; this should match 𝑐_tilde
         let mut hash = H::new();
-        hash.absorb(mu);
+        hash.absorb(mu).expect("absorb before squeeze is infallible");
 
         for row in 0..k {
             let mut wp_approx = match {
@@ -1363,7 +1364,8 @@ impl<
             // 10: 𝐰1′ ← UseHint(𝐡, 𝐰'_approx)
             // ▷ reconstruction of signer’s commitment
             wp_approx.use_hint::<GAMMA2>(&h_i);
-            hash.absorb(&wp_approx.w1_encode::<POLY_W1_PACKED_LEN>());
+            hash.absorb(&wp_approx.w1_encode::<POLY_W1_PACKED_LEN>())
+                .expect("absorb before squeeze is infallible");
         }
 
         let mut c_tilde_p = [0u8; LAMBDA_over_4];
@@ -1924,14 +1926,14 @@ impl MuBuilder {
         // Algorithm 7
         // 6: 𝜇 ← H(BytesToBits(𝑡𝑟)||𝑀', 64)
         let mut mb = Self { h: H::new() };
-        mb.h.absorb(tr);
+        mb.h.absorb(tr).expect("absorb before squeeze is infallible");
 
         // Algorithm 2
         // 10: 𝑀′ ← BytesToBits(IntegerToBytes(0, 1) ∥ IntegerToBytes(|𝑐𝑡𝑥|, 1) ∥ 𝑐𝑡𝑥) ∥ 𝑀
         // all done together
-        mb.h.absorb(&[0u8]);
-        mb.h.absorb(&[ctx.len() as u8]);
-        mb.h.absorb(ctx);
+        mb.h.absorb(&[0u8]).expect("absorb before squeeze is infallible");
+        mb.h.absorb(&[ctx.len() as u8]).expect("absorb before squeeze is infallible");
+        mb.h.absorb(ctx).expect("absorb before squeeze is infallible");
 
         // now ready to absorb M
         Ok(mb)
@@ -1939,7 +1941,7 @@ impl MuBuilder {
 
     /// Stream a chunk of the message.
     pub fn do_update(&mut self, msg_chunk: &[u8]) {
-        self.h.absorb(msg_chunk);
+        self.h.absorb(msg_chunk).expect("absorb before squeeze is infallible");
     }
 
     /// Finalize and return the mu value.

--- a/crypto/mldsa-lowmemory/src/mldsa_keys.rs
+++ b/crypto/mldsa-lowmemory/src/mldsa_keys.rs
@@ -511,9 +511,9 @@ impl<
         let mut K: [u8; 32] = [0u8; 32];
 
         let mut h = H::default();
-        h.absorb(seed.ref_to_bytes());
-        h.absorb(&(k as u8).to_le_bytes());
-        h.absorb(&(l as u8).to_le_bytes());
+        h.absorb(seed.ref_to_bytes()).expect("absorb before squeeze is infallible");
+        h.absorb(&(k as u8).to_le_bytes()).expect("absorb before squeeze is infallible");
+        h.absorb(&(l as u8).to_le_bytes()).expect("absorb before squeeze is infallible");
         let bytes_written = h.squeeze_out(&mut rho);
         debug_assert_eq!(bytes_written, 32);
         let bytes_written = h.squeeze_out(&mut rho_prime);

--- a/crypto/mldsa-lowmemory/tests/bc_test_data.rs
+++ b/crypto/mldsa-lowmemory/tests/bc_test_data.rs
@@ -946,7 +946,7 @@ impl BustedMuBuilder {
         // Algorithm 7
         // 6: 𝜇 ← H(BytesToBits(𝑡𝑟)||𝑀', 64)
         let mut mb = Self { h: SHAKE256::new() };
-        mb.h.absorb(tr);
+        mb.h.absorb(tr).expect("absorb before squeeze is infallible");
 
         // Algorithm 2
         // 10: 𝑀′ ← BytesToBits(IntegerToBytes(0, 1) ∥ IntegerToBytes(|𝑐𝑡𝑥|, 1) ∥ 𝑐𝑡𝑥) ∥ 𝑀
@@ -961,7 +961,7 @@ impl BustedMuBuilder {
 
     /// Stream a chunk of the message.
     pub fn do_update(&mut self, msg_chunk: &[u8]) {
-        self.h.absorb(msg_chunk);
+        self.h.absorb(msg_chunk).expect("absorb before squeeze is infallible");
     }
 
     /// Finalize and return the mu value.

--- a/crypto/mldsa-lowmemory/tests/mldsa_tests.rs
+++ b/crypto/mldsa-lowmemory/tests/mldsa_tests.rs
@@ -890,7 +890,9 @@ mod mldsa_tests {
         // variant tag weren't checked -- SHAKE128 (tag 5) must be rejected by MuBuilder (SHAKE256,
         // tag 6).
         let mut shake128 = SHAKE128::new();
-        shake128.absorb(b"Colorless green ideas sleep furiously");
+        shake128
+            .absorb(b"Colorless green ideas sleep furiously")
+            .expect("absorb before squeeze is infallible");
         let serialized_128 = shake128.suspend();
 
         match MuBuilder::from_suspended(serialized_128) {

--- a/crypto/mldsa/src/aux_functions.rs
+++ b/crypto/mldsa/src/aux_functions.rs
@@ -518,7 +518,7 @@ pub(crate) fn sample_in_ball<const LAMBDA_over_4: usize, const TAU: i32>(
     // 3: ctx ← H.Absorb(ctx, 𝜌)
     // 4: (ctx, 𝑠) ← H.Squeeze(ctx, 8)
     let mut h = H::new();
-    h.absorb(rho);
+    h.absorb(rho).expect("absorb before squeeze is infallible");
     let mut s = [0u8; 8];
     h.squeeze_out(&mut s);
 
@@ -581,8 +581,8 @@ pub(crate) fn rej_ntt_poly(rho: &[u8; 32], nonce: &[u8; 2]) -> Polynomial {
     let mut w_hat = Polynomial::new();
     let mut j: usize = 0;
     let mut g = G::new();
-    g.absorb(rho);
-    g.absorb(nonce);
+    g.absorb(rho).expect("absorb before squeeze is infallible");
+    g.absorb(nonce).expect("absorb before squeeze is infallible");
 
     // SHAKE is fairly inefficient if you just squeeze 3 bytes at a time, so we'll do a block.
     // size doesn't really matter, so long as it's a multiple of 3.
@@ -626,8 +626,8 @@ pub(crate) fn rej_bounded_poly<const ETA: usize>(rho: &[u8; 64], nonce: &[u8; 2]
     let mut a = Polynomial::new();
     let mut j: usize = 0;
     let mut h = H::new();
-    h.absorb(rho);
-    h.absorb(nonce);
+    h.absorb(rho).expect("absorb before squeeze is infallible");
+    h.absorb(nonce).expect("absorb before squeeze is infallible");
 
     // size doesn't really matter
     // 312 seemed to be the sweet spot from playing with benchmarks
@@ -733,8 +733,9 @@ pub(crate) fn expand_mask<const l: usize, const GAMMA1: i32, const GAMMA1_MASK_L
         // 4: 𝑣 ← H(𝜌′, 32𝑐)
         let v = {
             let mut h = H::new();
-            h.absorb(rho);
-            h.absorb(&(mu + (r as u16)).to_le_bytes());
+            h.absorb(rho).expect("absorb before squeeze is infallible");
+            h.absorb(&(mu + (r as u16)).to_le_bytes())
+                .expect("absorb before squeeze is infallible");
             let mut v = [0u8; GAMMA1_MASK_LEN];
             h.squeeze_out(&mut v);
             v

--- a/crypto/mldsa/src/hash_mldsa.rs
+++ b/crypto/mldsa/src/hash_mldsa.rs
@@ -607,16 +607,16 @@ impl<
         // 6: 𝜇 ← H(BytesToBits(𝑡𝑟)||𝑀', 64)
         let mu = {
             let mut h = H::new();
-            h.absorb(sk.tr());
+            h.absorb(sk.tr()).expect("absorb before squeeze is infallible");
 
             // Algorithm 4
             // 23: 𝑀' ← BytesToBits(IntegerToBytes(1, 1) ∥ IntegerToBytes(|𝑐𝑡𝑥|, 1) ∥ 𝑐𝑡𝑥 ∥ OID ∥ PH𝑀)
             // all done together
-            h.absorb(&[1u8]);
-            h.absorb(&[ctx.len() as u8]);
-            h.absorb(ctx);
-            h.absorb(HASH::OID_DER);
-            h.absorb(ph);
+            h.absorb(&[1u8]).expect("absorb before squeeze is infallible");
+            h.absorb(&[ctx.len() as u8]).expect("absorb before squeeze is infallible");
+            h.absorb(ctx).expect("absorb before squeeze is infallible");
+            h.absorb(HASH::OID_DER).expect("absorb before squeeze is infallible");
+            h.absorb(ph).expect("absorb before squeeze is infallible");
             let mut mu = [0u8; MLDSA_MU_LEN];
             let bytes_written = h.squeeze_out(&mut mu);
             debug_assert_eq!(bytes_written, MLDSA_MU_LEN);
@@ -730,16 +730,16 @@ impl<
         // 6: 𝜇 ← H(BytesToBits(𝑡𝑟)||𝑀', 64)
         let mu = {
             let mut h = H::new();
-            h.absorb(&pk.compute_tr());
+            h.absorb(&pk.compute_tr()).expect("absorb before squeeze is infallible");
 
             // Algorithm 4
             // 23: 𝑀 ← BytesToBits(IntegerToBytes(1, 1) ∥ IntegerToBytes(|𝑐𝑡𝑥|, 1) ∥ 𝑐𝑡𝑥 ∥ OID ∥ PH𝑀)
             // all done together
-            h.absorb(&[1u8]);
-            h.absorb(&[ctx.len() as u8]);
-            h.absorb(ctx);
-            h.absorb(HASH::OID_DER);
-            h.absorb(ph);
+            h.absorb(&[1u8]).expect("absorb before squeeze is infallible");
+            h.absorb(&[ctx.len() as u8]).expect("absorb before squeeze is infallible");
+            h.absorb(ctx).expect("absorb before squeeze is infallible");
+            h.absorb(HASH::OID_DER).expect("absorb before squeeze is infallible");
+            h.absorb(ph).expect("absorb before squeeze is infallible");
             let mut mu = [0u8; MLDSA_MU_LEN];
             _ = h.squeeze_out(&mut mu);
 

--- a/crypto/mldsa/src/matrix.rs
+++ b/crypto/mldsa/src/matrix.rs
@@ -196,7 +196,8 @@ impl<const LEN: usize> Vector<LEN> {
         // 3:   𝐰̃1 ← 𝐰̃1 || SimpleBitPack (𝐰1[𝑖], (𝑞 − 1)/(2𝛾2) − 1)
         // 4: end for
         for w in self.vec.iter() {
-            h.absorb(&w.w1_encode::<POLY_W1_PACKED_LEN>());
+            h.absorb(&w.w1_encode::<POLY_W1_PACKED_LEN>())
+                .expect("absorb before squeeze is infallible");
         }
     }
 }

--- a/crypto/mldsa/src/mldsa.rs
+++ b/crypto/mldsa/src/mldsa.rs
@@ -855,9 +855,9 @@ impl<
         let (s1_hat, mut s2) = {
             // scope for h
             let mut h = H::default();
-            h.absorb(seed.ref_to_bytes());
-            h.absorb(&(k as u8).to_le_bytes());
-            h.absorb(&(l as u8).to_le_bytes());
+            h.absorb(seed.ref_to_bytes()).expect("absorb before squeeze is infallible");
+            h.absorb(&(k as u8).to_le_bytes()).expect("absorb before squeeze is infallible");
+            h.absorb(&(l as u8).to_le_bytes()).expect("absorb before squeeze is infallible");
             let bytes_written = h.squeeze_out(&mut rho);
             debug_assert_eq!(bytes_written, 32);
             let mut rho_prime: [u8; 64] = [0u8; 64];
@@ -953,9 +953,9 @@ impl<
             // scope for h
             // 7: 𝜌″ ← H(𝐾||𝑟𝑛𝑑||𝜇, 64)
             let mut h = H::new();
-            h.absorb(sk.K());
-            h.absorb(&rnd);
-            h.absorb(mu);
+            h.absorb(sk.K()).expect("absorb before squeeze is infallible");
+            h.absorb(&rnd).expect("absorb before squeeze is infallible");
+            h.absorb(mu).expect("absorb before squeeze is infallible");
             let mut rho_p_p = [0u8; 64];
             h.squeeze_out(&mut rho_p_p);
 
@@ -1009,7 +1009,7 @@ impl<
                 // 15: 𝑐_tilde ← H(𝜇||w1Encode(𝐰1), 𝜆/4)
                 //  ▷ commitment hash
                 let mut hash = H::new();
-                hash.absorb(mu);
+                hash.absorb(mu).expect("absorb before squeeze is infallible");
                 w1.w1_encode_and_hash::<POLY_W1_PACKED_LEN>(&mut hash);
                 hash.squeeze_out(&mut sig_val_c_tilde);
             }
@@ -1190,7 +1190,7 @@ impl<
         let c_tilde_p = {
             let mut c_tilde_p = [0u8; LAMBDA_over_4];
             let mut hash = H::new();
-            hash.absorb(mu);
+            hash.absorb(mu).expect("absorb before squeeze is infallible");
             w1p.w1_encode_and_hash::<POLY_W1_PACKED_LEN>(&mut hash);
             hash.squeeze_out(&mut c_tilde_p);
 
@@ -1446,9 +1446,9 @@ impl<
             //   ▷ expand seed
             let (rho, rho_prime, K) = {
                 let mut h = H::default();
-                h.absorb(seed.ref_to_bytes());
-                h.absorb(&(k as u8).to_le_bytes());
-                h.absorb(&(l as u8).to_le_bytes());
+                h.absorb(seed.ref_to_bytes()).expect("absorb before squeeze is infallible");
+                h.absorb(&(k as u8).to_le_bytes()).expect("absorb before squeeze is infallible");
+                h.absorb(&(l as u8).to_le_bytes()).expect("absorb before squeeze is infallible");
                 let mut rho = [0u8; 32];
                 let bytes_written = h.squeeze_out(&mut rho);
                 debug_assert_eq!(bytes_written, 32);
@@ -1465,9 +1465,9 @@ impl<
             // Alg 7; 7: 𝜌″ ← H(𝐾||𝑟𝑛𝑑||𝜇, 64)
             let rho_p_p = {
                 let mut h = H::new();
-                h.absorb(&K);
-                h.absorb(&rnd);
-                h.absorb(mu);
+                h.absorb(&K).expect("absorb before squeeze is infallible");
+                h.absorb(&rnd).expect("absorb before squeeze is infallible");
+                h.absorb(mu).expect("absorb before squeeze is infallible");
                 let mut rho_p_p = [0u8; 64];
                 h.squeeze_out(&mut rho_p_p);
 
@@ -1537,7 +1537,7 @@ impl<
                 // 15: 𝑐_tilde ← H(𝜇||w1Encode(𝐰1), 𝜆/4)
                 //  ▷ commitment hash
                 let mut hash = H::new();
-                hash.absorb(mu);
+                hash.absorb(mu).expect("absorb before squeeze is infallible");
                 w1.w1_encode_and_hash::<POLY_W1_PACKED_LEN>(&mut hash);
                 hash.squeeze_out(&mut sig_val_c_tilde);
             }
@@ -2246,14 +2246,14 @@ impl MuBuilder {
         // Algorithm 7
         // 6: 𝜇 ← H(BytesToBits(𝑡𝑟)||𝑀', 64)
         let mut mb = Self { h: H::new() };
-        mb.h.absorb(tr);
+        mb.h.absorb(tr).expect("absorb before squeeze is infallible");
 
         // Algorithm 2
         // 10: 𝑀′ ← BytesToBits(IntegerToBytes(0, 1) ∥ IntegerToBytes(|𝑐𝑡𝑥|, 1) ∥ 𝑐𝑡𝑥) ∥ 𝑀
         // all done together
-        mb.h.absorb(&[0u8]);
-        mb.h.absorb(&[ctx.len() as u8]);
-        mb.h.absorb(ctx);
+        mb.h.absorb(&[0u8]).expect("absorb before squeeze is infallible");
+        mb.h.absorb(&[ctx.len() as u8]).expect("absorb before squeeze is infallible");
+        mb.h.absorb(ctx).expect("absorb before squeeze is infallible");
 
         // now ready to absorb M
         Ok(mb)
@@ -2261,7 +2261,7 @@ impl MuBuilder {
 
     /// Stream a chunk of the message.
     pub fn do_update(&mut self, msg_chunk: &[u8]) {
-        self.h.absorb(msg_chunk);
+        self.h.absorb(msg_chunk).expect("absorb before squeeze is infallible");
     }
 
     /// Finalize and return the mu value.

--- a/crypto/mldsa/tests/bc_test_data.rs
+++ b/crypto/mldsa/tests/bc_test_data.rs
@@ -963,7 +963,7 @@ impl BustedMuBuilder {
         // Algorithm 7
         // 6: 𝜇 ← H(BytesToBits(𝑡𝑟)||𝑀', 64)
         let mut mb = Self { h: SHAKE256::new() };
-        mb.h.absorb(tr);
+        mb.h.absorb(tr).expect("absorb before squeeze is infallible");
 
         // Algorithm 2
         // 10: 𝑀′ ← BytesToBits(IntegerToBytes(0, 1) ∥ IntegerToBytes(|𝑐𝑡𝑥|, 1) ∥ 𝑐𝑡𝑥) ∥ 𝑀
@@ -978,7 +978,7 @@ impl BustedMuBuilder {
 
     /// Stream a chunk of the message.
     pub fn do_update(&mut self, msg_chunk: &[u8]) {
-        self.h.absorb(msg_chunk);
+        self.h.absorb(msg_chunk).expect("absorb before squeeze is infallible");
     }
 
     /// Finalize and return the mu value.

--- a/crypto/mldsa/tests/mldsa_tests.rs
+++ b/crypto/mldsa/tests/mldsa_tests.rs
@@ -1076,7 +1076,9 @@ mod mldsa_tests {
         // variant tag weren't checked -- SHAKE128 (tag 5) must be rejected by MuBuilder (SHAKE256,
         // tag 6).
         let mut shake128 = SHAKE128::new();
-        shake128.absorb(b"Colorless green ideas sleep furiously");
+        shake128
+            .absorb(b"Colorless green ideas sleep furiously")
+            .expect("absorb before squeeze is infallible");
         let serialized_128 = shake128.suspend();
 
         match MuBuilder::from_suspended(serialized_128) {

--- a/crypto/mlkem-lowmemory/src/aux_functions.rs
+++ b/crypto/mlkem-lowmemory/src/aux_functions.rs
@@ -82,8 +82,8 @@ pub(crate) fn sample_ntt(rho: &[u8; 32], nonce: &[u8; 2]) -> Polynomial {
     // 1: ctx ← XOF.Init()
     // 2: ctx ← XOF.Absorb(ctx, 𝐵) ▷ input the given byte array into XOF
     let mut xof = SHAKE128::new();
-    xof.absorb(rho);
-    xof.absorb(nonce);
+    xof.absorb(rho).expect("absorb before squeeze is infallible");
+    xof.absorb(nonce).expect("absorb before squeeze is infallible");
 
     // 3: 𝑗 ← 0
     let mut j = 0usize;
@@ -199,8 +199,8 @@ pub(crate) fn sample_poly_CBD<const eta: i16>(b: &[u8; 32], n: u8) -> Polynomial
         2 => {
             let buf = {
                 let mut xof = SHAKE256::new();
-                xof.absorb(b);
-                xof.absorb(&n.to_le_bytes());
+                xof.absorb(b).expect("absorb before squeeze is infallible");
+                xof.absorb(&n.to_le_bytes()).expect("absorb before squeeze is infallible");
 
                 let mut buf = [0u8; 2 * 64];
                 xof.squeeze_out(&mut buf);
@@ -212,8 +212,8 @@ pub(crate) fn sample_poly_CBD<const eta: i16>(b: &[u8; 32], n: u8) -> Polynomial
         3 => {
             let buf = {
                 let mut xof = SHAKE256::new();
-                xof.absorb(b);
-                xof.absorb(&n.to_le_bytes());
+                xof.absorb(b).expect("absorb before squeeze is infallible");
+                xof.absorb(&n.to_le_bytes()).expect("absorb before squeeze is infallible");
                 let mut buf = [0u8; 3 * 64];
                 xof.squeeze_out(&mut buf);
                 buf

--- a/crypto/mlkem-lowmemory/src/mlkem.rs
+++ b/crypto/mlkem-lowmemory/src/mlkem.rs
@@ -489,8 +489,8 @@ impl<
         let K_bar: [u8; MLKEM_SS_LEN];
         K_bar = {
             let mut j = J::new();
-            j.absorb(dk.z());
-            j.absorb(&c);
+            j.absorb(dk.z()).expect("absorb before squeeze is infallible");
+            j.absorb(&c).expect("absorb before squeeze is infallible");
             let mut buf = [0u8; MLKEM_SS_LEN];
             let bytes_written = j.squeeze_out(&mut buf);
             debug_assert_eq!(bytes_written, MLKEM_SS_LEN);

--- a/crypto/mlkem-lowmemory/tests/mlkem_tests.rs
+++ b/crypto/mlkem-lowmemory/tests/mlkem_tests.rs
@@ -434,8 +434,10 @@ mod mlkem_tests {
                 //  J is SHAKE256(𝑠, 8*32)
 
                 let mut shake = SHAKE256::new();
-                shake.absorb(&seed.ref_to_bytes()[32..64]);
-                shake.absorb(&busted_ciphertext);
+                shake
+                    .absorb(&seed.ref_to_bytes()[32..64])
+                    .expect("absorb before squeeze is infallible");
+                shake.absorb(&busted_ciphertext).expect("absorb before squeeze is infallible");
                 let mut buf = [0u8; 32];
                 _ = shake.squeeze_out(&mut buf);
 

--- a/crypto/mlkem/src/aux_functions.rs
+++ b/crypto/mlkem/src/aux_functions.rs
@@ -94,8 +94,8 @@ pub fn sample_ntt(rho: &[u8; 32], nonce: &[u8; 2]) -> Polynomial {
     // 1: ctx ← XOF.Init()
     // 2: ctx ← XOF.Absorb(ctx, 𝐵) ▷ input the given byte array into XOF
     let mut xof = SHAKE128::new();
-    xof.absorb(rho);
-    xof.absorb(nonce);
+    xof.absorb(rho).expect("absorb before squeeze is infallible");
+    xof.absorb(nonce).expect("absorb before squeeze is infallible");
 
     // 3: 𝑗 ← 0
     let mut j = 0usize;
@@ -212,8 +212,8 @@ pub(crate) fn sample_poly_CBD<const eta: i16>(b: &[u8; 32], n: u8) -> Polynomial
         2 => {
             let buf = {
                 let mut xof = SHAKE256::new();
-                xof.absorb(b);
-                xof.absorb(&n.to_le_bytes());
+                xof.absorb(b).expect("absorb before squeeze is infallible");
+                xof.absorb(&n.to_le_bytes()).expect("absorb before squeeze is infallible");
 
                 let mut buf = [0u8; 2 * 64];
                 xof.squeeze_out(&mut buf);
@@ -225,8 +225,8 @@ pub(crate) fn sample_poly_CBD<const eta: i16>(b: &[u8; 32], n: u8) -> Polynomial
         3 => {
             let buf = {
                 let mut xof = SHAKE256::new();
-                xof.absorb(b);
-                xof.absorb(&n.to_le_bytes());
+                xof.absorb(b).expect("absorb before squeeze is infallible");
+                xof.absorb(&n.to_le_bytes()).expect("absorb before squeeze is infallible");
                 let mut buf = [0u8; 3 * 64];
                 xof.squeeze_out(&mut buf);
                 buf

--- a/crypto/mlkem/src/mlkem.rs
+++ b/crypto/mlkem/src/mlkem.rs
@@ -673,8 +673,8 @@ impl<
         let K_bar: [u8; MLKEM_SS_LEN];
         K_bar = {
             let mut j = J::new();
-            j.absorb(dk.z());
-            j.absorb(&c);
+            j.absorb(dk.z()).expect("absorb before squeeze is infallible");
+            j.absorb(&c).expect("absorb before squeeze is infallible");
             let mut buf = [0u8; MLKEM_SS_LEN];
             let bytes_written = j.squeeze_out(&mut buf);
             debug_assert_eq!(bytes_written, MLKEM_SS_LEN);

--- a/crypto/mlkem/tests/mlkem_tests.rs
+++ b/crypto/mlkem/tests/mlkem_tests.rs
@@ -468,8 +468,10 @@ mod mlkem_tests {
                 //  J is SHAKE256(𝑠, 8*32)
 
                 let mut shake = SHAKE256::new();
-                shake.absorb(&seed.ref_to_bytes()[32..64]);
-                shake.absorb(&busted_ciphertext);
+                shake
+                    .absorb(&seed.ref_to_bytes()[32..64])
+                    .expect("absorb before squeeze is infallible");
+                shake.absorb(&busted_ciphertext).expect("absorb before squeeze is infallible");
                 let mut buf = [0u8; 32];
                 _ = shake.squeeze_out(&mut buf);
 

--- a/crypto/sha3/src/keccak.rs
+++ b/crypto/sha3/src/keccak.rs
@@ -191,7 +191,7 @@ impl Drop for KeccakState {
 
 // This is pub(crate) so that the SerializableState handlers can unpack it.
 #[derive(Clone)]
-pub(crate) struct KeccakDigest {
+pub(crate) struct KeccakInternal {
     state: KeccakState,
     pub data_queue: [u8; 192],
     rate: usize,
@@ -209,7 +209,7 @@ pub(crate) enum KeccakSize {
     _512 = 512,
 }
 
-impl KeccakDigest {
+impl KeccakInternal {
     pub(super) fn new(size: KeccakSize) -> Self {
         let rate = 1600 - ((size as usize) << 1);
 
@@ -222,15 +222,29 @@ impl KeccakDigest {
         }
     }
 
+    /// Absorbs `data` (whole bytes only) into the sponge.
+    ///
+    /// # Contract
+    /// This private function has preconditions to entry that the caller must uphold:
+    /// ## `bits_in_queue` is byte-aligned (a multiple of 8) on entry.
+    /// currently all call sites within the crate respect this, and there are unit tests to trigger
+    /// the embedded debug_assert for existing call sites, but any new call sites to this MUST
+    /// respect this precondition. If we ever open up the [KeccakInternal] object to be called publicly,
+    /// then we'll have to add proper error-handling here.
+    ///
+    /// ## No absorbing after squeezing
+    /// The prohibition on absorbing more input after squeezing is only technically enforced
+    /// for SHAKE and not for KECCAK (and only because FIPS 202 Section 6.2 places a four-bit suffix
+    /// "1111" after the last byte of input). There is a debug_assert to catch this, but we could
+    /// in theory expose the Keccak primitive externally in the future and relax this restriction,
+    /// but some more careful reading of FIPS 202 and some thinking about error and security handling
+    /// would need to be done.
     pub(super) fn absorb(&mut self, data: &[u8]) {
-        if (self.bits_in_queue & 7) != 0 {
-            panic!("attempt to absorb with odd length queue");
-        }
-        if self.squeezing {
-            // Maybe this should be an error rather than a panic?
-            // But, like, don't write your code to absorb after squeezing.
-            panic!("attempt to absorb while squeezing");
-        }
+        // Debug-only backstops for the two contract preconditions; see the doc comment above. Both are
+        // enforced for real by the SHA3 / SHAKE callers within these crates, so these asserts
+        // _should_ be unreachable.
+        debug_assert!(self.bits_in_queue & 7 == 0, "attempt to absorb with odd length queue");
+        debug_assert!(!self.squeezing, "attempt to absorb while squeezing");
 
         for byte in data {
             self.data_queue[self.bits_in_queue >> 3] = *byte;
@@ -347,10 +361,10 @@ impl KeccakDigest {
 // KDF metadata. The helpers below serialize that shared state so the `SerializableState` impls in
 // `sha3.rs` and `shake.rs` are just thin wrappers that add/check the library version header.
 
-/// Number of bytes needed to serialize a [KeccakDigest]'s mutable state.
+/// Number of bytes needed to serialize a [KeccakInternal]'s mutable state.
 ///
 /// The `rate` is intentionally NOT serialized: it is fully determined by the SHA3/SHAKE variant and
-/// is re-supplied at deserialization time (see [KeccakDigest::from_serialized_state]).
+/// is re-supplied at deserialization time (see [KeccakInternal::from_serialized_state]).
 ///
 /// Layout (all integers little-endian):
 ///   [0   .. 200)  state.buf     [u64; 25]
@@ -359,7 +373,7 @@ impl KeccakDigest {
 ///   [400 .. 401)  squeezing     bool  (0 or 1)
 const KECCAK_SERIALIZED_LEN: usize = 200 + 192 + 8 + 1;
 
-/// Number of bytes needed to serialize the shared SHA3-family state (a variant tag, a [KeccakDigest],
+/// Number of bytes needed to serialize the shared SHA3-family state (a variant tag, a [KeccakInternal],
 /// plus the three KDF metadata fields), excluding the library version header.
 ///
 /// The leading variant tag distinguishes every SHA3/SHAKE variant — crucially including same-rate
@@ -377,7 +391,7 @@ pub(crate) const SHA3_FAMILY_STATE_LEN: usize = 1 + KECCAK_SERIALIZED_LEN + 10;
 /// Length in bytes of the serialized state of a SHA3 or SHAKE instance.
 pub const SUSPENDED_SHA3_STATE_LEN: usize = 3 + SHA3_FAMILY_STATE_LEN;
 
-impl KeccakDigest {
+impl KeccakInternal {
     /// Serializes this digest's mutable state into `out`. The `rate` is deliberately omitted; see
     /// [KECCAK_SERIALIZED_LEN].
     fn serialize_state(&self, out: &mut [u8; KECCAK_SERIALIZED_LEN]) {
@@ -396,7 +410,7 @@ impl KeccakDigest {
         out[400] = self.squeezing as u8;
     }
 
-    /// Reconstructs a [KeccakDigest] from a state produced by [KeccakDigest::serialize_state].
+    /// Reconstructs a [KeccakInternal] from a state produced by [KeccakInternal::serialize_state].
     ///
     /// `rate` is supplied by the caller (derived from its algorithm parameters) rather than read
     /// from the serialized bytes, since the rate is fully determined by the SHA3/SHAKE variant. The
@@ -415,10 +429,13 @@ impl KeccakDigest {
         // data_queue: [u8; 192]
         let data_queue: [u8; 192] = input[200..392].try_into().unwrap();
 
-        // bits_in_queue: usize. It can never legitimately exceed the rate.
-        // Reject it here as InvalidData rather than deferring to a downstream panic.
+        // bits_in_queue: usize.
+        // In a legitimate state it is always a multiple of 8 AND strictly less
+        // than the rate: absorb() only enqueues whole bytes, and a sub-byte queue exists only
+        // transiently inside absorb_bits(), which pads and switches to squeezing before returning.
+        // So here we reject unaligned values (ie where bits_in_queue is not a multiple of 8)
         let bits_in_queue = u64::from_le_bytes(input[392..400].try_into().unwrap()) as usize;
-        if bits_in_queue >= rate {
+        if bits_in_queue >= rate || (bits_in_queue & 7) != 0 {
             return Err(SuspendableError::InvalidData);
         }
 
@@ -433,12 +450,12 @@ impl KeccakDigest {
     }
 }
 
-/// Serializes the state shared by all SHA3-family objects (the `variant_tag`, a [KeccakDigest], plus
+/// Serializes the state shared by all SHA3-family objects (the `variant_tag`, a [KeccakInternal], plus
 /// the three KDF metadata fields) into `out`. See [SHA3_FAMILY_STATE_LEN] for the layout.
 pub(crate) fn serialize_sha3_family_state(
     out: &mut [u8; SHA3_FAMILY_STATE_LEN],
     variant_tag: u8,
-    keccak: &KeccakDigest,
+    keccak: &KeccakInternal,
     kdf_key_type: KeyType,
     kdf_security_strength: SecurityStrength,
     kdf_entropy: usize,
@@ -465,14 +482,14 @@ pub(crate) fn deserialize_sha3_family_state(
     input: &[u8; SHA3_FAMILY_STATE_LEN],
     expected_variant_tag: u8,
     rate: usize,
-) -> Result<(KeccakDigest, KeyType, SecurityStrength, usize), SuspendableError> {
+) -> Result<(KeccakInternal, KeyType, SecurityStrength, usize), SuspendableError> {
     if input[0] != expected_variant_tag {
         return Err(SuspendableError::InvalidData);
     }
 
     let keccak_in: &[u8; KECCAK_SERIALIZED_LEN] =
         input[1..1 + KECCAK_SERIALIZED_LEN].try_into().unwrap();
-    let keccak = KeccakDigest::from_serialized_state(keccak_in, rate)?;
+    let keccak = KeccakInternal::from_serialized_state(keccak_in, rate)?;
 
     // KeyType and SecurityStrength each own their canonical 1-byte encoding (`as u8` / `TryFrom<u8>`).
     let kdf_key_type = KeyType::try_from(input[1 + KECCAK_SERIALIZED_LEN])?;
@@ -491,7 +508,7 @@ mod keccak_tests {
 
     #[test]
     fn test_keccak() {
-        let mut d = KeccakDigest::new(KeccakSize::_256);
+        let mut d = KeccakInternal::new(KeccakSize::_256);
         let m_vec = hex::decode("6d657373616765").unwrap();
         d.absorb(&m_vec);
 
@@ -504,20 +521,20 @@ mod keccak_tests {
     }
 
     /// Regression test for from_serialized_state's validation of a not-yet-squeezing queue: a corrupt
-    /// state whose bits_in_queue is not byte-aligned, or equals the rate, must be rejected as
-    /// InvalidData rather than deserialized into a value that later panics in absorb() /
-    /// pad_and_switch_to_squeezing_phase().
+    /// state whose bits_in_queue is not byte-aligned, or equals/exceeds the rate, must be rejected as
+    /// InvalidData rather than deserialized into a value that later trips the debug_assert in absorb()
+    /// or the pad_and_switch_to_squeezing_phase() invariant.
     #[test]
     fn from_serialized_state_rejects_corrupt_bits_in_queue() {
         let rate = 1600 - ((KeccakSize::_256 as usize) << 1);
 
         // A valid, mid-absorb (not squeezing) serialized state.
-        let mut d = KeccakDigest::new(KeccakSize::_256);
+        let mut d = KeccakInternal::new(KeccakSize::_256);
         d.absorb(b"message");
         assert!(!d.squeezing);
         let mut good = [0u8; KECCAK_SERIALIZED_LEN];
         d.serialize_state(&mut good);
-        assert!(KeccakDigest::from_serialized_state(&good, rate).is_ok());
+        assert!(KeccakInternal::from_serialized_state(&good, rate).is_ok());
 
         // bits_in_queue lives at [392..400) as a little-endian u64 with squeezing at [400].
         assert_eq!(good[400], 0, "test setup expects a non-squeezing state");
@@ -529,7 +546,7 @@ mod keccak_tests {
         let mut corrupt = good;
         set_biq(&mut corrupt, rate as u64 + 8);
         assert!(matches!(
-            KeccakDigest::from_serialized_state(&corrupt, rate),
+            KeccakInternal::from_serialized_state(&corrupt, rate),
             Err(SuspendableError::InvalidData)
         ));
 
@@ -537,16 +554,18 @@ mod keccak_tests {
         let mut corrupt = good;
         set_biq(&mut corrupt, rate as u64);
         assert!(matches!(
-            KeccakDigest::from_serialized_state(&corrupt, rate),
+            KeccakInternal::from_serialized_state(&corrupt, rate),
             Err(SuspendableError::InvalidData)
         ));
 
-        // Not byte-aligned while not squeezing -> rejected (would panic in absorb()).
-        // let mut corrupt = good;
-        // set_biq(&mut corrupt, 9);
-        // assert!(matches!(
-        //     KeccakDigest::from_serialized_state(&corrupt, rate),
-        //     Err(SuspendableError::InvalidData)
-        // ));
+        // Non byte-aligned number of bits in queue -> rejected
+        // (meaning a bits_in_queue which is not a multiple of 8, and only allowed during the absorb_bits,
+        // which may not be called outside of absorb_last_partial_byte(), so is not a valid suspendable state)
+        let mut corrupt = good;
+        set_biq(&mut corrupt, 9);
+        assert!(matches!(
+            KeccakInternal::from_serialized_state(&corrupt, rate),
+            Err(SuspendableError::InvalidData)
+        ));
     }
 }

--- a/crypto/sha3/src/lib.rs
+++ b/crypto/sha3/src/lib.rs
@@ -64,6 +64,10 @@
 //!
 //! As with [Hash] above, the [XOF] trait has streaming APIs in the form of [XOF::absorb] and [XOF::squeeze].
 //! Unlike [Hash::do_final], [XOF::squeeze] can be called multiple times.
+//! Note, however, that once you start squeezing, you can no longer absorb more input -- [SHAKE::absorb]
+//! will throw a [HashError::InvalidState], but the SHAKE object will still be usable for squeezing
+//! as if the erroneous `absorb` call never happened.
+//!
 //! The following code produces the same output as the previous example:
 //!```
 //! use bouncycastle_core::traits::XOF;
@@ -71,7 +75,7 @@
 //!
 //! let data: &[u8] = b"Hello, world!";
 //! let mut shake = sha3::SHAKE128::new();
-//! shake.absorb(data);
+//! shake.absorb(data).expect("infallible before squeeze");
 //! let output_16byte: Vec<u8> = shake.squeeze(16);
 //!
 //! let mut shake = sha3::SHAKE128::new();

--- a/crypto/sha3/src/sha3.rs
+++ b/crypto/sha3/src/sha3.rs
@@ -1,6 +1,6 @@
 use crate::SHA3Params;
 use crate::keccak::{
-    KeccakDigest, SHA3_FAMILY_STATE_LEN, SUSPENDED_SHA3_STATE_LEN, deserialize_sha3_family_state,
+    KeccakInternal, SHA3_FAMILY_STATE_LEN, SUSPENDED_SHA3_STATE_LEN, deserialize_sha3_family_state,
     serialize_sha3_family_state,
 };
 use bouncycastle_core::errors::{HashError, KDFError, SuspendableError};
@@ -16,7 +16,7 @@ use bouncycastle_utils::{max, min};
 #[derive(Clone)]
 pub struct SHA3Internal<PARAMS: SHA3Params> {
     _params: std::marker::PhantomData<PARAMS>,
-    keccak: KeccakDigest,
+    keccak: KeccakInternal,
     kdf_key_type: KeyType,
     kdf_security_strength: SecurityStrength,
     kdf_entropy: usize,
@@ -29,7 +29,7 @@ impl<PARAMS: SHA3Params> SHA3Internal<PARAMS> {
     pub fn new() -> Self {
         Self {
             _params: std::marker::PhantomData,
-            keccak: KeccakDigest::new(PARAMS::SIZE),
+            keccak: KeccakInternal::new(PARAMS::SIZE),
             kdf_key_type: KeyType::Zeroized,
             kdf_security_strength: SecurityStrength::None,
             kdf_entropy: 0,

--- a/crypto/sha3/src/shake.rs
+++ b/crypto/sha3/src/shake.rs
@@ -1,6 +1,6 @@
 use crate::SHAKEParams;
 use crate::keccak::{
-    KeccakDigest, KeccakSize, SHA3_FAMILY_STATE_LEN, SUSPENDED_SHA3_STATE_LEN,
+    KeccakInternal, KeccakSize, SHA3_FAMILY_STATE_LEN, SUSPENDED_SHA3_STATE_LEN,
     deserialize_sha3_family_state, serialize_sha3_family_state,
 };
 use bouncycastle_core::errors::{HashError, KDFError, SuspendableError};
@@ -32,7 +32,7 @@ use bouncycastle_utils::{max, min};
 #[derive(Clone)]
 pub struct SHAKEInternal<PARAMS: SHAKEParams> {
     _phantomdata: core::marker::PhantomData<PARAMS>,
-    keccak: KeccakDigest,
+    keccak: KeccakInternal,
     kdf_key_type: KeyType,
     kdf_security_strength: SecurityStrength,
     kdf_entropy: usize,
@@ -50,7 +50,7 @@ impl<PARAMS: SHAKEParams> SHAKEInternal<PARAMS> {
     pub fn new() -> Self {
         Self {
             _phantomdata: core::marker::PhantomData,
-            keccak: KeccakDigest::new(PARAMS::SIZE),
+            keccak: KeccakInternal::new(PARAMS::SIZE),
             kdf_key_type: KeyType::Zeroized,
             kdf_security_strength: SecurityStrength::None,
             kdf_entropy: 0,
@@ -59,14 +59,16 @@ impl<PARAMS: SHAKEParams> SHAKEInternal<PARAMS> {
 
     /// Swallows errors and simply returns an empty Vec<u8> if the hashes fails for whatever reason.
     fn hash_internal(mut self, data: &[u8], result_len: usize) -> Vec<u8> {
-        self.absorb(data);
+        // Infallible: this is the only absorb, and it precedes the squeeze below.
+        self.absorb(data).expect("absorb precedes squeeze on a fresh SHAKE");
         self.squeeze(result_len)
     }
 
     fn hash_internal_out(mut self, data: &[u8], output: &mut [u8]) -> usize {
         output.fill(0);
 
-        self.absorb(data);
+        // Infallible: this is the only absorb, and it precedes the squeeze below.
+        self.absorb(data).expect("absorb precedes squeeze on a fresh SHAKE");
         self.squeeze_out(output)
     }
 
@@ -86,7 +88,8 @@ impl<PARAMS: SHAKEParams> SHAKEInternal<PARAMS> {
             .clone();
         }
 
-        self.absorb(key.ref_to_bytes())
+        // Infallible: mix_key_internal is only called during the absorb phase, before any squeeze.
+        self.absorb(key.ref_to_bytes()).expect("absorb precedes squeeze during key mixing");
     }
 
     fn derive_key_final_internal(
@@ -123,7 +126,9 @@ impl<PARAMS: SHAKEParams> SHAKEInternal<PARAMS> {
             self.kdf_security_strength = SecurityStrength::None; // BytesLowEntropy can't have a securtiy level.
         }
 
-        self.absorb(additional_input);
+        // Infallible: additional_input is absorbed before the squeeze below, and this method is only
+        // reached during the absorb phase.
+        self.absorb(additional_input).expect("absorb precedes squeeze during key derivation");
 
         let mut bytes_written: usize = 0;
         key_material::do_hazardous_operations(output_key, |output_key| {
@@ -272,8 +277,22 @@ impl<PARAMS: SHAKEParams> XOF for SHAKEInternal<PARAMS> {
         self.hash_internal_out(data, output)
     }
 
-    fn absorb(&mut self, data: &[u8]) {
-        self.keccak.absorb(data)
+    /// This can throw a [HashError::InvalidState] if called after squeezing has begun,
+    /// but is safe to consider infallible otherwise -- IE feel free to use `.unwrap()` or `.expect()`
+    /// on the result if you are confident that your code cannot call `absorb` after squeezing.
+    ///
+    /// A rejected call leaves the SHAKE object untouched so the output stream continues consistently.
+    /// IE it is safe to attempt to feed in more input and do nothing if the absorb fails
+    /// ("safe" in the sense that it won't panic, but it may still produce an incorrect output which
+    /// could be insecure in the sense of being predictable or low-entropy).
+    fn absorb(&mut self, data: &[u8]) -> Result<(), HashError> {
+        // A sponge XOF cannot return to absorbing once squeezing has begun (FIPS 202 defines SHAKE as
+        // a single function of the whole message; re-absorbing would be an unapproved duplex).
+        if self.keccak.squeezing {
+            return Err(HashError::InvalidState("cannot absorb after squeezing has begun"));
+        }
+        self.keccak.absorb(data);
+        Ok(())
     }
 
     /// Switches to squeezing.
@@ -282,6 +301,11 @@ impl<PARAMS: SHAKEParams> XOF for SHAKEInternal<PARAMS> {
         partial_byte: u8,
         num_partial_bits: usize,
     ) -> Result<(), HashError> {
+        // Same phase rule as absorb(): reject a partial-byte absorb once squeezing has begun. Checked
+        // before any state mutation so a rejected call leaves the sponge untouched.
+        if self.keccak.squeezing {
+            return Err(HashError::InvalidState("cannot absorb after squeezing has begun"));
+        }
         if !(1..=7).contains(&num_partial_bits) {
             return Err(HashError::InvalidLength("must be in the range [0,7]"));
         }
@@ -296,6 +320,8 @@ impl<PARAMS: SHAKEParams> XOF for SHAKEInternal<PARAMS> {
             final_input >>= 8;
         }
 
+        // Infallible: guarded above (not squeezing), the queue is byte-aligned here, and final_bits is
+        // in 0..=7 by construction.
         self.keccak.absorb_bits(final_input as u8, final_bits).expect("Absorb failed.");
 
         Ok(())

--- a/crypto/sha3/tests/shake_tests.rs
+++ b/crypto/sha3/tests/shake_tests.rs
@@ -26,7 +26,7 @@ mod shake_tests {
 
         // test bounds
         let mut shake = SHAKE128::new();
-        shake.absorb(&[0u8, 1u8, 2u8, 3u8, 4u8]);
+        shake.absorb(&[0u8, 1u8, 2u8, 3u8, 4u8]).expect("absorb before squeeze is infallible");
         let _throwaway = shake.squeeze(3);
         match shake.squeeze_partial_byte_final(0) {
             Err(_) => { /* good */ }
@@ -36,7 +36,7 @@ mod shake_tests {
         }
 
         let mut shake = SHAKE128::new();
-        shake.absorb(&[0u8, 1u8, 2u8, 3u8, 4u8]);
+        shake.absorb(&[0u8, 1u8, 2u8, 3u8, 4u8]).expect("absorb before squeeze is infallible");
         let _throwaway = shake.squeeze(3);
         match shake.squeeze_partial_byte_final(8) {
             Err(_) => { /* good */ }
@@ -47,7 +47,7 @@ mod shake_tests {
 
         for i in 1..7 {
             let mut shake = SHAKE128::new();
-            shake.absorb(&[0u8, 1u8, 2u8, 3u8, 4u8]);
+            shake.absorb(&[0u8, 1u8, 2u8, 3u8, 4u8]).expect("absorb before squeeze is infallible");
             _ = shake.squeeze(3);
             let out: u8 = shake.squeeze_partial_byte_final(i).expect("Squeeze failed");
             assert_eq!(out, 0xFF >> (8 - i));
@@ -55,11 +55,47 @@ mod shake_tests {
 
         // success case -- output slice version
         let mut shake = SHAKE128::new();
-        shake.absorb(&[0u8, 1u8, 2u8, 3u8, 4u8]);
+        shake.absorb(&[0u8, 1u8, 2u8, 3u8, 4u8]).expect("absorb before squeeze is infallible");
         _ = shake.squeeze(3);
         let mut out = 0u8;
         shake.squeeze_partial_byte_final_out(1, &mut out).expect("Squeeze failed");
         assert_eq!(out, 0x01);
+    }
+
+    /// Once squeezing has begun, a SHAKE cannot return to absorbing (FIPS 202 defines SHAKE as a
+    /// single function of the whole message). Both absorb entry points must reject a post-squeeze call
+    /// with `HashError::InvalidState` rather than panicking, and a rejected call must leave the sponge
+    /// untouched so the output stream continues consistently.
+    #[test]
+    fn absorb_after_squeeze_is_rejected() {
+        use bouncycastle_core::errors::HashError;
+
+        // absorb() after squeeze() -> InvalidState.
+        let mut shake = SHAKE128::new();
+        shake.absorb(b"input").expect("absorb before squeeze is infallible");
+        let _ = shake.squeeze(16);
+        assert!(matches!(shake.absorb(b"more"), Err(HashError::InvalidState(_))));
+
+        // absorb_last_partial_byte() after squeeze() -> InvalidState.
+        let mut shake = SHAKE256::new();
+        shake.absorb(b"input").expect("absorb before squeeze is infallible");
+        let _ = shake.squeeze(16);
+        assert!(matches!(shake.absorb_last_partial_byte(0x01, 3), Err(HashError::InvalidState(_))));
+
+        // A rejected absorb must not corrupt state: the output stream continues as if it never
+        // happened. Squeezing 16 + 16 bytes around a rejected absorb must equal a clean squeeze of 32.
+        let mut a = SHAKE128::new();
+        a.absorb(b"input").expect("absorb before squeeze is infallible");
+        let first = a.squeeze(16);
+        assert!(a.absorb(b"more").is_err());
+        let second = a.squeeze(16);
+
+        let mut b = SHAKE128::new();
+        b.absorb(b"input").expect("absorb before squeeze is infallible");
+        let clean = b.squeeze(32);
+
+        assert_eq!(first.as_slice(), &clean[..16]);
+        assert_eq!(second.as_slice(), &clean[16..]);
     }
 
     #[test]
@@ -248,7 +284,7 @@ mod shake_tests {
 
         // A helper that exercises the full round-trip for one SHAKE variant.
         fn round_trip<const N: usize, X: XOF + Suspendable<N> + Clone>(mut shake: X, input: &[u8]) {
-            shake.absorb(input);
+            shake.absorb(input).expect("absorb before squeeze is infallible");
 
             // do the default trait-conformance tests
             TestFrameworkSuspendableState::new().test(&shake);
@@ -289,7 +325,7 @@ mod shake_tests {
         // variant tag). The SHAKE256 -> SHA3-256 case is the important one: they share the same rate
         // (1088), so only the variant tag distinguishes them.
         let mut shake128 = SHAKE128::new();
-        shake128.absorb(str.as_bytes());
+        shake128.absorb(str.as_bytes()).expect("absorb before squeeze is infallible");
         let serialized_128 = shake128.suspend();
         match SHAKE256::from_suspended(serialized_128) {
             Err(SuspendableError::InvalidData) => { /* good */ }
@@ -297,7 +333,7 @@ mod shake_tests {
         }
 
         let mut shake256 = SHAKE256::new();
-        shake256.absorb(str.as_bytes());
+        shake256.absorb(str.as_bytes()).expect("absorb before squeeze is infallible");
         let serialized_256 = shake256.suspend();
         match SHA3_256::from_suspended(serialized_256) {
             Err(SuspendableError::InvalidData) => { /* good */ }
@@ -324,10 +360,12 @@ mod shake_tests {
         let output: Vec<u8>;
 
         if partial_bits == 0 {
-            shake.absorb(tc.msg.as_slice());
+            shake.absorb(tc.msg.as_slice()).expect("absorb before squeeze is infallible");
             output = shake.squeeze(tc.output.len());
         } else {
-            shake.absorb(&tc.msg[..(tc.msg.len() - 1)]);
+            shake
+                .absorb(&tc.msg[..(tc.msg.len() - 1)])
+                .expect("absorb before squeeze is infallible");
             shake
                 .absorb_last_partial_byte(tc.msg[tc.msg.len() - 1], partial_bits)
                 .expect("Absorb failed");


### PR DESCRIPTION
Upon closer inspection of FIPS 202, SHAKE cannot absorb after squeezing. This commit locks in this behaviour with proper error handling and tests. Also renamed the struct KeccakDigest to KeccakInternal for consistency with other modules.

Closes #27.