### PR TITLE
core: split BlockCipher into block-aligned BlockCipherEncryptor/Decryptor

### DIFF
--- a/alpha_0.1.3_release_notes.md
+++ b/alpha_0.1.3_release_notes.md
@@ -3,3 +3,26 @@
 ## Major features
 
 ## Minor features / bug fixes
+
+Block cipher traits (PR #96):
+
+* The single `BlockCipher` streaming trait is split into `BlockCipherEncryptor` and `BlockCipherDecryptor` (mirroring
+  `KEMEncapsulator` / `KEMDecapsulator`) so the direction is encoded in the implementing type. A minimal `BlockCipher`
+  supertrait carries the shared `MAX_SECURITY_STRENGTH`; the `SymmetricCipher` one-shot API is no longer a supertrait.
+* The single-block `do_{en,de}crypt_block[_out]` methods are replaced by multi-block
+  `do_{en,de}crypt_blocks[_out]<const N>`, taking `&[[u8; BLOCK_LEN]; N]` so the block count is compile-time and
+  input/output lengths cannot disagree.
+* `do_encrypt_init_rng(key, &mut dyn RNG)` is added alongside `do_encrypt_init`, matching the `encaps` / `encaps_rng`
+  pattern.
+* The `do_{en,de}crypt_final[_out]` methods are removed: the traits are now strictly block-aligned, and padding of
+  arbitrary-length data belongs to a separate `PaddedEncryptor` / `PaddedDecryptor` layer built on top.
+* One-shot static APIs are provided (default) methods implemented once in the traits -- `encrypt_blocks`,
+  `encrypt_blocks_rng`, `encrypt_blocks_out`, `encrypt_blocks_out_rng` on `BlockCipherEncryptor` and `decrypt_blocks`,
+  `decrypt_blocks_out` on `BlockCipherDecryptor` -- so every block-aligned mode gets the house-standard
+  take-data-return-result API at no cost to implementors.
+
+Testing:
+
+* The core-test-framework block cipher test now takes separate encryptor/decryptor type parameters, exercises N = 1 and
+  N = 2 (including mixed single/multi-block encrypt vs decrypt sequences), and checks the one-shots agree with the
+  streaming API and round-trip.

--- a/crypto/core-test-framework/src/symmetric_ciphers.rs
+++ b/crypto/core-test-framework/src/symmetric_ciphers.rs
@@ -6,7 +6,8 @@ use bouncycastle_core::key_material::{
     KeyMaterial, KeyMaterialTrait, KeyType, do_hazardous_operations,
 };
 use bouncycastle_core::traits::{
-    AEADCipher, BlockCipherDecryptor, BlockCipherEncryptor, SecurityStrength, StreamCipher, SymmetricCipher,
+    AEADCipher, BlockCipherDecryptor, BlockCipherEncryptor, SecurityStrength, StreamCipher,
+    SymmetricCipher,
 };
 
 /// Instance of the test framework.
@@ -154,9 +155,7 @@ impl TestFrameworkBlockCipher {
         let mut ct = [[0u8; BLOCK_LEN]; 1];
         let mut pt = [[0u8; BLOCK_LEN]; 1];
         for msg_chunk in DUMMY_SEED.as_chunks::<BLOCK_LEN>().0.iter() {
-            let ct_bytes_written = encryptor
-                .do_encrypt_blocks_out(&[*msg_chunk], &mut ct)
-                .unwrap();
+            let ct_bytes_written = encryptor.do_encrypt_blocks_out(&[*msg_chunk], &mut ct).unwrap();
             assert_eq!(ct_bytes_written, BLOCK_LEN);
 
             let pt_bytes_written = decryptor.do_decrypt_blocks_out(&ct, &mut pt).unwrap();

--- a/crypto/core-test-framework/src/symmetric_ciphers.rs
+++ b/crypto/core-test-framework/src/symmetric_ciphers.rs
@@ -6,7 +6,7 @@ use bouncycastle_core::key_material::{
     KeyMaterial, KeyMaterialTrait, KeyType, do_hazardous_operations,
 };
 use bouncycastle_core::traits::{
-    AEADCipher, BlockCipher, SecurityStrength, StreamCipher, SymmetricCipher,
+    AEADCipher, BlockCipherDecryptor, BlockCipherEncryptor, SecurityStrength, StreamCipher, SymmetricCipher,
 };
 
 /// Instance of the test framework.
@@ -124,7 +124,8 @@ impl TestFrameworkBlockCipher {
         const KEY_LEN: usize,
         const INIT_DATA_LEN: usize,
         const BLOCK_LEN: usize,
-        C: BlockCipher<KEY_LEN, INIT_DATA_LEN, BLOCK_LEN>,
+        E: BlockCipherEncryptor<KEY_LEN, INIT_DATA_LEN, BLOCK_LEN>,
+        D: BlockCipherDecryptor<KEY_LEN, INIT_DATA_LEN, BLOCK_LEN>,
     >(
         &self,
     ) {
@@ -135,42 +136,76 @@ impl TestFrameworkBlockCipher {
         .unwrap();
 
         // to test blocks, we'll chunk our dummy seed
-        let (mut encryptor, iv) = C::do_encrypt_init(&key).unwrap();
-        let mut decryptor = C::do_decrypt_init(&key, &iv).unwrap();
+        let (mut encryptor, iv) = E::do_encrypt_init(&key).unwrap();
+        let mut decryptor = D::do_decrypt_init(&key, &iv).unwrap();
 
+        // one block at a time (N = 1)
         for msg_chunk in DUMMY_SEED.as_chunks::<BLOCK_LEN>().0.iter() {
-            let ct = encryptor.do_encrypt_block(msg_chunk).unwrap();
-            let pt = decryptor.do_decrypt_block(&ct).unwrap();
+            let ct = encryptor.do_encrypt_blocks(&[*msg_chunk]).unwrap();
+            let [pt] = decryptor.do_decrypt_blocks(&ct).unwrap();
             assert_eq!(msg_chunk, &pt);
         }
 
         // do it again using the _out versions
 
-        let (mut encryptor, iv) = C::do_encrypt_init(&key).unwrap();
-        let mut decryptor = C::do_decrypt_init(&key, &iv).unwrap();
+        let (mut encryptor, iv) = E::do_encrypt_init(&key).unwrap();
+        let mut decryptor = D::do_decrypt_init(&key, &iv).unwrap();
 
-        let mut ct = [0u8; BLOCK_LEN];
-        let mut pt = [0u8; BLOCK_LEN];
+        let mut ct = [[0u8; BLOCK_LEN]; 1];
+        let mut pt = [[0u8; BLOCK_LEN]; 1];
         for msg_chunk in DUMMY_SEED.as_chunks::<BLOCK_LEN>().0.iter() {
-            let ct_bytes_written = encryptor.do_encrypt_block_out(msg_chunk, &mut ct).unwrap();
+            let ct_bytes_written = encryptor
+                .do_encrypt_blocks_out(&[*msg_chunk], &mut ct)
+                .unwrap();
             assert_eq!(ct_bytes_written, BLOCK_LEN);
 
-            let pt_bytes_written = decryptor.do_decrypt_block_out(&ct, &mut pt).unwrap();
+            let pt_bytes_written = decryptor.do_decrypt_blocks_out(&ct, &mut pt).unwrap();
             assert_eq!(pt_bytes_written, BLOCK_LEN);
 
-            assert_eq!(msg_chunk, &pt);
+            assert_eq!(msg_chunk, &pt[0]);
+        }
+
+        // multi-block (N = 2): blocks encrypted together must decrypt both together and one at a time,
+        // and blocks encrypted one at a time must decrypt together.
+        let (mut encryptor, iv) = E::do_encrypt_init(&key).unwrap();
+        let mut decryptor = D::do_decrypt_init(&key, &iv).unwrap();
+
+        let mut ct = [[0u8; BLOCK_LEN]; 2];
+        let mut pt = [[0u8; BLOCK_LEN]; 2];
+        for msg_pair in DUMMY_SEED.as_chunks::<BLOCK_LEN>().0.as_chunks::<2>().0.iter() {
+            // encrypt together, decrypt together (by value)
+            let ct_by_value = encryptor.do_encrypt_blocks(msg_pair).unwrap();
+            let pt_by_value = decryptor.do_decrypt_blocks(&ct_by_value).unwrap();
+            assert_eq!(msg_pair, &pt_by_value);
+
+            // encrypt together (_out), decrypt one at a time
+            let ct_bytes_written = encryptor.do_encrypt_blocks_out(msg_pair, &mut ct).unwrap();
+            assert_eq!(ct_bytes_written, 2 * BLOCK_LEN);
+            for (msg_chunk, ct_chunk) in msg_pair.iter().zip(ct.iter()) {
+                let [pt] = decryptor.do_decrypt_blocks(&[*ct_chunk]).unwrap();
+                assert_eq!(msg_chunk, &pt);
+            }
+
+            // encrypt one at a time, decrypt together (_out)
+            for (msg_chunk, ct_chunk) in msg_pair.iter().zip(ct.iter_mut()) {
+                let [c] = encryptor.do_encrypt_blocks(&[*msg_chunk]).unwrap();
+                *ct_chunk = c;
+            }
+            let pt_bytes_written = decryptor.do_decrypt_blocks_out(&ct, &mut pt).unwrap();
+            assert_eq!(pt_bytes_written, 2 * BLOCK_LEN);
+            assert_eq!(msg_pair, &pt);
         }
 
         // test that the iv is random (ie not the same on two runs)
-        let (_encryptor, iv1) = C::do_encrypt_init(&key).unwrap();
-        let (_encryptor, iv2) = C::do_encrypt_init(&key).unwrap();
+        let (_encryptor, iv1) = E::do_encrypt_init(&key).unwrap();
+        let (_encryptor, iv2) = E::do_encrypt_init(&key).unwrap();
         assert_ne!(iv1, iv2);
 
         // error case: KeyMaterial of wrong type
         let mac_key =
             KeyMaterial::<KEY_LEN>::from_bytes_as_type(&DUMMY_SEED[..KEY_LEN], KeyType::MACKey)
                 .unwrap();
-        match C::do_encrypt_init(&mac_key) {
+        match E::do_encrypt_init(&mac_key) {
             Err(SymmetricCipherError::KeyMaterialError(_)) => { /* good */ }
             _ => panic!("Unexpected error"),
         };
@@ -194,15 +229,15 @@ impl TestFrameworkBlockCipher {
             // (and bypasses the key-length guard) without complaining.
             do_hazardous_operations(&mut key, |key| key.set_security_strength(ss.clone())).unwrap();
 
-            match C::do_encrypt_init(&key) {
+            match E::do_encrypt_init(&key) {
                 Ok(_) => {
-                    if ss >= &C::MAX_SECURITY_STRENGTH { /* good */
+                    if ss >= &E::MAX_SECURITY_STRENGTH { /* good */
                     } else {
                         panic!("Should have been a strong enough key");
                     }
                 }
                 Err(SymmetricCipherError::KeyMaterialError(_)) => {
-                    if ss < &C::MAX_SECURITY_STRENGTH { /* good */
+                    if ss < &E::MAX_SECURITY_STRENGTH { /* good */
                     } else {
                         panic!("Should not have accepted a key weaker than algorithm");
                     }

--- a/crypto/core-test-framework/src/symmetric_ciphers.rs
+++ b/crypto/core-test-framework/src/symmetric_ciphers.rs
@@ -195,6 +195,21 @@ impl TestFrameworkBlockCipher {
             assert_eq!(msg_pair, &pt);
         }
 
+        // one-shot API: must agree with the streaming API for the same key, and round-trip
+        let two_blocks: &[[u8; BLOCK_LEN]; 2] =
+            &DUMMY_SEED.as_chunks::<BLOCK_LEN>().0.as_chunks::<2>().0[0];
+        let (iv, ct) = E::encrypt_blocks(&key, two_blocks).unwrap();
+        assert_eq!(D::decrypt_blocks(&key, &iv, &ct).unwrap(), *two_blocks);
+        let mut streamed = D::do_decrypt_init(&key, &iv).unwrap();
+        assert_eq!(streamed.do_decrypt_blocks(&ct).unwrap(), *two_blocks);
+
+        let mut ct = [[0u8; BLOCK_LEN]; 2];
+        let mut pt = [[0u8; BLOCK_LEN]; 2];
+        let (iv, n) = E::encrypt_blocks_out(&key, two_blocks, &mut ct).unwrap();
+        assert_eq!(n, 2 * BLOCK_LEN);
+        assert_eq!(D::decrypt_blocks_out(&key, &iv, &ct, &mut pt).unwrap(), 2 * BLOCK_LEN);
+        assert_eq!(pt, *two_blocks);
+
         // test that the iv is random (ie not the same on two runs)
         let (_encryptor, iv1) = E::do_encrypt_init(&key).unwrap();
         let (_encryptor, iv2) = E::do_encrypt_init(&key).unwrap();

--- a/crypto/core/src/traits.rs
+++ b/crypto/core/src/traits.rs
@@ -130,6 +130,44 @@ pub trait BlockCipherEncryptor<
         plaintext: &[[u8; BLOCK_LEN]; N],
         ciphertext: &mut [[u8; BLOCK_LEN]; N],
     ) -> Result<usize, SymmetricCipherError>;
+
+    /// One-shot: encrypts `N` blocks under a fresh init. Returns the generated init data and the ciphertext.
+    fn encrypt_blocks<const N: usize>(
+        key: &KeyMaterial<KEY_LEN>,
+        plaintext: &[[u8; BLOCK_LEN]; N],
+    ) -> Result<([u8; INIT_DATA_LEN], [[u8; BLOCK_LEN]; N]), SymmetricCipherError> {
+        let (mut enc, init_data) = Self::do_encrypt_init(key)?;
+        Ok((init_data, enc.do_encrypt_blocks(plaintext)?))
+    }
+    /// As [`BlockCipherEncryptor::encrypt_blocks`], but sources randomness from the provided RNG.
+    fn encrypt_blocks_rng<const N: usize>(
+        key: &KeyMaterial<KEY_LEN>,
+        rng: &mut dyn RNG,
+        plaintext: &[[u8; BLOCK_LEN]; N],
+    ) -> Result<([u8; INIT_DATA_LEN], [[u8; BLOCK_LEN]; N]), SymmetricCipherError> {
+        let (mut enc, init_data) = Self::do_encrypt_init_rng(key, rng)?;
+        Ok((init_data, enc.do_encrypt_blocks(plaintext)?))
+    }
+    /// One-shot: encrypts `N` blocks under a fresh init into the provided buffer.
+    /// Returns the generated init data and `N * BLOCK_LEN`.
+    fn encrypt_blocks_out<const N: usize>(
+        key: &KeyMaterial<KEY_LEN>,
+        plaintext: &[[u8; BLOCK_LEN]; N],
+        ciphertext: &mut [[u8; BLOCK_LEN]; N],
+    ) -> Result<([u8; INIT_DATA_LEN], usize), SymmetricCipherError> {
+        let (mut enc, init_data) = Self::do_encrypt_init(key)?;
+        Ok((init_data, enc.do_encrypt_blocks_out(plaintext, ciphertext)?))
+    }
+    /// As [`BlockCipherEncryptor::encrypt_blocks_out`], but sources randomness from the provided RNG.
+    fn encrypt_blocks_out_rng<const N: usize>(
+        key: &KeyMaterial<KEY_LEN>,
+        rng: &mut dyn RNG,
+        plaintext: &[[u8; BLOCK_LEN]; N],
+        ciphertext: &mut [[u8; BLOCK_LEN]; N],
+    ) -> Result<([u8; INIT_DATA_LEN], usize), SymmetricCipherError> {
+        let (mut enc, init_data) = Self::do_encrypt_init_rng(key, rng)?;
+        Ok((init_data, enc.do_encrypt_blocks_out(plaintext, ciphertext)?))
+    }
 }
 
 /// The decryption half of a block cipher's streaming API; see [`BlockCipherEncryptor`].
@@ -156,6 +194,24 @@ pub trait BlockCipherDecryptor<
         ciphertext: &[[u8; BLOCK_LEN]; N],
         plaintext: &mut [[u8; BLOCK_LEN]; N],
     ) -> Result<usize, SymmetricCipherError>;
+
+    /// One-shot: decrypts `N` blocks from the given init data.
+    fn decrypt_blocks<const N: usize>(
+        key: &KeyMaterial<KEY_LEN>,
+        init_data: &[u8; INIT_DATA_LEN],
+        ciphertext: &[[u8; BLOCK_LEN]; N],
+    ) -> Result<[[u8; BLOCK_LEN]; N], SymmetricCipherError> {
+        Self::do_decrypt_init(key, init_data)?.do_decrypt_blocks(ciphertext)
+    }
+    /// One-shot: decrypts `N` blocks from the given init data into the provided buffer. Returns `N * BLOCK_LEN`.
+    fn decrypt_blocks_out<const N: usize>(
+        key: &KeyMaterial<KEY_LEN>,
+        init_data: &[u8; INIT_DATA_LEN],
+        ciphertext: &[[u8; BLOCK_LEN]; N],
+        plaintext: &mut [[u8; BLOCK_LEN]; N],
+    ) -> Result<usize, SymmetricCipherError> {
+        Self::do_decrypt_init(key, init_data)?.do_decrypt_blocks_out(ciphertext, plaintext)
+    }
 }
 
 /// The basic functions of an Authenticated Encryption with Addititional Data cipher.

--- a/crypto/core/src/traits.rs
+++ b/crypto/core/src/traits.rs
@@ -80,72 +80,75 @@ pub trait SymmetricCipher<const KEY_LEN: usize, const INIT_DATA_LEN: usize>: Alg
     ) -> Result<usize, SymmetricCipherError>;
 }
 
-/// The basic functions of a block cipher.
+/// Metadata shared by [`BlockCipherEncryptor`] and [`BlockCipherDecryptor`].
+pub trait BlockCipher {
+    /// Maximum security strength supported by the algorithm; keys tagged with a lower strength are
+    /// rejected by the `_init` constructors.
+    const MAX_SECURITY_STRENGTH: SecurityStrength;
+}
+
+/// The encryption half of a block cipher's streaming API. Strictly block-aligned: whole blocks in, whole
+/// blocks out, no finalization step. Padding of non-block-aligned data is handled by a separate layer
+/// (`PaddedEncryptor` / `PaddedDecryptor`) built on top of this trait.
+///
+/// Encryption and decryption are separate traits (as with [`KEMEncapsulator`] / [`KEMDecapsulator`]) so
+/// that the direction can be encoded in the type, and so that a policy can permit decryption of an
+/// algorithm while forbidding new encryptions.
+///
 /// This trait allows for a block cipher to generate initialization data, such as an Initialization Vector (IV) or Counter (CTR)
 /// which is not technically part of the ciphertext, but must be transmitted along with the ciphertext in order for the
 /// recipient to perform successful decryption. The length of the initialization data is specified by the implementing struct
 /// via the `INIT_DATA_LEN` constant.
-/// In order for these one-shot APIs to be usable securely in all contexts, the init data will be generated
+/// In order for these APIs to be usable securely in all contexts, the init data will be generated
 /// securely by the block cipher implementation and returned along with the ciphertext, and there is no API for the
 /// user to provide the init data. If you require this functionality, see the documentation for the underlying implementation.
-pub trait BlockCipher<const KEY_LEN: usize, const INIT_DATA_LEN: usize, const BLOCK_LEN: usize>:
-    SymmetricCipher<KEY_LEN, INIT_DATA_LEN> + Sized
+pub trait BlockCipherEncryptor<const KEY_LEN: usize, const INIT_DATA_LEN: usize, const BLOCK_LEN: usize>:
+    BlockCipher + Sized
 {
-    /// Constructor that begins a flow of the streaming API for encrypting one block at a time.
-    /// Allows for the implementation to return init data such as an IV which is generated prior to encrypting the first block.
+    /// Begins a streaming encryption flow, returning the generated init data (e.g. IV).
+    /// Sources randomness from the library's default OS-backed RNG.
     fn do_encrypt_init(
         key: &KeyMaterial<KEY_LEN>,
     ) -> Result<(Self, [u8; INIT_DATA_LEN]), SymmetricCipherError>;
-    /// Encrypts a single block of plaintext.
-    fn do_encrypt_block(
+    /// As [`BlockCipherEncryptor::do_encrypt_init`], but sources randomness from the provided RNG.
+    fn do_encrypt_init_rng(
+        key: &KeyMaterial<KEY_LEN>,
+        rng: &mut dyn RNG,
+    ) -> Result<(Self, [u8; INIT_DATA_LEN]), SymmetricCipherError>;
+    /// Encrypts `N` consecutive blocks of plaintext. A sequence of calls is equivalent to one call over
+    /// the concatenation.
+    fn do_encrypt_blocks<const N: usize>(
         &mut self,
-        plaintext: &[u8; BLOCK_LEN],
-    ) -> Result<[u8; BLOCK_LEN], SymmetricCipherError>;
-    /// Encrypts a single block of plaintext and writes the ciphertext to the provided buffer.
-    fn do_encrypt_block_out(
+        plaintext: &[[u8; BLOCK_LEN]; N],
+    ) -> Result<[[u8; BLOCK_LEN]; N], SymmetricCipherError>;
+    /// Encrypts `N` consecutive blocks of plaintext into the provided buffer. Returns `N * BLOCK_LEN`.
+    fn do_encrypt_blocks_out<const N: usize>(
         &mut self,
-        plaintext: &[u8; BLOCK_LEN],
-        ciphertext: &mut [u8; BLOCK_LEN],
+        plaintext: &[[u8; BLOCK_LEN]; N],
+        ciphertext: &mut [[u8; BLOCK_LEN]; N],
     ) -> Result<usize, SymmetricCipherError>;
-    /// Encrypts the final block of plaintext.
-    fn do_encrypt_final(
-        &mut self,
-        plaintext: &[u8; BLOCK_LEN],
-    ) -> Result<[u8; BLOCK_LEN], SymmetricCipherError>;
-    /// Encrypts the final block of plaintext and writes the ciphertext to the provided buffer.
-    fn do_encrypt_final_out(
-        &mut self,
-        plaintext: &[u8; BLOCK_LEN],
-        ciphertext: &mut [u8; BLOCK_LEN],
-    ) -> Result<usize, SymmetricCipherError>;
-    /// Constructor that begins a flow of the streaming API for decryption one block at a time.
+}
+
+/// The decryption half of a block cipher's streaming API; see [`BlockCipherEncryptor`].
+pub trait BlockCipherDecryptor<const KEY_LEN: usize, const INIT_DATA_LEN: usize, const BLOCK_LEN: usize>:
+    BlockCipher + Sized
+{
+    /// Begins a streaming decryption flow from the init data returned by [`BlockCipherEncryptor::do_encrypt_init`].
     fn do_decrypt_init(
         key: &KeyMaterial<KEY_LEN>,
         init_data: &[u8; INIT_DATA_LEN],
     ) -> Result<Self, SymmetricCipherError>;
-    /// Decrypts a single block of ciphertext.
-    fn do_decrypt_block(
+    /// Decrypts `N` consecutive blocks of ciphertext. A sequence of calls is equivalent to one call over
+    /// the concatenation.
+    fn do_decrypt_blocks<const N: usize>(
         &mut self,
-        ciphertext: &[u8; BLOCK_LEN],
-    ) -> Result<[u8; BLOCK_LEN], SymmetricCipherError>;
-    /// Decrypts a single block of ciphertext and writes the plaintext to the provided buffer.
-    fn do_decrypt_block_out(
+        ciphertext: &[[u8; BLOCK_LEN]; N],
+    ) -> Result<[[u8; BLOCK_LEN]; N], SymmetricCipherError>;
+    /// Decrypts `N` consecutive blocks of ciphertext into the provided buffer. Returns `N * BLOCK_LEN`.
+    fn do_decrypt_blocks_out<const N: usize>(
         &mut self,
-        ciphertext: &[u8; BLOCK_LEN],
-        plaintext: &mut [u8; BLOCK_LEN],
-    ) -> Result<usize, SymmetricCipherError>;
-    /// Decrypts the final block of ciphertext.
-    /// This is the decryption counterpart to [`BlockCipher::do_encrypt_final`] and is where an
-    /// implementation validates and strips any padding (or otherwise finalizes the flow).
-    fn do_decrypt_final(
-        &mut self,
-        ciphertext: &[u8; BLOCK_LEN],
-    ) -> Result<[u8; BLOCK_LEN], SymmetricCipherError>;
-    /// Decrypts the final block of ciphertext and writes the plaintext to the provided buffer.
-    fn do_decrypt_final_out(
-        &mut self,
-        ciphertext: &[u8; BLOCK_LEN],
-        plaintext: &mut [u8; BLOCK_LEN],
+        ciphertext: &[[u8; BLOCK_LEN]; N],
+        plaintext: &mut [[u8; BLOCK_LEN]; N],
     ) -> Result<usize, SymmetricCipherError>;
 }
 
@@ -170,7 +173,7 @@ pub trait AEADCipher<const KEY_LEN: usize, const NONCE_LEN: usize, const TAG_LEN
     /// that is not encrypted but is protected by the authentication tag; ie it can be sent along with the ciphertext
     /// and any tampering with it will result in the decryption operation failing the tag check.
     /// Returns a tuple containing the randomly-generated nonce, number of bytes written to the ciphertext buffer, and the tag.
-    /// If you need a deterministic mode where you feed in the nonce, use the streaming API of [`BlockCipher`]
+    /// If you need a deterministic mode where you feed in the nonce, use the streaming API of [`BlockCipherEncryptor`]
     /// or [`StreamCipher`] as appropriate and feed the nonce into the IV field.
     fn aead_encrypt_out(
         key: &KeyMaterial<KEY_LEN>,
@@ -178,7 +181,7 @@ pub trait AEADCipher<const KEY_LEN: usize, const NONCE_LEN: usize, const TAG_LEN
         plaintext: &[u8],
         ciphertext: &mut [u8],
     ) -> Result<([u8; NONCE_LEN], usize, [u8; TAG_LEN]), SymmetricCipherError>;
-    /// All AEAD ciphers will also be either a [`BlockCipher`] or a [`StreamCipher`], and so will already
+    /// All AEAD ciphers will also be either a block cipher ([`BlockCipherEncryptor`] / [`BlockCipherDecryptor`]) or a [`StreamCipher`], and so will already
     /// have a streaming API.
     /// This allows you to finish either style of streaming API flow with AEAD specific do_final()
     /// that computes and returns the authentication tag.
@@ -207,7 +210,7 @@ pub trait AEADCipher<const KEY_LEN: usize, const NONCE_LEN: usize, const TAG_LEN
         tag: &[u8; TAG_LEN],
         plaintext: &mut [u8],
     ) -> Result<usize, SymmetricCipherError>;
-    /// All AEAD ciphers will also be either a [`BlockCipher`] or a [`StreamCipher`], and so will already
+    /// All AEAD ciphers will also be either a block cipher ([`BlockCipherEncryptor`] / [`BlockCipherDecryptor`]) or a [`StreamCipher`], and so will already
     /// have a streaming API.
     /// This allows you to finish either style of streaming API flow with AEAD specific do_final()
     /// that computes and returns the authentication tag.

--- a/crypto/core/src/traits.rs
+++ b/crypto/core/src/traits.rs
@@ -102,8 +102,11 @@ pub trait BlockCipher {
 /// In order for these APIs to be usable securely in all contexts, the init data will be generated
 /// securely by the block cipher implementation and returned along with the ciphertext, and there is no API for the
 /// user to provide the init data. If you require this functionality, see the documentation for the underlying implementation.
-pub trait BlockCipherEncryptor<const KEY_LEN: usize, const INIT_DATA_LEN: usize, const BLOCK_LEN: usize>:
-    BlockCipher + Sized
+pub trait BlockCipherEncryptor<
+    const KEY_LEN: usize,
+    const INIT_DATA_LEN: usize,
+    const BLOCK_LEN: usize,
+>: BlockCipher + Sized
 {
     /// Begins a streaming encryption flow, returning the generated init data (e.g. IV).
     /// Sources randomness from the library's default OS-backed RNG.
@@ -130,8 +133,11 @@ pub trait BlockCipherEncryptor<const KEY_LEN: usize, const INIT_DATA_LEN: usize,
 }
 
 /// The decryption half of a block cipher's streaming API; see [`BlockCipherEncryptor`].
-pub trait BlockCipherDecryptor<const KEY_LEN: usize, const INIT_DATA_LEN: usize, const BLOCK_LEN: usize>:
-    BlockCipher + Sized
+pub trait BlockCipherDecryptor<
+    const KEY_LEN: usize,
+    const INIT_DATA_LEN: usize,
+    const BLOCK_LEN: usize,
+>: BlockCipher + Sized
 {
     /// Begins a streaming decryption flow from the init data returned by [`BlockCipherEncryptor::do_encrypt_init`].
     fn do_decrypt_init(


### PR DESCRIPTION
I had some left over credits (I get reset at 7:00 AM Oz, time). Something similar needs to be done for AEAD and symmetric ciphers as well, but there are a few things that need to get bedded down before this. I've got a second PR which I'll submit soon which does padding, I was also able to model CBC mode before I ran out, so the Encryptor/Decryptor traits have shown themselves to be adaptable enough, modeling with the original BlockCipher class showed that padding and mode support would need to be added to each block cipher. The actual traits are based on the KEM Encapsulator/Decapsulator traits and include the one shot option.

The other difference, which is the addition of multi-block support is based on what we've found in the BC LTS Java release when we needed to add multi-lane support for AES. Basically the old tried and true BlockCipher class didn't make it and then we ended up having to add MultiBlockCipher and then shoehorning it into various spots in the existing API to make sure everything synced up correctly. I figured we should probably spare ourselves rediscovering that here.

There's no need for do_final in this case as the block cipher constructs assume everything is block aligned. This will make sense in the next PR which introduces support for PKCS#7 padding (CBC modeling was done with this too).

**Claude Summary** follows:

Reworks the block cipher streaming traits in `core` ahead of the first mode implementations. No implementers exist yet, so this is trait-shape only plus the matching test-framework update.

## Changes

- **Split `BlockCipher` into `BlockCipherEncryptor` and `BlockCipherDecryptor`**, mirroring `KEMEncapsulator` / `KEMDecapsulator`, so an implementation can encode direction in its type (e.g. `Cbc<Aes128, Encrypting>`) and a policy can permit decryption while forbidding new encryptions. A minimal `BlockCipher` supertrait carries the shared `MAX_SECURITY_STRENGTH`. The one-shot `SymmetricCipher` is no longer a supertrait.
- **`do_{en,de}crypt_blocks[_out]<const N>`** replace the single-block methods, taking `&[[u8; BLOCK_LEN]; N]`. The block count is a const generic, so in/out lengths cannot disagree at runtime and no count parameter is needed; `N = 1` is a single block.
- **`do_encrypt_init_rng(key, &mut dyn RNG)`** added alongside `do_encrypt_init`, matching the `encaps` / `encaps_rng` pattern, so known-IV test vectors can be driven through the trait without exposing a caller-supplied IV.
- **`do_{en,de}crypt_final[_out]` removed.** The traits are now strictly block-aligned; padding of arbitrary-length data belongs to a separate layer (`PaddedEncryptor` / `PaddedDecryptor`, follow-up PR on `feature/block-cipher-padding`).

## Test framework

`TestFrameworkBlockCipher::test` now takes separate `E: BlockCipherEncryptor` / `D: BlockCipherDecryptor` type parameters and exercises `N = 1` and `N = 2`, including mixed single/multi-block encrypt vs decrypt sequences, so an implementation must treat a multi-block call as exactly the sequential equivalent.

## Verification

`cargo build --workspace`, `cargo test --workspace`, `cargo doc` (no broken intra-doc links), `cargo fmt --check` all clean.

