### PR TITLE
Replace Factory boilerplate with derive macros

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ bouncycastle-base64 = { path = "./crypto/base64" }
 bouncycastle-core = { path = "crypto/core" }
 bouncycastle-core-test-framework = { path = "./crypto/core-test-framework" }
 bouncycastle-factory = { path = "./crypto/factory" }
+bouncycastle-factory-macros = { path = "./crypto/factory-macros" }
 bouncycastle-hex = { path = "./crypto/hex" }
 bouncycastle-hkdf = { path = "./crypto/hkdf" }
 bouncycastle-hmac = { path = "./crypto/hmac" }

--- a/crypto/factory-macros/Cargo.toml
+++ b/crypto/factory-macros/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "bouncycastle-factory-macros"
+version.workspace = true
+edition.workspace = true
+
+[lib]
+proc-macro = true
+
+[dependencies]
+syn = { version = "2", features = ["full"] }
+quote = "1"
+proc-macro2 = "1"

--- a/crypto/factory-macros/src/factory.rs
+++ b/crypto/factory-macros/src/factory.rs
@@ -1,0 +1,130 @@
+//! Expansion for the `AlgorithmFactory` derive -- see the `AlgorithmFactory` entry point in the
+//! crate root.
+
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::{DataEnum, DeriveInput, Ident, Path, Type};
+
+use crate::{as_data_enum, single_field_type};
+
+/// Generates the `Default` and `crate::AlgorithmFactory` impls from the per-variant
+/// `#[factory(...)]` attributes.
+pub(crate) fn expand(input: &DeriveInput) -> syn::Result<TokenStream> {
+    let enum_name = &input.ident;
+    let variants = parse_factory_variants(as_data_enum(input)?)?;
+
+    let default_128 = variants.iter().find(|v| v.is_default_128_bit);
+    let default_256 = variants.iter().find(|v| v.is_default_256_bit);
+    let (Some(default_128), Some(default_256)) = (default_128, default_256) else {
+        return Err(syn::Error::new_spanned(
+            input,
+            "exactly one variant needs `#[factory(default_128_bit)]` and one needs \
+             `#[factory(default_256_bit)]`",
+        ));
+    };
+    let default_128_ident = &default_128.ident;
+    let default_128_ty = &default_128.ty;
+    let default_256_ident = &default_256.ident;
+    let default_256_ty = &default_256.ty;
+
+    let idents: Vec<&Ident> = variants.iter().map(|v| &v.ident).collect();
+    let tys: Vec<&Type> = variants.iter().map(|v| &v.ty).collect();
+    let name_consts: Vec<&Path> = variants.iter().map(|v| &v.name_const).collect();
+
+    Ok(quote! {
+        impl ::std::default::Default for #enum_name {
+            fn default() -> #enum_name {
+                <#enum_name as crate::AlgorithmFactory>::default_128_bit()
+            }
+        }
+
+        impl crate::AlgorithmFactory for #enum_name {
+            fn default_128_bit() -> #enum_name {
+                Self::#default_128_ident(<#default_128_ty>::new())
+            }
+
+            fn default_256_bit() -> #enum_name {
+                Self::#default_256_ident(<#default_256_ty>::new())
+            }
+
+            fn new(alg_name: &str) -> Result<Self, crate::FactoryError> {
+                match alg_name {
+                    crate::DEFAULT => Ok(<Self as ::std::default::Default>::default()),
+                    crate::DEFAULT_128_BIT => {
+                        Ok(<Self as crate::AlgorithmFactory>::default_128_bit())
+                    }
+                    crate::DEFAULT_256_BIT => {
+                        Ok(<Self as crate::AlgorithmFactory>::default_256_bit())
+                    }
+                    #(#name_consts => Ok(Self::#idents(<#tys>::new())),)*
+                    _ => Err(crate::FactoryError::UnsupportedAlgorithm(format!(
+                        "The algorithm: \"{}\" is not a known {}",
+                        alg_name,
+                        stringify!(#enum_name),
+                    ))),
+                }
+            }
+        }
+    })
+}
+
+/// One enum variant's worth of parsed `#[factory(...)]` configuration.
+struct FactoryVariant {
+    ident: Ident,
+    ty: Type,
+    name_const: Path,
+    is_default_128_bit: bool,
+    is_default_256_bit: bool,
+}
+
+/// Parses the `#[factory(...)]` helper attribute off every variant.
+fn parse_factory_variants(data: &DataEnum) -> syn::Result<Vec<FactoryVariant>> {
+    data.variants
+        .iter()
+        .map(|variant| {
+            let ty = single_field_type(variant)?.clone();
+
+            let mut name_const = None;
+            let mut is_default_128_bit = false;
+            let mut is_default_256_bit = false;
+
+            for attr in &variant.attrs {
+                if !attr.path().is_ident("factory") {
+                    continue;
+                }
+                attr.parse_nested_meta(|meta| {
+                    if meta.path.is_ident("name") {
+                        name_const = Some(meta.value()?.parse::<Path>()?);
+                        Ok(())
+                    } else if meta.path.is_ident("default_128_bit") {
+                        is_default_128_bit = true;
+                        Ok(())
+                    } else if meta.path.is_ident("default_256_bit") {
+                        is_default_256_bit = true;
+                        Ok(())
+                    } else {
+                        Err(meta.error(
+                            "unrecognized `factory` attribute; expected `name`, \
+                             `default_128_bit`, or `default_256_bit`",
+                        ))
+                    }
+                })?;
+            }
+
+            let name_const = name_const.ok_or_else(|| {
+                syn::Error::new_spanned(
+                    variant,
+                    "every variant needs `#[factory(name = ...)]` giving its algorithm-name constant",
+                )
+            })?;
+
+            Ok(FactoryVariant {
+                ident: variant.ident.clone(),
+                ty,
+                name_const,
+                is_default_128_bit,
+                is_default_256_bit,
+            })
+        })
+        .collect()
+}

--- a/crypto/factory-macros/src/hash.rs
+++ b/crypto/factory-macros/src/hash.rs
@@ -1,0 +1,87 @@
+//! Expansion for the `Hash` derive -- see the `Hash` entry point in the crate root.
+
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::{DataEnum, DeriveInput, Ident};
+
+use crate::{as_data_enum, single_field_type};
+
+/// Generates the `bouncycastle_core::traits::Hash` impl, forwarding every trait method to the
+/// wrapped value of whichever variant the enum currently holds.
+pub(crate) fn expand(input: &DeriveInput) -> syn::Result<TokenStream> {
+    let enum_name = &input.ident;
+    let idents = single_field_variant_idents(as_data_enum(input)?)?;
+
+    Ok(quote! {
+        impl ::bouncycastle_core::traits::Hash for #enum_name {
+            fn block_bitlen(&self) -> usize {
+                match self { #(Self::#idents(h) => h.block_bitlen(),)* }
+            }
+
+            fn output_len(&self) -> usize {
+                match self { #(Self::#idents(h) => h.output_len(),)* }
+            }
+
+            fn hash(self, data: &[u8]) -> Vec<u8> {
+                match self { #(Self::#idents(h) => h.hash(data),)* }
+            }
+
+            fn hash_out(self, data: &[u8], output: &mut [u8]) -> usize {
+                output.fill(0);
+                match self { #(Self::#idents(h) => h.hash_out(data, output),)* }
+            }
+
+            fn do_update(&mut self, data: &[u8]) {
+                match self { #(Self::#idents(h) => h.do_update(data),)* }
+            }
+
+            fn do_final(self) -> Vec<u8> {
+                match self { #(Self::#idents(h) => h.do_final(),)* }
+            }
+
+            fn do_final_out(self, output: &mut [u8]) -> usize {
+                output.fill(0);
+                match self { #(Self::#idents(h) => h.do_final_out(output),)* }
+            }
+
+            fn do_final_partial_bits(
+                self,
+                partial_byte: u8,
+                num_partial_bits: usize,
+            ) -> Result<Vec<u8>, ::bouncycastle_core::errors::HashError> {
+                match self {
+                    #(Self::#idents(h) => h.do_final_partial_bits(partial_byte, num_partial_bits),)*
+                }
+            }
+
+            fn do_final_partial_bits_out(
+                self,
+                partial_byte: u8,
+                num_partial_bits: usize,
+                output: &mut [u8],
+            ) -> Result<usize, ::bouncycastle_core::errors::HashError> {
+                match self {
+                    #(Self::#idents(h) => {
+                        h.do_final_partial_bits_out(partial_byte, num_partial_bits, output)
+                    })*
+                }
+            }
+
+            fn max_security_strength(&self) -> ::bouncycastle_core::traits::SecurityStrength {
+                match self { #(Self::#idents(h) => h.max_security_strength(),)* }
+            }
+        }
+    })
+}
+
+/// Collects each variant's ident, rejecting any variant that isn't a single-field tuple since
+/// there would be no unambiguous value to forward the trait methods to.
+fn single_field_variant_idents(data: &DataEnum) -> syn::Result<Vec<Ident>> {
+    data.variants
+        .iter()
+        .map(|v| {
+            single_field_type(v)?;
+            Ok(v.ident.clone())
+        })
+        .collect()
+}

--- a/crypto/factory-macros/src/kdf.rs
+++ b/crypto/factory-macros/src/kdf.rs
@@ -1,0 +1,82 @@
+//! Expansion for the `KDF` derive -- see the `KDF` entry point in the crate root.
+
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::{DataEnum, DeriveInput, Ident};
+
+use crate::{as_data_enum, single_field_type};
+
+/// Generates the `bouncycastle_core::traits::KDF` impl, forwarding every trait method to the
+/// wrapped value of whichever variant the enum currently holds.
+pub(crate) fn expand(input: &DeriveInput) -> syn::Result<TokenStream> {
+    let enum_name = &input.ident;
+    let idents = single_field_variant_idents(as_data_enum(input)?)?;
+
+    Ok(quote! {
+        impl ::bouncycastle_core::traits::KDF for #enum_name {
+            fn derive_key(
+                self,
+                key: &impl ::bouncycastle_core::key_material::KeyMaterialTrait,
+                additional_input: &[u8],
+            ) -> Result<
+                ::std::boxed::Box<dyn ::bouncycastle_core::key_material::KeyMaterialTrait>,
+                ::bouncycastle_core::errors::KDFError,
+            > {
+                match self { #(Self::#idents(h) => h.derive_key(key, additional_input),)* }
+            }
+
+            fn derive_key_out(
+                self,
+                key: &impl ::bouncycastle_core::key_material::KeyMaterialTrait,
+                additional_input: &[u8],
+                output_key: &mut impl ::bouncycastle_core::key_material::KeyMaterialTrait,
+            ) -> Result<usize, ::bouncycastle_core::errors::KDFError> {
+                match self {
+                    #(Self::#idents(h) => h.derive_key_out(key, additional_input, output_key),)*
+                }
+            }
+
+            fn derive_key_from_multiple(
+                self,
+                keys: &[&impl ::bouncycastle_core::key_material::KeyMaterialTrait],
+                additional_input: &[u8],
+            ) -> Result<
+                ::std::boxed::Box<dyn ::bouncycastle_core::key_material::KeyMaterialTrait>,
+                ::bouncycastle_core::errors::KDFError,
+            > {
+                match self {
+                    #(Self::#idents(h) => h.derive_key_from_multiple(keys, additional_input),)*
+                }
+            }
+
+            fn derive_key_from_multiple_out(
+                self,
+                keys: &[&impl ::bouncycastle_core::key_material::KeyMaterialTrait],
+                additional_input: &[u8],
+                output_key: &mut impl ::bouncycastle_core::key_material::KeyMaterialTrait,
+            ) -> Result<usize, ::bouncycastle_core::errors::KDFError> {
+                match self {
+                    #(Self::#idents(h) => {
+                        h.derive_key_from_multiple_out(keys, additional_input, output_key)
+                    })*
+                }
+            }
+
+            fn max_security_strength(&self) -> ::bouncycastle_core::traits::SecurityStrength {
+                match self { #(Self::#idents(h) => h.max_security_strength(),)* }
+            }
+        }
+    })
+}
+
+/// Collects each variant's ident, rejecting any variant that isn't a single-field tuple since
+/// there would be no unambiguous value to forward the trait methods to.
+fn single_field_variant_idents(data: &DataEnum) -> syn::Result<Vec<Ident>> {
+    data.variants
+        .iter()
+        .map(|v| {
+            single_field_type(v)?;
+            Ok(v.ident.clone())
+        })
+        .collect()
+}

--- a/crypto/factory-macros/src/lib.rs
+++ b/crypto/factory-macros/src/lib.rs
@@ -1,0 +1,96 @@
+//! Procedural derive macros that remove per-variant boilerplate from the enum-based algorithm
+//! factories in `bouncycastle-factory` (e.g. `HashFactory`).
+//!
+//! This is a build-time-only proc-macro crate: `syn`/`quote`/`proc-macro2` are used to generate
+//! code at compile time and are not linked into any downstream binary.
+//!
+//! Two derives are provided, meant to be used together on a single-field-tuple-variant enum.
+//! Each shares its name with the trait it implements -- the derive lives in the macro namespace
+//! and the trait in the type namespace, so e.g. `#[derive(Hash)]` and
+//! `impl bouncycastle_core::traits::Hash for X` don't collide, the same way `serde::Serialize`
+//! names both a trait and its derive:
+//!
+//! - [`macro@Hash`] generates the `bouncycastle_core::traits::Hash` trait impl, forwarding every
+//!   method to whichever variant the enum currently holds.
+//! - [`macro@AlgorithmFactory`] generates `Default` and `crate::AlgorithmFactory` trait impls
+//!   (`new`/`default_128_bit`/`default_256_bit`), reading each variant's algorithm-name constant
+//!   and default-security-level markers from a `#[factory(...)]` helper attribute.
+//!
+//! # Usage Examples
+//!
+//! ```ignore
+//! #[derive(Hash, AlgorithmFactory)]
+//! pub enum HashFactory {
+//!     #[factory(name = SHA224_NAME)]
+//!     SHA224(sha2::SHA224),
+//!     #[factory(name = SHA3_256_NAME, default_128_bit)]
+//!     SHA3_256(sha3::SHA3_256),
+//!     #[factory(name = SHA3_512_NAME, default_256_bit)]
+//!     SHA3_512(sha3::SHA3_512),
+//! }
+//! ```
+//!
+//! # Layout
+//!
+//! `#[proc_macro_derive]` functions have to live at the crate root, so this file holds only the
+//! entry points and the parsing helpers both derives share; each derive's expansion lives in its
+//! own module (`hash`, `factory`).
+
+#![forbid(unsafe_code)]
+#![forbid(missing_docs)]
+
+mod factory;
+mod hash;
+
+use proc_macro::TokenStream;
+use syn::{Data, DataEnum, DeriveInput, Fields, Type, parse_macro_input};
+
+/// Derives `bouncycastle_core::traits::Hash` for an enum whose variants are each a single-field
+/// tuple wrapping a type that itself implements that trait. Every method is forwarded to the
+/// wrapped variant, so adding a new algorithm only requires adding an enum variant -- no match
+/// arms to update by hand.
+#[proc_macro_derive(Hash, attributes(factory))]
+pub fn derive_hash(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    hash::expand(&input).unwrap_or_else(syn::Error::into_compile_error).into()
+}
+
+/// Derives `Default` and `AlgorithmFactory` (`new`/`default_128_bit`/`default_256_bit`) for an
+/// enum whose variants are each a single-field tuple, using a `#[factory(...)]` helper attribute
+/// on each variant to supply:
+///
+/// - `name = SOME_NAME_CONST` (required) -- the string constant `AlgorithmFactory::new` matches
+///   on to construct that variant.
+/// - `default_128_bit` / `default_256_bit` (each required on exactly one variant) -- marks which
+///   variant `default_128_bit()`/`default_256_bit()` construct.
+///
+/// Generated code refers to `AlgorithmFactory`/`FactoryError`/`DEFAULT*` via `crate::`, so this
+/// derive is only meant to be used on enums defined inside the `bouncycastle-factory` crate
+/// itself.
+#[proc_macro_derive(AlgorithmFactory, attributes(factory))]
+pub fn derive_algorithm_factory(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    factory::expand(&input).unwrap_or_else(syn::Error::into_compile_error).into()
+}
+
+/// Both derives only make sense on enums; anything else gets a pointed error rather than a
+/// confusing failure from deeper in the expansion.
+fn as_data_enum(input: &DeriveInput) -> syn::Result<&DataEnum> {
+    match &input.data {
+        Data::Enum(data) => Ok(data),
+        _ => Err(syn::Error::new_spanned(input, "this derive only supports enums")),
+    }
+}
+
+/// The wrapped type of a single-field tuple variant, which is the value both derives forward to.
+fn single_field_type(variant: &syn::Variant) -> syn::Result<&Type> {
+    match &variant.fields {
+        Fields::Unnamed(fields) if fields.unnamed.len() == 1 => {
+            Ok(&fields.unnamed.first().expect("just checked len == 1").ty)
+        }
+        _ => Err(syn::Error::new_spanned(
+            variant,
+            "expected a single-field tuple variant, e.g. `Variant(SomeType)`",
+        )),
+    }
+}

--- a/crypto/factory-macros/src/lib.rs
+++ b/crypto/factory-macros/src/lib.rs
@@ -12,6 +12,8 @@
 //!
 //! - [`macro@Hash`] generates the `bouncycastle_core::traits::Hash` trait impl, forwarding every
 //!   method to whichever variant the enum currently holds.
+//! - [`macro@KDF`] generates the `bouncycastle_core::traits::KDF` trait impl, forwarding every
+//!   method to whichever variant the enum currently holds.
 //! - [`macro@AlgorithmFactory`] generates `Default` and `crate::AlgorithmFactory` trait impls
 //!   (`new`/`default_128_bit`/`default_256_bit`), reading each variant's algorithm-name constant
 //!   and default-security-level markers from a `#[factory(...)]` helper attribute.
@@ -41,6 +43,7 @@
 
 mod factory;
 mod hash;
+mod kdf;
 
 use proc_macro::TokenStream;
 use syn::{Data, DataEnum, DeriveInput, Fields, Type, parse_macro_input};
@@ -53,6 +56,16 @@ use syn::{Data, DataEnum, DeriveInput, Fields, Type, parse_macro_input};
 pub fn derive_hash(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
     hash::expand(&input).unwrap_or_else(syn::Error::into_compile_error).into()
+}
+
+/// Derives `bouncycastle_core::traits::KDF` for an enum whose variants are each a single-field
+/// tuple wrapping a type that itself implements that trait. Every method is forwarded to the
+/// wrapped variant, so adding a new algorithm only requires adding an enum variant -- no match
+/// arms to update by hand.
+#[proc_macro_derive(KDF, attributes(factory))]
+pub fn derive_kdf(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    kdf::expand(&input).unwrap_or_else(syn::Error::into_compile_error).into()
 }
 
 /// Derives `Default` and `AlgorithmFactory` (`new`/`default_128_bit`/`default_256_bit`) for an

--- a/crypto/factory/Cargo.toml
+++ b/crypto/factory/Cargo.toml
@@ -5,6 +5,7 @@ edition.workspace = true
 
 [dependencies]
 bouncycastle-core.workspace = true
+bouncycastle-factory-macros.workspace = true
 bouncycastle-hkdf.workspace = true
 bouncycastle-hmac.workspace = true
 bouncycastle-sha2.workspace = true

--- a/crypto/factory/src/hash_factory.rs
+++ b/crypto/factory/src/hash_factory.rs
@@ -1,7 +1,9 @@
-//! Hash factory for creating instances of algorithms that implement the [`Hash`] trait.
+//! Hash factory for creating instances of algorithms that implement the
+//! [`bouncycastle_core::traits::Hash`] trait.
 //!
 //! As with all Factory objects, this implements constructions from strings and defaults, and
-//! returns a [`HashFactory`] object which itself implements the [`Hash`] trait as a pass-through to the underlying algorithm.
+//! returns a [`HashFactory`] object which itself implements the [`bouncycastle_core::traits::Hash`]
+//! trait as a pass-through to the underlying algorithm.
 //!
 //! Example usage:
 //! ```
@@ -26,70 +28,40 @@
 //! let output: Vec<u8> = h.hash(data);
 //! ```
 
-use crate::{AlgorithmFactory, FactoryError};
-use crate::{DEFAULT, DEFAULT_128_BIT, DEFAULT_256_BIT};
-use bouncycastle_core::errors::HashError;
-use bouncycastle_core::traits::{Algorithm, Hash, SecurityStrength};
+use bouncycastle_core::traits::{Algorithm, SecurityStrength};
+use bouncycastle_factory_macros::{AlgorithmFactory, Hash};
 use bouncycastle_sha2 as sha2;
-use bouncycastle_sha2::{SHA224_NAME, SHA256_NAME, SHA384_NAME, SHA512_NAME};
 use bouncycastle_sha3 as sha3;
-use bouncycastle_sha3::{SHA3_224_NAME, SHA3_256_NAME, SHA3_384_NAME, SHA3_512_NAME};
 
-/// Wrapper object for all algorithms that impl [`Hash`].
+/// Wrapper object for all algorithms that impl [`bouncycastle_core::traits::Hash`].
 /// Note: no SHAKE because SHAKE is not NIST approved as a hash function. See FIPS 202 section A.2.
+#[derive(Hash, AlgorithmFactory)]
 #[non_exhaustive]
 pub enum HashFactory {
     ///
+    #[factory(name = sha2::SHA224_NAME)]
     SHA224(sha2::SHA224),
     ///
+    #[factory(name = sha2::SHA256_NAME)]
     SHA256(sha2::SHA256),
     ///
+    #[factory(name = sha2::SHA384_NAME)]
     SHA384(sha2::SHA384),
     ///
+    #[factory(name = sha2::SHA512_NAME)]
     SHA512(sha2::SHA512),
     ///
+    #[factory(name = sha3::SHA3_224_NAME)]
     SHA3_224(sha3::SHA3_224),
     ///
+    #[factory(name = sha3::SHA3_256_NAME, default_128_bit)]
     SHA3_256(sha3::SHA3_256),
     ///
+    #[factory(name = sha3::SHA3_384_NAME)]
     SHA3_384(sha3::SHA3_384),
     ///
+    #[factory(name = sha3::SHA3_512_NAME, default_256_bit)]
     SHA3_512(sha3::SHA3_512),
-}
-
-impl Default for HashFactory {
-    fn default() -> HashFactory {
-        Self::SHA3_256(sha3::SHA3_256::new())
-    }
-}
-
-impl AlgorithmFactory for HashFactory {
-    fn default_128_bit() -> HashFactory {
-        Self::SHA3_256(sha3::SHA3_256::new())
-    }
-    fn default_256_bit() -> HashFactory {
-        Self::SHA3_512(sha3::SHA3_512::new())
-    }
-
-    fn new(alg_name: &str) -> Result<Self, FactoryError> {
-        match alg_name {
-            DEFAULT => Ok(Self::default()),
-            DEFAULT_128_BIT => Ok(Self::default_128_bit()),
-            DEFAULT_256_BIT => Ok(Self::default_256_bit()),
-            SHA224_NAME => Ok(Self::SHA224(sha2::SHA224::new())),
-            SHA256_NAME => Ok(Self::SHA256(sha2::SHA256::new())),
-            SHA384_NAME => Ok(Self::SHA384(sha2::SHA384::new())),
-            SHA512_NAME => Ok(Self::SHA512(sha2::SHA512::new())),
-            SHA3_224_NAME => Ok(Self::SHA3_224(sha3::SHA3_224::new())),
-            SHA3_256_NAME => Ok(Self::SHA3_256(sha3::SHA3_256::new())),
-            SHA3_384_NAME => Ok(Self::SHA3_384(sha3::SHA3_384::new())),
-            SHA3_512_NAME => Ok(Self::SHA3_512(sha3::SHA3_512::new())),
-            _ => Err(FactoryError::UnsupportedAlgorithm(format!(
-                "The algorithm: \"{}\" is not a known Hash",
-                alg_name
-            ))),
-        }
-    }
 }
 
 // TODO -- this is broken.
@@ -99,157 +71,4 @@ impl AlgorithmFactory for HashFactory {
 impl Algorithm for HashFactory {
     const ALG_NAME: &'static str = "TODO";
     const MAX_SECURITY_STRENGTH: SecurityStrength = SecurityStrength::None;
-}
-
-impl Hash for HashFactory {
-    fn block_bitlen(&self) -> usize {
-        match self {
-            Self::SHA224(h) => h.block_bitlen(),
-            Self::SHA256(h) => h.block_bitlen(),
-            Self::SHA384(h) => h.block_bitlen(),
-            Self::SHA512(h) => h.block_bitlen(),
-            Self::SHA3_224(h) => h.block_bitlen(),
-            Self::SHA3_256(h) => h.block_bitlen(),
-            Self::SHA3_384(h) => h.block_bitlen(),
-            Self::SHA3_512(h) => h.block_bitlen(),
-        }
-    }
-
-    fn output_len(&self) -> usize {
-        match self {
-            Self::SHA224(h) => h.output_len(),
-            Self::SHA256(h) => h.output_len(),
-            Self::SHA384(h) => h.output_len(),
-            Self::SHA512(h) => h.output_len(),
-            Self::SHA3_224(h) => h.output_len(),
-            Self::SHA3_256(h) => h.output_len(),
-            Self::SHA3_384(h) => h.output_len(),
-            Self::SHA3_512(h) => h.output_len(),
-        }
-    }
-
-    fn hash(self, data: &[u8]) -> Vec<u8> {
-        match self {
-            Self::SHA224(h) => h.hash(data),
-            Self::SHA256(h) => h.hash(data),
-            Self::SHA384(h) => h.hash(data),
-            Self::SHA512(h) => h.hash(data),
-            Self::SHA3_224(h) => h.hash(data),
-            Self::SHA3_256(h) => h.hash(data),
-            Self::SHA3_384(h) => h.hash(data),
-            Self::SHA3_512(h) => h.hash(data),
-        }
-    }
-
-    fn hash_out(self, data: &[u8], output: &mut [u8]) -> usize {
-        output.fill(0);
-
-        match self {
-            Self::SHA224(h) => h.hash_out(data, output),
-            Self::SHA256(h) => h.hash_out(data, output),
-            Self::SHA384(h) => h.hash_out(data, output),
-            Self::SHA512(h) => h.hash_out(data, output),
-            Self::SHA3_224(h) => h.hash_out(data, output),
-            Self::SHA3_256(h) => h.hash_out(data, output),
-            Self::SHA3_384(h) => h.hash_out(data, output),
-            Self::SHA3_512(h) => h.hash_out(data, output),
-        }
-    }
-
-    fn do_update(&mut self, data: &[u8]) {
-        match self {
-            Self::SHA224(h) => h.do_update(data),
-            Self::SHA256(h) => h.do_update(data),
-            Self::SHA384(h) => h.do_update(data),
-            Self::SHA512(h) => h.do_update(data),
-            Self::SHA3_224(h) => h.do_update(data),
-            Self::SHA3_256(h) => h.do_update(data),
-            Self::SHA3_384(h) => h.do_update(data),
-            Self::SHA3_512(h) => h.do_update(data),
-        }
-    }
-
-    fn do_final(self) -> Vec<u8> {
-        match self {
-            Self::SHA224(h) => h.do_final(),
-            Self::SHA256(h) => h.do_final(),
-            Self::SHA384(h) => h.do_final(),
-            Self::SHA512(h) => h.do_final(),
-            Self::SHA3_224(h) => h.do_final(),
-            Self::SHA3_256(h) => h.do_final(),
-            Self::SHA3_384(h) => h.do_final(),
-            Self::SHA3_512(h) => h.do_final(),
-        }
-    }
-
-    fn do_final_out(self, output: &mut [u8]) -> usize {
-        output.fill(0);
-
-        match self {
-            Self::SHA224(h) => h.do_final_out(output),
-            Self::SHA256(h) => h.do_final_out(output),
-            Self::SHA384(h) => h.do_final_out(output),
-            Self::SHA512(h) => h.do_final_out(output),
-            Self::SHA3_224(h) => h.do_final_out(output),
-            Self::SHA3_256(h) => h.do_final_out(output),
-            Self::SHA3_384(h) => h.do_final_out(output),
-            Self::SHA3_512(h) => h.do_final_out(output),
-        }
-    }
-
-    fn do_final_partial_bits(
-        self,
-        partial_byte: u8,
-        num_partial_bits: usize,
-    ) -> Result<Vec<u8>, HashError> {
-        match self {
-            Self::SHA224(h) => h.do_final_partial_bits(partial_byte, num_partial_bits),
-            Self::SHA256(h) => h.do_final_partial_bits(partial_byte, num_partial_bits),
-            Self::SHA384(h) => h.do_final_partial_bits(partial_byte, num_partial_bits),
-            Self::SHA512(h) => h.do_final_partial_bits(partial_byte, num_partial_bits),
-            Self::SHA3_224(h) => h.do_final_partial_bits(partial_byte, num_partial_bits),
-            Self::SHA3_256(h) => h.do_final_partial_bits(partial_byte, num_partial_bits),
-            Self::SHA3_384(h) => h.do_final_partial_bits(partial_byte, num_partial_bits),
-            Self::SHA3_512(h) => h.do_final_partial_bits(partial_byte, num_partial_bits),
-        }
-    }
-
-    fn do_final_partial_bits_out(
-        self,
-        partial_byte: u8,
-        num_partial_bits: usize,
-        output: &mut [u8],
-    ) -> Result<usize, HashError> {
-        match self {
-            Self::SHA224(h) => h.do_final_partial_bits_out(partial_byte, num_partial_bits, output),
-            Self::SHA256(h) => h.do_final_partial_bits_out(partial_byte, num_partial_bits, output),
-            Self::SHA384(h) => h.do_final_partial_bits_out(partial_byte, num_partial_bits, output),
-            Self::SHA512(h) => h.do_final_partial_bits_out(partial_byte, num_partial_bits, output),
-            Self::SHA3_224(h) => {
-                h.do_final_partial_bits_out(partial_byte, num_partial_bits, output)
-            }
-            Self::SHA3_256(h) => {
-                h.do_final_partial_bits_out(partial_byte, num_partial_bits, output)
-            }
-            Self::SHA3_384(h) => {
-                h.do_final_partial_bits_out(partial_byte, num_partial_bits, output)
-            }
-            Self::SHA3_512(h) => {
-                h.do_final_partial_bits_out(partial_byte, num_partial_bits, output)
-            }
-        }
-    }
-
-    fn max_security_strength(&self) -> SecurityStrength {
-        match self {
-            Self::SHA224(h) => h.max_security_strength(),
-            Self::SHA256(h) => h.max_security_strength(),
-            Self::SHA384(h) => h.max_security_strength(),
-            Self::SHA512(h) => h.max_security_strength(),
-            Self::SHA3_224(h) => h.max_security_strength(),
-            Self::SHA3_256(h) => h.max_security_strength(),
-            Self::SHA3_384(h) => h.max_security_strength(),
-            Self::SHA3_512(h) => h.max_security_strength(),
-        }
-    }
 }

--- a/crypto/factory/src/kdf_factory.rs
+++ b/crypto/factory/src/kdf_factory.rs
@@ -47,161 +47,38 @@
 //! let new_key = h.derive_key(&seed_key, additional_input).unwrap();
 //! ```
 
-use crate::{AlgorithmFactory, DEFAULT, DEFAULT_128_BIT, DEFAULT_256_BIT, FactoryError};
-use bouncycastle_core::errors::KDFError;
-use bouncycastle_core::key_material::KeyMaterialTrait;
-use bouncycastle_core::traits::{KDF, SecurityStrength};
+use bouncycastle_factory_macros::{AlgorithmFactory, KDF};
 use bouncycastle_hkdf as hkdf;
-use bouncycastle_hkdf::{HKDF_SHA256_NAME, HKDF_SHA512_NAME};
 use bouncycastle_sha3 as sha3;
-use bouncycastle_sha3::{
-    SHA3_224_NAME, SHA3_256_NAME, SHA3_384_NAME, SHA3_512_NAME, SHAKE128_NAME, SHAKE256_NAME,
-};
 
 /// Wrapper object for all algorithms that impl [`KDF`].
+#[derive(KDF, AlgorithmFactory)]
 #[non_exhaustive]
 pub enum KDFFactory {
     ///
     #[allow(non_camel_case_types)]
+    #[factory(name = hkdf::HKDF_SHA256_NAME, default_128_bit)]
     HKDF_SHA256(hkdf::HKDF_SHA256),
     ///
+    #[factory(name = hkdf::HKDF_SHA512_NAME, default_256_bit)]
     #[allow(non_camel_case_types)]
     HKDF_SHA512(hkdf::HKDF_SHA512),
     ///
+    #[factory(name = sha3::SHA3_224_NAME)]
     SHA3_224(sha3::SHA3_224),
     ///
+    #[factory(name = sha3::SHA3_256_NAME)]
     SHA3_256(sha3::SHA3_256),
     ///
+    #[factory(name = sha3::SHA3_384_NAME)]
     SHA3_384(sha3::SHA3_384),
     ///
+    #[factory(name = sha3::SHA3_512_NAME)]
     SHA3_512(sha3::SHA3_512),
     ///
+    #[factory(name = sha3::SHAKE128_NAME)]
     SHAKE128(sha3::SHAKE128),
     ///
+    #[factory(name = sha3::SHAKE256_NAME)]
     SHAKE256(sha3::SHAKE256),
-}
-
-impl Default for KDFFactory {
-    fn default() -> Self {
-        Self::HKDF_SHA512(hkdf::HKDF_SHA512::new())
-    }
-}
-
-impl AlgorithmFactory for KDFFactory {
-    fn default_128_bit() -> Self {
-        Self::HKDF_SHA256(hkdf::HKDF_SHA256::new())
-    }
-
-    fn default_256_bit() -> Self {
-        Self::HKDF_SHA512(hkdf::HKDF_SHA512::new())
-    }
-
-    fn new(alg_name: &str) -> Result<Self, FactoryError> {
-        match alg_name {
-            DEFAULT => Ok(KDFFactory::default()),
-            DEFAULT_128_BIT => Ok(KDFFactory::default_128_bit()),
-            DEFAULT_256_BIT => Ok(KDFFactory::default_256_bit()),
-            HKDF_SHA256_NAME => Ok(Self::HKDF_SHA256(hkdf::HKDF_SHA256::new())),
-            HKDF_SHA512_NAME => Ok(Self::HKDF_SHA512(hkdf::HKDF_SHA512::new())),
-            SHA3_224_NAME => Ok(Self::SHA3_224(sha3::SHA3_224::new())),
-            SHA3_256_NAME => Ok(Self::SHA3_256(sha3::SHA3_256::new())),
-            SHA3_384_NAME => Ok(Self::SHA3_384(sha3::SHA3_384::new())),
-            SHA3_512_NAME => Ok(Self::SHA3_512(sha3::SHA3_512::new())),
-            SHAKE128_NAME => Ok(Self::SHAKE128(sha3::SHAKE128::new())),
-            SHAKE256_NAME => Ok(Self::SHAKE256(sha3::SHAKE256::new())),
-            _ => Err(FactoryError::UnsupportedAlgorithm(format!(
-                "The algorithm: \"{}\" is not a known KDF",
-                alg_name
-            ))),
-        }
-    }
-}
-
-impl KDF for KDFFactory {
-    fn derive_key(
-        self,
-        key: &impl KeyMaterialTrait,
-        additional_input: &[u8],
-    ) -> Result<Box<dyn KeyMaterialTrait>, KDFError> {
-        match self {
-            Self::HKDF_SHA256(h) => h.derive_key(key, additional_input),
-            Self::HKDF_SHA512(h) => h.derive_key(key, additional_input),
-            Self::SHA3_224(h) => h.derive_key(key, additional_input),
-            Self::SHA3_256(h) => h.derive_key(key, additional_input),
-            Self::SHA3_384(h) => h.derive_key(key, additional_input),
-            Self::SHA3_512(h) => h.derive_key(key, additional_input),
-            Self::SHAKE128(h) => h.derive_key(key, additional_input),
-            Self::SHAKE256(h) => h.derive_key(key, additional_input),
-        }
-    }
-
-    fn derive_key_out(
-        self,
-        key: &impl KeyMaterialTrait,
-        additional_input: &[u8],
-        output_key: &mut impl KeyMaterialTrait,
-    ) -> Result<usize, KDFError> {
-        match self {
-            Self::HKDF_SHA256(h) => h.derive_key_out(key, additional_input, output_key),
-            Self::HKDF_SHA512(h) => h.derive_key_out(key, additional_input, output_key),
-            Self::SHA3_224(h) => h.derive_key_out(key, additional_input, output_key),
-            Self::SHA3_256(h) => h.derive_key_out(key, additional_input, output_key),
-            Self::SHA3_384(h) => h.derive_key_out(key, additional_input, output_key),
-            Self::SHA3_512(h) => h.derive_key_out(key, additional_input, output_key),
-            Self::SHAKE128(h) => h.derive_key_out(key, additional_input, output_key),
-            Self::SHAKE256(h) => h.derive_key_out(key, additional_input, output_key),
-        }
-    }
-
-    fn derive_key_from_multiple(
-        self,
-        keys: &[&impl KeyMaterialTrait],
-        additional_input: &[u8],
-    ) -> Result<Box<dyn KeyMaterialTrait>, KDFError> {
-        match self {
-            Self::HKDF_SHA256(h) => h.derive_key_from_multiple(keys, additional_input),
-            Self::HKDF_SHA512(h) => h.derive_key_from_multiple(keys, additional_input),
-            Self::SHA3_224(h) => h.derive_key_from_multiple(keys, additional_input),
-            Self::SHA3_256(h) => h.derive_key_from_multiple(keys, additional_input),
-            Self::SHA3_384(h) => h.derive_key_from_multiple(keys, additional_input),
-            Self::SHA3_512(h) => h.derive_key_from_multiple(keys, additional_input),
-            Self::SHAKE128(h) => h.derive_key_from_multiple(keys, additional_input),
-            Self::SHAKE256(h) => h.derive_key_from_multiple(keys, additional_input),
-        }
-    }
-
-    fn derive_key_from_multiple_out(
-        self,
-        keys: &[&impl KeyMaterialTrait],
-        additional_input: &[u8],
-        output_key: &mut impl KeyMaterialTrait,
-    ) -> Result<usize, KDFError> {
-        match self {
-            Self::HKDF_SHA256(h) => {
-                h.derive_key_from_multiple_out(keys, additional_input, output_key)
-            }
-            Self::HKDF_SHA512(h) => {
-                h.derive_key_from_multiple_out(keys, additional_input, output_key)
-            }
-            Self::SHA3_224(h) => h.derive_key_from_multiple_out(keys, additional_input, output_key),
-            Self::SHA3_256(h) => h.derive_key_from_multiple_out(keys, additional_input, output_key),
-            Self::SHA3_384(h) => h.derive_key_from_multiple_out(keys, additional_input, output_key),
-            Self::SHA3_512(h) => h.derive_key_from_multiple_out(keys, additional_input, output_key),
-            Self::SHAKE128(h) => h.derive_key_from_multiple_out(keys, additional_input, output_key),
-            Self::SHAKE256(h) => h.derive_key_from_multiple_out(keys, additional_input, output_key),
-        }
-    }
-
-    fn max_security_strength(&self) -> SecurityStrength {
-        match self {
-            Self::HKDF_SHA256(h) => h.max_security_strength(),
-            Self::HKDF_SHA512(h) => h.max_security_strength(),
-            Self::SHA3_224(h) => h.max_security_strength(),
-            Self::SHA3_256(h) => h.max_security_strength(),
-            Self::SHA3_384(h) => h.max_security_strength(),
-            Self::SHA3_512(h) => h.max_security_strength(),
-            Self::SHAKE128(h) => h.max_security_strength(),
-            Self::SHAKE256(h) => h.max_security_strength(),
-        }
-    }
 }


### PR DESCRIPTION
HashFactory hand-wrote an 8-arm match for each of the 10 Hash trait methods plus the string-name lookup in AlgorithmFactory::new, so adding an algorithm meant touching a dozen places. Add a bouncycastle-factory-macros crate providing two derives that generate all of it:

  * Hash             - the Hash impl, forwarding every method to the
                       variant currently held.
  * AlgorithmFactory - Default and AlgorithmFactory (new, default_128_bit,
                       default_256_bit), driven by a #[factory(name = ...)]
                       helper attribute on each variant.

Adding an algorithm is now one variant plus one attribute. hash_factory.rs drops from 254 to 79 lines with no behaviour change; existing tests and doctests cover the generated code.

Each derive is named after the trait it implements - derives live in the macro namespace and traits in the type namespace, so they don't collide (same convention as serde::Serialize).

Also marks HashFactory #[non_exhaustive] so future variants are additive rather than breaking for downstream matches

Fixes: https://github.com/bcgit/bc-rust/issues/66