### PR TITLE
Sha3 final patches

### DIFF
--- a/crypto/core/src/traits.rs
+++ b/crypto/core/src/traits.rs
@@ -1083,8 +1083,11 @@ pub trait XOF: Default {
     /// The entire output buffer is zeroized before the output is written.
     fn squeeze_out(&mut self, output: &mut [u8]) -> usize;
 
-    /// Squeezes a partial byte from the XOF.
-    /// Output will be in the top `num_bits` bits of the returned u8 (ie Big Endian).
+    /// Squeezes a partial byte (`num_bits` in `1..=7`) from the XOF.
+    /// The bits are returned in the least significant `num_bits` bits of the returned u8, with the
+    /// remaining high bits zero. This follows the FIPS 202 Appendix B.1 bit-string convention
+    /// (the first bit of a byte is its least significant bit) and matches the input convention of
+    /// [`XOF::absorb_last_partial_byte`].
     /// This is a final call and consumes self.
     fn squeeze_partial_byte_final(self, num_bits: usize) -> Result<u8, HashError>;
 

--- a/crypto/sha3/src/keccak.rs
+++ b/crypto/sha3/src/keccak.rs
@@ -500,18 +500,36 @@ mod keccak_tests {
     use super::*;
     use bouncycastle_hex as hex;
 
+    /// Basic sponge sanity: absorbing in one chunk or many gives the same output, successive
+    /// squeezes continue the stream (do not repeat), and different capacities give different output.
     #[test]
     fn test_keccak() {
-        let mut d = KeccakInternal::new(KeccakSize::_256);
         let m_vec = hex::decode("6d657373616765").unwrap();
+
+        let mut d = KeccakInternal::new(KeccakSize::_256);
         d.absorb(&m_vec);
+        let mut out1 = [0u8; 32];
+        d.squeeze(&mut out1);
+        let mut out2 = [0u8; 32];
+        d.squeeze(&mut out2);
+        assert_ne!(out1, [0u8; 32]);
+        assert_ne!(out1, out2, "successive squeezes must continue the output stream");
 
-        let mut out = [0u8; 32];
-        d.squeeze(&mut out);
-        println!("n1: {:x?}", &out);
+        // chunked absorb + single 64-byte squeeze must reproduce out1 || out2
+        let mut d = KeccakInternal::new(KeccakSize::_256);
+        for b in &m_vec {
+            d.absorb(core::slice::from_ref(b));
+        }
+        let mut out64 = [0u8; 64];
+        d.squeeze(&mut out64);
+        assert_eq!(&out64[..32], &out1);
+        assert_eq!(&out64[32..], &out2);
 
-        d.squeeze(&mut out);
-        println!("n2: {:x?}", &out);
+        let mut d = KeccakInternal::new(KeccakSize::_512);
+        d.absorb(&m_vec);
+        let mut out_c512 = [0u8; 32];
+        d.squeeze(&mut out_c512);
+        assert_ne!(out_c512, out1);
     }
 
     /// Regression test for from_serialized_state's validation of a not-yet-squeezing queue: a corrupt

--- a/crypto/sha3/src/lib.rs
+++ b/crypto/sha3/src/lib.rs
@@ -89,7 +89,7 @@
 //! [`KDF`] acts on [`KeyMaterial`] objects as both the input and output values.
 //! In the case of SHA3, the [`KDF`] interfaces are simple wrapper functions around the underlying SHA3 or SHAKE
 //! primitive that correctly maintains the length and entropy metadata of the key material that it is acting on.
-//! This is intended to act as a developer ait to prevent  some classes of developer mistakes, such as
+//! This is intended to act as a developer aid to prevent some classes of developer mistakes, such as
 //! deriving a cryptographic key from uninitialized (aka zeroized) input key material, or using low-entropy
 //! input key material to derive a MAC, symmetric, or asymmetric key.
 //!
@@ -107,6 +107,37 @@
 //! This would also be the case even if the input had type
 //! [`KeyType::CryptographicRandom`] since the input [`KeyMaterial`] is 16 bytes but [`SHA3_256`] needs at least 32 bytes of
 //! full-entropy input key material in order to be able to produce full entropy output key material.
+//!
+//! # Memory Usage
+//!
+//! All SHA3 and SHAKE variants share the same Keccak-f\[1600\] sponge and so have identical memory
+//! footprints. No heap memory is used by the algorithms themselves; the `Vec<u8>`-returning
+//! convenience methods allocate only the output buffer, and the `*_out` variants allocate nothing.
+//!
+//! | Object                                  | Size (bytes) |
+//! |-----------------------------------------|--------------|
+//! | `SHA3_224` .. `SHA3_512`, `SHAKE128/256` | 440          |
+//! | Suspended state ([`Suspendable`])       | 415          |
+//!
+//! The object size is dominated by the 200-byte sponge state and a 192-byte input/output queue.
+//! The Keccak permutation itself runs on 25 `u64` locals plus a handful of temporaries, so transient
+//! stack usage per call is on the order of a few hundred bytes beyond the object.
+//!
+//! # Security Considerations
+//!
+//! * SHA3-224/256/384/512 offer 112/128/192/256 bits of collision resistance respectively; SHAKE128
+//!   and SHAKE256 offer 128 and 256 bits of security for output lengths at least twice that size
+//!   (FIPS 202 Appendix A.1).
+//! * SHAKE is an XOF, not a hash: `SHAKE128(m, 32)` is a prefix of `SHAKE128(m, 64)`. If the output
+//!   length must be bound to the digest, include it in the message (FIPS 202 Appendix A.2). For this
+//!   reason SHAKE does not implement [`Hash`].
+//! * Once squeezing begins, no further input can be absorbed; [`XOF::absorb`] returns
+//!   [`HashError::InvalidState`] rather than silently producing an unapproved construction.
+//! * The sponge state and queue are held in [`bouncycastle_utils::secret::Secret`] and zeroized on
+//!   drop. Transient copies in registers/stack locals during the permutation are not zeroized.
+//! * The implementation contains no data-dependent branches or table lookups.
+//! * The [`KDF`] entropy tracking is a developer aid, not a security proof: it can only reason about
+//!   the metadata attached to [`KeyMaterial`] inputs.
 //!
 //! # Suspending and resuming execution
 //!
@@ -160,17 +191,17 @@ mod sha3;
 mod shake;
 
 /*** String constants ***/
-///
+/// Algorithm name string for SHA3-224, as used by the factories and CLI.
 pub const SHA3_224_NAME: &str = "SHA3-224";
-///
+/// Algorithm name string for SHA3-256, as used by the factories and CLI.
 pub const SHA3_256_NAME: &str = "SHA3-256";
-///
+/// Algorithm name string for SHA3-384, as used by the factories and CLI.
 pub const SHA3_384_NAME: &str = "SHA3-384";
-///
+/// Algorithm name string for SHA3-512, as used by the factories and CLI.
 pub const SHA3_512_NAME: &str = "SHA3-512";
-///
+/// Algorithm name string for SHAKE128, as used by the factories and CLI.
 pub const SHAKE128_NAME: &str = "SHAKE128";
-///
+/// Algorithm name string for SHAKE256, as used by the factories and CLI.
 pub const SHAKE256_NAME: &str = "SHAKE256";
 
 /*** pub types ***/
@@ -205,11 +236,13 @@ trait SHA3Params: HashAlgParams {
 
 // TODO: it would probably be more elegant to macro these.
 
-impl HashAlgParams for SHA3_224 {
-    const OUTPUT_LEN: usize = 28;
-    // const BLOCK_LEN: usize = 64;
-    const BLOCK_LEN: usize = 144; // FIPS 202 Table 3
+/// The public hash types expose the same parameters as their `*Params` marker, so the constants
+/// are defined exactly once (on the params struct) and forwarded here.
+impl<PARAMS: SHA3Params> HashAlgParams for SHA3Internal<PARAMS> {
+    const OUTPUT_LEN: usize = PARAMS::OUTPUT_LEN;
+    const BLOCK_LEN: usize = PARAMS::BLOCK_LEN;
 }
+
 /// The parameters for SHA3_224.
 #[derive(Clone)]
 pub struct SHA3_224Params;
@@ -219,7 +252,6 @@ impl Algorithm for SHA3_224Params {
 }
 impl HashAlgParams for SHA3_224Params {
     const OUTPUT_LEN: usize = 28;
-    // const BLOCK_LEN: usize = 64;
     const BLOCK_LEN: usize = 144; // FIPS 202 Table 3
 }
 impl SHA3Params for SHA3_224Params {
@@ -233,11 +265,6 @@ impl AlgorithmOID for SHA3_224 {
         &[0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x02, 0x07];
 }
 
-impl HashAlgParams for SHA3_256 {
-    const OUTPUT_LEN: usize = 32;
-    // const BLOCK_LEN: usize = 64;
-    const BLOCK_LEN: usize = 136; // FIPS 202 Table 3
-}
 /// The parameters for SHA3_256.
 #[derive(Clone)]
 pub struct SHA3_256Params;
@@ -247,7 +274,6 @@ impl Algorithm for SHA3_256Params {
 }
 impl HashAlgParams for SHA3_256Params {
     const OUTPUT_LEN: usize = 32;
-    // const BLOCK_LEN: usize = 64;
     const BLOCK_LEN: usize = 136; // FIPS 202 Table 3
 }
 impl SHA3Params for SHA3_256Params {
@@ -263,18 +289,12 @@ impl AlgorithmOID for SHA3_256 {
 /// The parameters for SHA3_384.
 #[derive(Clone)]
 pub struct SHA3_384Params;
-impl HashAlgParams for SHA3_384 {
-    const OUTPUT_LEN: usize = 48;
-    // const BLOCK_LEN: usize = 128;
-    const BLOCK_LEN: usize = 104; // FIPS 202 Table 3
-}
 impl Algorithm for SHA3_384Params {
     const ALG_NAME: &'static str = SHA3_384_NAME;
     const MAX_SECURITY_STRENGTH: SecurityStrength = SecurityStrength::_192bit;
 }
 impl HashAlgParams for SHA3_384Params {
     const OUTPUT_LEN: usize = 48;
-    // const BLOCK_LEN: usize = 128;
     const BLOCK_LEN: usize = 104; // FIPS 202 Table 3
 }
 impl SHA3Params for SHA3_384Params {
@@ -290,18 +310,12 @@ impl AlgorithmOID for SHA3_384 {
 /// The parameters for SHA3_512.
 #[derive(Clone)]
 pub struct SHA3_512Params;
-impl HashAlgParams for SHA3_512 {
-    const OUTPUT_LEN: usize = 64;
-    // const BLOCK_LEN: usize = 128;
-    const BLOCK_LEN: usize = 72; // FIPS 202 Table 3
-}
 impl Algorithm for SHA3_512Params {
     const ALG_NAME: &'static str = SHA3_512_NAME;
     const MAX_SECURITY_STRENGTH: SecurityStrength = SecurityStrength::_256bit;
 }
 impl HashAlgParams for SHA3_512Params {
     const OUTPUT_LEN: usize = 64;
-    // const BLOCK_LEN: usize = 128;
     const BLOCK_LEN: usize = 72; // FIPS 202 Table 3
 }
 impl SHA3Params for SHA3_512Params {

--- a/crypto/sha3/src/sha3.rs
+++ b/crypto/sha3/src/sha3.rs
@@ -44,6 +44,43 @@ impl<PARAMS: SHA3Params> SHA3Internal<PARAMS> {
         self.do_final_out(output)
     }
 
+    /// Appends the SHA3 domain-separation suffix and pads as per FIPS 202 s. 6.1, then squeezes the digest.
+    ///
+    /// `num_partial_bits` (0..=7, validated by the caller) trailing message bits are taken from the
+    /// least significant bits of `partial_byte` (FIPS 202 Appendix B.1 bit ordering). FIPS 202 s. 6.1
+    /// defines SHA3-d(M) = KECCAK[c](M || 01, d), so the two suffix bits are appended directly above
+    /// the message bits; pad10*1 is then applied by the sponge when it switches to squeezing.
+    ///
+    /// Returns the number of bytes written (`min(output.len(), OUTPUT_LEN)`); a shorter output buffer
+    /// truncates the digest, a longer one is zero-filled past the digest.
+    fn finalize(mut self, partial_byte: u8, num_partial_bits: usize, output: &mut [u8]) -> usize {
+        debug_assert!(num_partial_bits <= 7);
+        output.fill(0);
+
+        // Mutants note: This is just bit-setting into empty space.
+        // It works the same regardless of whether it's OR or XOR.
+        let mut final_input: u16 =
+            ((partial_byte as u16) & ((1 << num_partial_bits) - 1)) | (0x02 << num_partial_bits);
+        let mut final_bits = num_partial_bits + 2;
+
+        // If message bits + suffix fill a whole byte, absorb it as a normal byte first.
+        if final_bits >= 8 {
+            self.keccak.absorb(&[final_input as u8]);
+            final_bits -= 8;
+            final_input >>= 8;
+        }
+
+        // Infallible: the queue is byte-aligned here, final_bits is in 0..=7 by construction, and a
+        // Hash object cannot have started squeezing (finalize consumes self and is the only squeeze path).
+        self.keccak
+            .absorb_bits(final_input as u8, final_bits)
+            .expect("absorb_bits is infallible on a byte-aligned, not-yet-squeezing Hash");
+
+        // Truncate to OUTPUT_LEN if the caller supplied a larger buffer (see the Hash trait docs).
+        let n = *min(&output.len(), &PARAMS::OUTPUT_LEN);
+        self.keccak.squeeze(&mut output[..n])
+    }
+
     fn mix_key_internal(&mut self, key: &impl KeyMaterialTrait) {
         // track the strongest input key type
         self.kdf_key_type = *max(&self.kdf_key_type, &key.key_type());
@@ -170,16 +207,9 @@ impl<PARAMS: SHA3Params> Hash for SHA3Internal<PARAMS> {
 
     // TODO: investigate why this doesn't take a &mut [u8; HASH_LEN] 
     // Being able to do so would improve ergonomics
-    fn do_final_out(mut self, output: &mut [u8]) -> usize {
-        output.fill(0);
-
-        // this shouldn't fail because, by construction, the function is only called once, 
-        // and this is the only way to absorb partial bits.
-        self.keccak.absorb_bits(0x02, 2).expect("do_final_out: keccak.absorb_bits failed."); 
-
-        // Truncate to output_len() if the caller supplied a larger buffer (see the Hash trait docs).
-        let n = *min(&output.len(), &self.output_len());
-        self.keccak.squeeze(&mut output[..n])
+    fn do_final_out(self, output: &mut [u8]) -> usize {
+        // A whole-byte message is the zero-partial-bits case of the general finalization.
+        self.finalize(0, 0, output)
     }
 
     fn do_final_partial_bits(
@@ -187,45 +217,23 @@ impl<PARAMS: SHA3Params> Hash for SHA3Internal<PARAMS> {
         partial_byte: u8,
         num_partial_bits: usize,
     ) -> Result<Vec<u8>, HashError> {
-        let dbg_rslt_len = self.output_len();
-        let mut output: Vec<u8> = vec![0u8; self.output_len()];
-        let bytes_written =
-            self.do_final_partial_bits_out(partial_byte, num_partial_bits, output.as_mut_slice())?;
-        debug_assert_eq!(bytes_written, dbg_rslt_len);
-
+        let mut output: Vec<u8> = vec![0u8; PARAMS::OUTPUT_LEN];
+        self.do_final_partial_bits_out(partial_byte, num_partial_bits, &mut output)?;
         Ok(output)
     }
 
     fn do_final_partial_bits_out(
-        mut self,
+        self,
         partial_byte: u8,
         num_partial_bits: usize,
         output: &mut [u8],
     ) -> Result<usize, HashError> {
-        output.fill(0);
-
         // Validate before shifting: `1 << num_partial_bits` on a u16 would overflow for values >= 16,
         // and 8..=15 would silently absorb garbage. 0 is allowed and is equivalent to do_final_out().
         if num_partial_bits > 7 {
             return Err(HashError::InvalidLength("num_partial_bits must be in the range [0,7]"));
         }
-
-        // Mutants note: This is just bit-setting into empty space. 
-        // It works the same regardless of whether it's OR or XOR.
-        let mut final_input: u16 =
-            ((partial_byte as u16) & ((1 << num_partial_bits) - 1)) | (0x02 << num_partial_bits);
-        let mut final_bits = num_partial_bits + 2;
-
-        if final_bits >= 8 {
-            self.keccak.absorb(&[final_input as u8]);
-            final_bits -= 8;
-            final_input >>= 8;
-        }
-
-        self.keccak.absorb_bits(final_input as u8, final_bits)?;
-
-        let n = *min(&output.len(), &self.output_len());
-        Ok(self.keccak.squeeze(&mut output[..n]))
+        Ok(self.finalize(partial_byte, num_partial_bits, output))
     }
 
     fn max_security_strength(&self) -> SecurityStrength {

--- a/crypto/sha3/src/sha3.rs
+++ b/crypto/sha3/src/sha3.rs
@@ -15,7 +15,7 @@ use bouncycastle_utils::{max, min};
 /// provided and NIST-approved parameters.
 #[derive(Clone)]
 pub struct SHA3Internal<PARAMS: SHA3Params> {
-    _params: std::marker::PhantomData<PARAMS>,
+    _params: core::marker::PhantomData<PARAMS>,
     keccak: KeccakInternal,
     kdf_key_type: KeyType,
     kdf_security_strength: SecurityStrength,
@@ -28,7 +28,7 @@ impl<PARAMS: SHA3Params> SHA3Internal<PARAMS> {
     /// Get a new SHA3 instance, ready for use.
     pub fn new() -> Self {
         Self {
-            _params: std::marker::PhantomData,
+            _params: core::marker::PhantomData,
             keccak: KeccakInternal::new(PARAMS::SIZE),
             kdf_key_type: KeyType::Zeroized,
             kdf_security_strength: SecurityStrength::None,
@@ -52,12 +52,11 @@ impl<PARAMS: SHA3Params> SHA3Internal<PARAMS> {
         if key.is_full_entropy() {
             self.kdf_entropy += key.key_len();
             self.kdf_security_strength =
-                max(&self.kdf_security_strength, &key.security_strength()).clone();
-            self.kdf_security_strength = min(
+                *max(&self.kdf_security_strength, &key.security_strength());
+            self.kdf_security_strength = *min(
                 &self.kdf_security_strength,
                 &SecurityStrength::from_bits(PARAMS::OUTPUT_LEN * 8 / 2),
-            )
-            .clone();
+            );
         }
 
         self.do_update(key.ref_to_bytes())
@@ -82,14 +81,14 @@ impl<PARAMS: SHA3Params> SHA3Internal<PARAMS> {
         // it requires full-entropy input that is at least block length.
         // TODO: citation needed (NIST)
         if self.kdf_entropy < PARAMS::OUTPUT_LEN {
-            self.kdf_key_type = min(&self.kdf_key_type, &KeyType::Unknown).clone();
+            self.kdf_key_type = *min(&self.kdf_key_type, &KeyType::Unknown);
             self.kdf_security_strength = SecurityStrength::None; // BytesLowEntropy can't have a securtiy level.
         }
 
         self.do_update(additional_input);
 
-        let mut key_type = self.kdf_key_type.clone();
-        let output_security_strength = self.kdf_security_strength.clone();
+        let mut key_type = self.kdf_key_type;
+        let output_security_strength = self.kdf_security_strength;
         let mut bytes_written: usize = 0;
         key_material::do_hazardous_operations(output_key, |output_key| {
             bytes_written = self.do_final_out(output_key.ref_to_bytes_mut()?);
@@ -107,16 +106,17 @@ impl<PARAMS: SHA3Params> SHA3Internal<PARAMS> {
         }
         key_material::do_hazardous_operations(&mut *output_key, |output_key| {
             output_key.set_key_type(key_type)?;
-            output_key.set_security_strength(
-                min(&output_security_strength, &SecurityStrength::from_bits(bytes_written * 8)).clone(),
-            )
+            output_key.set_security_strength(*min(
+                &output_security_strength,
+                &SecurityStrength::from_bits(bytes_written * 8),
+            ))
         })
         .expect(
             "both set_key_type() and set_security_strength() should be infallible within a hazop block",
         );
 
         output_key
-            .set_key_len(min(&output_key.key_len(), &PARAMS::OUTPUT_LEN).clone())
+            .set_key_len(*min(&output_key.key_len(), &PARAMS::OUTPUT_LEN))
             .expect("should be infallible to truncate key length");
         Ok(bytes_written)
     }
@@ -150,10 +150,9 @@ impl<PARAMS: SHA3Params> Hash for SHA3Internal<PARAMS> {
         output
     }
 
-    fn hash_out(self, data: &[u8], mut output: &mut [u8]) -> usize {
-        output.fill(0);
-
-        self.hash_internal(data, &mut output)
+    fn hash_out(self, data: &[u8], output: &mut [u8]) -> usize {
+        // hash_internal zeroizes `output` before writing.
+        self.hash_internal(data, output)
     }
 
     fn do_update(&mut self, data: &[u8]) {
@@ -178,14 +177,9 @@ impl<PARAMS: SHA3Params> Hash for SHA3Internal<PARAMS> {
         // and this is the only way to absorb partial bits.
         self.keccak.absorb_bits(0x02, 2).expect("do_final_out: keccak.absorb_bits failed."); 
 
-        let bytes_written = if output.len() <= self.output_len() {
-            self.keccak.squeeze(output)
-        } else {
-            let min =
-                if output.len() >= self.output_len() { self.output_len() } else { output.len() };
-            self.keccak.squeeze(&mut output[..min])
-        };
-        bytes_written
+        // Truncate to output_len() if the caller supplied a larger buffer (see the Hash trait docs).
+        let n = *min(&output.len(), &self.output_len());
+        self.keccak.squeeze(&mut output[..n])
     }
 
     fn do_final_partial_bits(
@@ -210,6 +204,12 @@ impl<PARAMS: SHA3Params> Hash for SHA3Internal<PARAMS> {
     ) -> Result<usize, HashError> {
         output.fill(0);
 
+        // Validate before shifting: `1 << num_partial_bits` on a u16 would overflow for values >= 16,
+        // and 8..=15 would silently absorb garbage. 0 is allowed and is equivalent to do_final_out().
+        if num_partial_bits > 7 {
+            return Err(HashError::InvalidLength("num_partial_bits must be in the range [0,7]"));
+        }
+
         // Mutants note: This is just bit-setting into empty space. 
         // It works the same regardless of whether it's OR or XOR.
         let mut final_input: u16 =
@@ -224,8 +224,8 @@ impl<PARAMS: SHA3Params> Hash for SHA3Internal<PARAMS> {
 
         self.keccak.absorb_bits(final_input as u8, final_bits)?;
 
-        let min = if output.len() >= self.output_len() { self.output_len() } else { output.len() };
-        Ok(self.keccak.squeeze(&mut output[..min]))
+        let n = *min(&output.len(), &self.output_len());
+        Ok(self.keccak.squeeze(&mut output[..n]))
     }
 
     fn max_security_strength(&self) -> SecurityStrength {
@@ -321,7 +321,7 @@ impl<PARAMS: SHA3Params> Suspendable<SUSPENDED_SHA3_STATE_LEN> for SHA3Internal<
             deserialize_sha3_family_state(input, PARAMS::STATE_TAG, rate)?;
 
         Ok(SHA3Internal {
-            _params: std::marker::PhantomData,
+            _params: core::marker::PhantomData,
             keccak,
             kdf_key_type,
             kdf_security_strength,

--- a/crypto/sha3/src/shake.rs
+++ b/crypto/sha3/src/shake.rs
@@ -76,12 +76,11 @@ impl<PARAMS: SHAKEParams> SHAKEInternal<PARAMS> {
         if key.is_full_entropy() {
             self.kdf_entropy += key.key_len();
             self.kdf_security_strength =
-                max(&self.kdf_security_strength, &key.security_strength()).clone();
-            self.kdf_security_strength = min(
+                *max(&self.kdf_security_strength, &key.security_strength());
+            self.kdf_security_strength = *min(
                 &self.kdf_security_strength,
                 &SecurityStrength::from_bits(PARAMS::SIZE as usize),
-            )
-            .clone();
+            );
         }
 
         // Infallible: mix_key_internal is only called during the absorb phase, before any squeeze.
@@ -117,7 +116,7 @@ impl<PARAMS: SHAKEParams> SHAKEInternal<PARAMS> {
         // TODO: The intuition behind this is that SHAKE256 and SHA3-256 are both KECCAK[512], and SHAKE128 is KECCAK[256],
         // TODO: However, it is necessary to find an actual reference for this "fully-seeded" threshold.
         if self.kdf_entropy < 2 * (PARAMS::SIZE as usize) / 8 {
-            self.kdf_key_type = min(&self.kdf_key_type, &KeyType::Unknown).clone();
+            self.kdf_key_type = *min(&self.kdf_key_type, &KeyType::Unknown);
             self.kdf_security_strength = SecurityStrength::None; // BytesLowEntropy can't have a securtiy level.
         }
 
@@ -139,10 +138,10 @@ impl<PARAMS: SHAKEParams> SHAKEInternal<PARAMS> {
         }
         key_material::do_hazardous_operations(output_key, |output_key| {
             output_key.set_key_type(self.kdf_key_type)?;
-            output_key.set_security_strength(
-                min(&self.kdf_security_strength, &SecurityStrength::from_bits(bytes_written * 8))
-                    .clone(),
-            )
+            output_key.set_security_strength(*min(
+                &self.kdf_security_strength,
+                &SecurityStrength::from_bits(bytes_written * 8),
+            ))
         })?;
         Ok(bytes_written)
     }
@@ -270,8 +269,7 @@ impl<PARAMS: SHAKEParams> XOF for SHAKEInternal<PARAMS> {
     }
 
     fn hash_xof_out(self, data: &[u8], output: &mut [u8]) -> usize {
-        output.fill(0);
-
+        // hash_internal_out zeroizes `output` before writing.
         self.hash_internal_out(data, output)
     }
 
@@ -304,8 +302,10 @@ impl<PARAMS: SHAKEParams> XOF for SHAKEInternal<PARAMS> {
         if self.keccak.squeezing {
             return Err(HashError::InvalidState("cannot absorb after squeezing has begun"));
         }
-        if !(1..=7).contains(&num_partial_bits) {
-            return Err(HashError::InvalidLength("must be in the range [0,7]"));
+        // Validate before shifting: `1 << num_partial_bits` on a u16 would overflow for values >= 16,
+        // and 8..=15 would silently absorb garbage. 0 is allowed and simply finalizes with no partial byte.
+        if num_partial_bits > 7 {
+            return Err(HashError::InvalidLength("num_partial_bits must be in the range [0,7]"));
         }
         // Mutants note: This is just bit-setting into empty space. 
         // It works the same regardless of whether it's OR or XOR.
@@ -355,14 +355,20 @@ impl<PARAMS: SHAKEParams> XOF for SHAKEInternal<PARAMS> {
         output: &mut u8,
     ) -> Result<(), HashError> {
         if !(1..=7).contains(&num_bits) {
-            return Err(HashError::InvalidLength("must be in the range [0,7]"));
+            return Err(HashError::InvalidLength("num_bits must be in the range [1,7]"));
         }
 
         *output = 0;
 
+        // Route through squeeze_out() rather than keccak.squeeze() directly, so that if this is the
+        // first squeeze the SHAKE "1111" domain-separation suffix (FIPS 202 s. 6.2) is applied.
+        // Calling keccak.squeeze() here would produce raw Keccak output instead of SHAKE output.
         let mut buf = [0u8; 1];
-        self.keccak.squeeze(&mut buf);
-        *output = buf[0] >> 8 - num_bits;
+        self.squeeze_out(&mut buf);
+
+        // FIPS 202 Appendix B.1 (h2b): the first `num_bits` bits of an output byte are its least
+        // significant bits. This matches the input-side convention used by absorb_last_partial_byte().
+        *output = buf[0] & ((1u8 << num_bits) - 1);
         Ok(())
     }
 

--- a/crypto/sha3/tests/sha3_tests.rs
+++ b/crypto/sha3/tests/sha3_tests.rs
@@ -1,6 +1,7 @@
 #[cfg(test)]
 mod sha3_tests {
     use super::sha3_test_helpers::*;
+    use bouncycastle_core::errors::HashError;
     use bouncycastle_core::key_material;
     use bouncycastle_core::key_material::{
         KeyMaterial, KeyMaterial256, KeyMaterial512, KeyMaterialTrait, KeyType,
@@ -140,6 +141,28 @@ mod sha3_tests {
         let mut output = vec![0u8; SHA3_224::OUTPUT_LEN - 1];
         SHA3_224::new().do_final_partial_bits_out(input_byte, 7, &mut *output).unwrap();
         assert_eq!(output, expected_output[..SHA3_224::OUTPUT_LEN - 1]);
+    }
+
+    /// do_final_partial_bits() must validate num_partial_bits before shifting: 0 is equivalent to
+    /// do_final(), 8+ is rejected with InvalidLength rather than panicking (16+ used to overflow a shift).
+    #[test]
+    fn partial_bits_range_is_validated() {
+        for bad in [8usize, 9, 15, 16, 64, usize::MAX] {
+            let mut h = SHA3_256::new();
+            h.do_update(b"abc");
+            assert!(
+                matches!(h.do_final_partial_bits(0xFF, bad), Err(HashError::InvalidLength(_))),
+                "num_partial_bits={bad}"
+            );
+            let mut out = [0u8; 32];
+            assert!(matches!(
+                SHA3_256::new().do_final_partial_bits_out(0xFF, bad, &mut out),
+                Err(HashError::InvalidLength(_))
+            ));
+        }
+        let mut h = SHA3_256::new();
+        h.do_update(b"abc");
+        assert_eq!(h.do_final_partial_bits(0xFF, 0).unwrap(), SHA3_256::new().hash(b"abc"));
     }
 
     #[test]

--- a/crypto/sha3/tests/shake_tests.rs
+++ b/crypto/sha3/tests/shake_tests.rs
@@ -3,6 +3,7 @@ extern crate core;
 #[cfg(test)]
 mod shake_tests {
     use super::shake_test_helpers::*;
+    use bouncycastle_core::errors::HashError;
     use bouncycastle_core::key_material::{
         KeyMaterial, KeyMaterial256, KeyMaterial512, KeyMaterialTrait, KeyType,
     };
@@ -60,6 +61,50 @@ mod shake_tests {
         let mut out = 0u8;
         shake.squeeze_partial_byte_final_out(1, &mut out).expect("Squeeze failed");
         assert_eq!(out, 0x01);
+    }
+
+    /// Regression: squeeze_partial_byte_final() as the *first* squeeze must apply the SHAKE "1111"
+    /// domain suffix (previously it bypassed it and returned raw Keccak output), and must return the
+    /// low `num_bits` bits of the next output byte (FIPS 202 B.1 bit ordering), zero-extended.
+    #[test]
+    fn partial_bit_output_as_first_squeeze_matches_full_output() {
+        let msg = b"abc";
+        for skip in [0usize, 1, 5] {
+            let mut shake = SHAKE256::new();
+            shake.absorb(msg).unwrap();
+            let full = shake.squeeze(skip + 1)[skip];
+            // pick a byte that is not all-ones/all-zeros so bit selection is actually tested
+            assert!(full != 0x00 && full != 0xFF, "test vector byte must be non-uniform: {full:#x}");
+
+            for n in 1..=7usize {
+                let mut shake = SHAKE256::new();
+                shake.absorb(msg).unwrap();
+                if skip > 0 {
+                    _ = shake.squeeze(skip);
+                }
+                let got = shake.squeeze_partial_byte_final(n).unwrap();
+                assert_eq!(got, full & ((1u8 << n) - 1), "skip={skip} n={n}");
+                assert_eq!(got >> n, 0, "high bits must be zero");
+            }
+        }
+    }
+
+    /// absorb_last_partial_byte() must validate num_partial_bits before shifting: 0 is allowed
+    /// (finalize with no partial byte), 8+ is rejected with InvalidLength rather than panicking.
+    #[test]
+    fn absorb_last_partial_byte_validates_range() {
+        for bad in [8usize, 9, 15, 16, 64, usize::MAX] {
+            let mut shake = SHAKE128::new();
+            shake.absorb(b"abc").unwrap();
+            assert!(
+                matches!(shake.absorb_last_partial_byte(0xFF, bad), Err(HashError::InvalidLength(_))),
+                "num_partial_bits={bad}"
+            );
+        }
+        let mut a = SHAKE128::new();
+        a.absorb(b"abc").unwrap();
+        a.absorb_last_partial_byte(0xFF, 0).unwrap();
+        assert_eq!(a.squeeze(32), SHAKE128::new().hash_xof(b"abc", 32));
     }
 
     /// Once squeezing has begun, a SHAKE cannot return to absorbing (FIPS 202 defines SHAKE as a


### PR DESCRIPTION
changes two things:

- partial-bit squeeze returned the wrong bits, it was tested, but it appears the test was using 0xff which hid the error.
- validates  num_partial_bits in do_final_partial_bits so it has to be between 0 and 7. Previously 8 to 15 meant the data was just absorbed and 16 and greater caused a panic.
