### PR TITLE
Refactored MLDSAParams to remove the hideous turbofish.

### DIFF
--- a/crypto/mldsa-lowmemory/src/aux_functions.rs
+++ b/crypto/mldsa-lowmemory/src/aux_functions.rs
@@ -1,12 +1,14 @@
 //! Implements auxiliary functions for ML-DSA as defined in Section 7 of FIPS 204.
 
-// use crate::matrix::{Matrix, Vector};
 use crate::mldsa::{G, H, POLY_T0PACKED_LEN};
-use crate::mldsa::{
-    MLDSA44_GAMMA1, MLDSA44_GAMMA2, MLDSA65_GAMMA1, MLDSA65_GAMMA2, N, POLY_T1PACKED_LEN, d, q,
+use crate::mldsa::{N, POLY_T1PACKED_LEN, d, q};
+use crate::params::{
+    GAMMA1_2_POW_17, GAMMA1_2_POW_19, GAMMA2_Q_MINUS_1_OVER_32, GAMMA2_Q_MINUS_1_OVER_88,
+    MLDSAParams,
 };
 use crate::polynomial::Polynomial;
 use bouncycastle_core::traits::XOF;
+use bouncycastle_utils::secret::ZeroizablePrimitive;
 
 /// Algorithm 14 CoeffFromThreeBytes(𝑏0, 𝑏1, 𝑏2)
 /// Output: An integer modulo 𝑞 or ⊥.
@@ -32,8 +34,8 @@ pub(crate) fn coeff_from_three_bytes(b: &[u8; 3]) -> Result<i32, ()> {
 /// Input: Integer 𝑏 ∈ {0, 1, … , 15}.
 /// Output: An integer between −𝜂 and 𝜂, or ⊥.
 #[inline(always)]
-pub(crate) fn coeff_from_half_byte<const ETA: usize>(b: u8) -> Result<i32, ()> {
-    if ETA == 2 && b < 15 {
+pub(crate) fn coeff_from_half_byte<P: MLDSAParams>(b: u8) -> Result<i32, ()> {
+    if P::ETA == 2 && b < 15 {
         // Original code is bad because '%' is not constant-time.
         // Ok(2 - (b % 5) as i32)
         // TODO: Verify whether this function is constant time and whether it can be further optimized
@@ -44,7 +46,7 @@ pub(crate) fn coeff_from_half_byte<const ETA: usize>(b: u8) -> Result<i32, ()> {
         };
         Ok(2 - b as i32)
     } else {
-        if ETA == 4 && b < 9 { Ok(4 - b as i32) } else { Err(()) }
+        if P::ETA == 4 && b < 9 { Ok(4 - b as i32) } else { Err(()) }
     }
 }
 
@@ -81,14 +83,14 @@ pub const fn bitlen_eta(eta: usize) -> usize {
 // `match ETA` folds away per monomorphization (ETA is a const generic), so ETA = 2
 // and ETA = 4 each compile to just their own arm, leaving no dispatch at runtime.
 #[inline(always)]
-pub(crate) fn bit_pack_eta<const ETA: usize>(w: &Polynomial, r: &mut [u8]) {
-    debug_assert_eq!(r.len(), bitlen_eta(ETA));
+pub(crate) fn bit_pack_eta<P: MLDSAParams>(w: &Polynomial, r: &mut [u8]) {
+    debug_assert_eq!(r.len(), bitlen_eta(P::ETA));
 
     // temp swap space
     let mut t: [u8; 8] = [0; 8];
 
-    match ETA {
-        // MLDSA44 and MLDSA87
+    match P::ETA {
+        // MLDSA-44 and MLDSA-87
         2 => {
             let eta: i32 = 2;
             for i in 0..N / 8 {
@@ -106,7 +108,7 @@ pub(crate) fn bit_pack_eta<const ETA: usize>(w: &Polynomial, r: &mut [u8]) {
                 r[3 * i + 2] = (t[5] >> 1) | (t[6] << 2) | (t[7] << 5);
             }
         }
-        // MLDSA65
+        // MLDSA-65
         4 => {
             let eta: i32 = 4;
             for i in 0..N / 2 {
@@ -163,20 +165,22 @@ pub(crate) fn bit_pack_t0(t0: &Polynomial) -> [u8; POLY_T0PACKED_LEN] {
 }
 
 /// A variant of Algorithm 17 specific to packing z in the signature value in \[−𝛾1 + 1, 𝛾1].
-pub(crate) fn bitpack_gamma1<const POLY_Z_PACKED_LEN: usize, const GAMMA1: i32>(
-    z: &Polynomial,
-    out: &mut [u8; POLY_Z_PACKED_LEN],
-) {
+/// The destination is a slice rather than a `P::PolyZPacked`: the only caller writes straight into
+/// its window of the signature buffer, which is chunked at runtime because the chunk size
+/// `P::POLY_Z_PACKED_LEN` cannot be a const generic argument.
+pub(crate) fn bitpack_gamma1<P: MLDSAParams>(z: &Polynomial, out: &mut [u8]) {
+    debug_assert_eq!(out.len(), P::POLY_Z_PACKED_LEN);
     out.fill(0);
 
     let mut t: [u32; 4] = [0; 4];
-    match GAMMA1 {
-        MLDSA44_GAMMA1 => {
+    match P::GAMMA1 {
+        // MLDSA-44
+        GAMMA1_2_POW_17 => {
             for i in 0..N / 4 {
-                t[0] = (GAMMA1 - z[4 * i]) as u32;
-                t[1] = (GAMMA1 - z[4 * i + 1]) as u32;
-                t[2] = (GAMMA1 - z[4 * i + 2]) as u32;
-                t[3] = (GAMMA1 - z[4 * i + 3]) as u32;
+                t[0] = (P::GAMMA1 - z[4 * i]) as u32;
+                t[1] = (P::GAMMA1 - z[4 * i + 1]) as u32;
+                t[2] = (P::GAMMA1 - z[4 * i + 2]) as u32;
+                t[3] = (P::GAMMA1 - z[4 * i + 3]) as u32;
 
                 out[9 * i] = t[0] as u8;
                 out[9 * i + 1] = (t[0] >> 8) as u8;
@@ -189,11 +193,11 @@ pub(crate) fn bitpack_gamma1<const POLY_Z_PACKED_LEN: usize, const GAMMA1: i32>(
                 out[9 * i + 8] = (t[3] >> 10) as u8;
             }
         }
-        // MLDSA-65 and 87 have the same GAMMA1 value
-        MLDSA65_GAMMA1 => {
+        // MLDSA-65 and -87 have the same GAMMA1 value
+        GAMMA1_2_POW_19 => {
             for i in 0..N / 2 {
-                t[0] = (GAMMA1 - z[2 * i]) as u32;
-                t[1] = (GAMMA1 - z[2 * i + 1]) as u32;
+                t[0] = (P::GAMMA1 - z[2 * i]) as u32;
+                t[1] = (P::GAMMA1 - z[2 * i + 1]) as u32;
 
                 out[5 * i] = t[0] as u8;
                 out[5 * i + 1] = (t[0] >> 8) as u8;
@@ -239,10 +243,10 @@ pub(crate) fn simple_bit_unpack_t1(v: &[u8; POLY_T1PACKED_LEN]) -> Polynomial {
 // `match ETA` folds away per monomorphization (ETA is a const generic), so ETA = 2
 // and ETA = 4 each compile to just their own arm, leaving no dispatch at runtime.
 #[inline(always)]
-pub(crate) fn bit_unpack_eta_out<const ETA: usize>(v: &[u8], w: &mut Polynomial) {
-    debug_assert_eq!(v.len(), bitlen_eta(ETA));
+pub(crate) fn bit_unpack_eta_out<P: MLDSAParams>(v: &[u8], w: &mut Polynomial) {
+    debug_assert_eq!(v.len(), bitlen_eta(P::ETA));
 
-    match ETA {
+    match P::ETA {
         // MLDSA44 and MLDSA87
         2 => {
             let eta: i32 = 2;
@@ -291,11 +295,12 @@ pub(crate) fn bit_unpack_eta_out<const ETA: usize>(v: &[u8], w: &mut Polynomial)
 // `match ETA` folds away per monomorphization (ETA is a const generic), so ETA = 2
 // and ETA = 4 each compile to just their own arm, leaving no dispatch at runtime.
 #[inline(always)]
-pub(crate) fn bit_unpack_gamma1<const GAMMA1: i32>(v: &[u8]) -> Polynomial {
+pub(crate) fn bit_unpack_gamma1<P: MLDSAParams>(v: &[u8]) -> Polynomial {
     let mut w = Polynomial::new();
 
-    match GAMMA1 {
-        MLDSA44_GAMMA1 => {
+    match P::GAMMA1 {
+        // MLDSA-44
+        GAMMA1_2_POW_17 => {
             // const gamma1: i32 = 1<<17;
             for i in 0..N / 4 {
                 w[4 * i] = (((v[9 * i] as i32) | ((v[9 * i + 1] as i32) << 8))
@@ -311,14 +316,14 @@ pub(crate) fn bit_unpack_gamma1<const GAMMA1: i32>(v: &[u8]) -> Polynomial {
                     | ((v[9 * i + 8] as i32) << 10))
                     & 0x3FFFF;
 
-                w[4 * i] = GAMMA1 - w[4 * i];
-                w[4 * i + 1] = GAMMA1 - w[4 * i + 1];
-                w[4 * i + 2] = GAMMA1 - w[4 * i + 2];
-                w[4 * i + 3] = GAMMA1 - w[4 * i + 3];
+                w[4 * i] = P::GAMMA1 - w[4 * i];
+                w[4 * i + 1] = P::GAMMA1 - w[4 * i + 1];
+                w[4 * i + 2] = P::GAMMA1 - w[4 * i + 2];
+                w[4 * i + 3] = P::GAMMA1 - w[4 * i + 3];
             }
         }
-        // MLDSA-65 and 87 have the same GAMMA1 value
-        MLDSA65_GAMMA1 => {
+        // MLDSA-65 and -87 have the same GAMMA1 value
+        GAMMA1_2_POW_19 => {
             // const gamma1: i32 = 1<<19;
             for i in 0..N / 2 {
                 w[2 * i] = (((v[5 * i] as i32) | ((v[5 * i + 1] as i32) << 8))
@@ -328,8 +333,8 @@ pub(crate) fn bit_unpack_gamma1<const GAMMA1: i32>(v: &[u8]) -> Polynomial {
                     | ((v[5 * i + 4] as i32) << 12))
                     & 0xFFFFF;
 
-                w[2 * i] = GAMMA1 - w[2 * i];
-                w[2 * i + 1] = GAMMA1 - w[2 * i + 1];
+                w[2 * i] = P::GAMMA1 - w[2 * i];
+                w[2 * i + 1] = P::GAMMA1 - w[2 * i + 1];
             }
         }
         _ => {
@@ -341,51 +346,39 @@ pub(crate) fn bit_unpack_gamma1<const GAMMA1: i32>(v: &[u8]) -> Polynomial {
 }
 
 /// Part of unpacking the sig value
-pub(crate) fn unpack_c_tilde<const LAMBDA_over_4: usize>(sig: &[u8]) -> &[u8; LAMBDA_over_4] {
-    sig[..LAMBDA_over_4].try_into().unwrap()
+pub(crate) fn unpack_c_tilde<P: MLDSAParams>(sig: &[u8]) -> P::SigCTilde {
+    let mut c_tilde = <P::SigCTilde as ZeroizablePrimitive>::ZEROED;
+    c_tilde.as_mut().copy_from_slice(&sig[..P::C_TILDE_LEN]);
+    c_tilde
 }
 /// Part of unpacking the sig value
-pub(crate) fn unpack_z_row<
-    const GAMMA1: i32,
-    const GAMMA1_MINUS_BETA: i32,
-    const LAMBDA_over_4: usize,
-    const POLY_Z_PACKED_LEN: usize,
-    const SIG_LEN: usize,
->(
+pub(crate) fn unpack_z_row<P: MLDSAParams, const SIG_LEN: usize>(
     idx: usize,
     sig: &[u8; SIG_LEN],
 ) -> Result<Polynomial, ()> {
-    // assert: idx < l, but here there is no access to l
+    debug_assert!(idx < P::l);
 
     // skip to the start of the z's
-    let pos = LAMBDA_over_4;
-    let z = bit_unpack_gamma1::<GAMMA1>(
-        &sig[pos + idx * POLY_Z_PACKED_LEN..pos + (idx + 1) * POLY_Z_PACKED_LEN],
+    let pos = P::C_TILDE_LEN;
+    let z = bit_unpack_gamma1::<P>(
+        &sig[pos + idx * P::POLY_Z_PACKED_LEN..pos + (idx + 1) * P::POLY_Z_PACKED_LEN],
     );
 
     // Perform the norm check from
     // Alg 8; Line 13 (first half) return [[ ||𝐳||∞ < 𝛾1 − 𝛽]]
-    if z.check_norm::<GAMMA1_MINUS_BETA>() { Err(()) } else { Ok(z) }
+    if z.check_norm(P::GAMMA1_MINUS_BETA) { Err(()) } else { Ok(z) }
 }
 /// Part of unpacking the sig value
-pub(crate) fn unpack_h_row<
-    const GAMMA1: i32,
-    const k: usize,
-    const l: usize,
-    const OMEGA: i32,
-    const LAMBDA_over_4: usize,
-    const POLY_Z_PACKED_LEN: usize,
-    const SIG_LEN: usize,
->(
+pub(crate) fn unpack_h_row<P: MLDSAParams, const SIG_LEN: usize>(
     row: usize,
     sig: &[u8; SIG_LEN],
 ) -> Option<Polynomial> {
-    debug_assert!(row < k);
+    debug_assert!(row < P::k);
 
     let mut h = Polynomial::new();
 
     // skip over the other stuff in the encoded sig value
-    let pos = LAMBDA_over_4 + l * POLY_Z_PACKED_LEN;
+    let pos = P::C_TILDE_LEN + P::l * P::POLY_Z_PACKED_LEN;
 
     // This inlines Algorithm 21 HintBitUnpack(𝑦)
 
@@ -394,15 +387,15 @@ pub(crate) fn unpack_h_row<
     // let mut idx = 0usize;
     // This row calc is a bit weird because technically it's supposed to be done at the end
     // of the previous loop
-    let idx = if row == 0 { 0 } else { sig[pos + OMEGA as usize + row - 1] as usize };
+    let idx = if row == 0 { 0 } else { sig[pos + P::OMEGA as usize + row - 1] as usize };
 
     // 3: for 𝑖 from 0 to 𝑘 − 1 do
     //  ▷ reconstruct 𝐡[𝑖]
     // for i in 0..k {
     // 4: if 𝑦[𝜔 + 𝑖] < Index or 𝑦[𝜔 + 𝑖] > 𝜔 then return ⊥
     // mutants note: don't have test vectors that exercise this condition
-    if sig[pos + (OMEGA as usize) + row] < (idx as u8)
-        || sig[pos + (OMEGA as usize) + row] > OMEGA as u8
+    if sig[pos + (P::OMEGA as usize) + row] < (idx as u8)
+        || sig[pos + (P::OMEGA as usize) + row] > P::OMEGA as u8
     {
         return None;
     }
@@ -410,7 +403,7 @@ pub(crate) fn unpack_h_row<
     // 6: First ← Index
     // 7: while Index < 𝑦[𝜔 + 𝑖] do
     //   ▷ 𝑦[𝜔 + 𝑖] says how far one can advance Index
-    for j in idx..sig[pos + OMEGA as usize + row] as usize {
+    for j in idx..sig[pos + P::OMEGA as usize + row] as usize {
         // 8: if Index > First then
         // 9:   if 𝑦[Index − 1] ≥ 𝑦[Index] then return ⊥
         //       ▷ malformed input
@@ -427,9 +420,9 @@ pub(crate) fn unpack_h_row<
 
     // ▷ read any leftover bytes in the first 𝜔 bytes of 𝑦 for malformed (nonzero) bytes
     // mutants note:
-    if row == k - 1 {
-        let idx = sig[pos + OMEGA as usize + row] as usize;
-        for j in idx..OMEGA as usize {
+    if row == P::k - 1 {
+        let idx = sig[pos + P::OMEGA as usize + row] as usize;
+        for j in idx..P::OMEGA as usize {
             if sig[pos + j] != 0 {
                 return None;
             }
@@ -443,9 +436,7 @@ pub(crate) fn unpack_h_row<
 /// Samples a polynomial 𝑐 ∈ 𝑅 with coefficients from {−1, 0, 1} and Hamming weight 𝜏 ≤ 64.
 /// Input: A seed 𝜌 ∈ 𝔹𝜆/4
 /// Output: A polynomial 𝑐 in 𝑅.
-pub(crate) fn sample_in_ball<const LAMBDA_over_4: usize, const TAU: i32>(
-    rho: &[u8; LAMBDA_over_4],
-) -> Polynomial {
+pub(crate) fn sample_in_ball<P: MLDSAParams>(rho: &P::SigCTilde) -> Polynomial {
     // 1: 𝑐 ← 0
     let mut c = Polynomial::new();
 
@@ -453,7 +444,7 @@ pub(crate) fn sample_in_ball<const LAMBDA_over_4: usize, const TAU: i32>(
     // 3: ctx ← H.Absorb(ctx, 𝜌)
     // 4: (ctx, 𝑠) ← H.Squeeze(ctx, 8)
     let mut h = H::new();
-    h.absorb(rho).expect("absorb before squeeze is infallible");
+    h.absorb(rho.as_ref()).expect("absorb before squeeze is infallible");
     let mut s = [0u8; 8];
     h.squeeze_out(&mut s);
 
@@ -469,7 +460,7 @@ pub(crate) fn sample_in_ball<const LAMBDA_over_4: usize, const TAU: i32>(
     // let mut pos = 8;
     // let mut b;
     let mut j = [0u8];
-    for i in (N - TAU as usize)..N {
+    for i in (N - P::TAU as usize)..N {
         // 7: (ctx, 𝑗) ← H.Squeeze(ctx, 1)
         // Note: At first, it might seem to be faster to pre-squeeze a buffer outside the loop.
         // However, after experimentation and testing, the difference is not noticeable.
@@ -557,7 +548,7 @@ pub(crate) fn rej_ntt_poly(rho: &[u8; 32], nonce: &[u8; 2]) -> Polynomial {
 /// This is supposed to take a rho: [u8; 66], which is: 𝜌||IntegerToBytes(𝑠, 1)||IntegerToBytes(𝑟, 1)
 /// but to avoid needing to copy bytes and allocate more memory,
 /// here that is split into a [u8;64] and a [u8;2]
-pub(crate) fn rej_bounded_poly<const ETA: usize>(rho: &[u8; 64], nonce: &[u8; 2]) -> Polynomial {
+pub(crate) fn rej_bounded_poly<P: MLDSAParams>(rho: &[u8; 64], nonce: &[u8; 2]) -> Polynomial {
     let mut a = Polynomial::new();
     let mut j: usize = 0;
     let mut h = H::new();
@@ -574,8 +565,8 @@ pub(crate) fn rej_bounded_poly<const ETA: usize>(rho: &[u8; 64], nonce: &[u8; 2]
     let mut idx: usize = 0;
 
     while j < N {
-        let z0 = coeff_from_half_byte::<ETA>(z_arr[idx] & 0x0F); // equiv to % 16 (but faster, and more importantly, constant-time)
-        let z1 = coeff_from_half_byte::<ETA>(z_arr[idx] >> 4); // equiv to div_floor(16) (but faster, and more importantly, constant-time)
+        let z0 = coeff_from_half_byte::<P>(z_arr[idx] & 0x0F); // equiv to % 16 (but faster, and more importantly, constant-time)
+        let z1 = coeff_from_half_byte::<P>(z_arr[idx] >> 4); // equiv to div_floor(16) (but faster, and more importantly, constant-time)
 
         if z0.is_ok() {
             a[j] = z0.unwrap();
@@ -600,21 +591,19 @@ pub(crate) fn rej_bounded_poly<const ETA: usize>(rho: &[u8; 64], nonce: &[u8; 2]
 /// Samples a vector 𝐲 ∈ 𝑅ℓ such that each polynomial 𝐲[𝑟] has coefficients between −𝛾1 + 1 and 𝛾1.
 /// Input: A seed 𝜌 ∈ 𝔹64 and a nonnegative integer 𝜇.
 /// Output: Vector 𝐲 ∈ 𝑅ℓ .
-pub(crate) fn expand_mask_poly<const GAMMA1: i32, const GAMMA1_MASK_LEN: usize>(
-    rho: &[u8; 64],
-    nonce: u16,
-) -> Polynomial {
+pub(crate) fn expand_mask_poly<P: MLDSAParams>(rho: &[u8; 64], nonce: u16) -> Polynomial {
     // 1: 𝑐 ← 1 + bitlen (𝛾1 − 1)
     //  ▷ 𝛾1 is always a power of 2
     // 3: 𝜌′ ← 𝜌||IntegerToBytes(𝜇 + 𝑟, 2)
-    // 32c = GAMMA1_MASK_LEN;
     // 4: 𝑣 ← H(𝜌′, 32𝑐)
+    // The 32𝑐 bytes squeezed on line 4 are exactly `P::POLY_Z_PACKED_LEN`, so the buffer for them
+    // is `P::PolyZPacked`; see the docs on `MLDSAParams::POLY_Z_PACKED_LEN`.
     let mut h = H::new();
     h.absorb(rho).expect("absorb before squeeze is infallible");
     h.absorb(&nonce.to_le_bytes()).expect("absorb before squeeze is infallible");
-    let mut v = [0u8; GAMMA1_MASK_LEN];
-    h.squeeze_out(&mut v);
-    bit_unpack_gamma1::<GAMMA1>(&v)
+    let mut v = <P::PolyZPacked as ZeroizablePrimitive>::ZEROED;
+    h.squeeze_out(v.as_mut());
+    bit_unpack_gamma1::<P>(v.as_ref())
 }
 
 /// Algorithm 35 Power2Round(𝑟)
@@ -657,7 +646,7 @@ fn test_power_2_round() {
 // the hope here is that the compiler will aggressively inline this function,
 // and optimize away the branching.
 #[inline(always)]
-pub(crate) fn decompose<const GAMMA2: i32>(r: i32) -> (i32, i32) {
+pub(crate) fn decompose<P: MLDSAParams>(r: i32) -> (i32, i32) {
     // 1: 𝑟+ ← 𝑟 mod 𝑞
     // 2: 𝑟0 ← 𝑟+ mod±(2𝛾2)
     // 3: if 𝑟+ − 𝑟0 = 𝑞 − 1 then
@@ -672,14 +661,14 @@ pub(crate) fn decompose<const GAMMA2: i32>(r: i32) -> (i32, i32) {
     let mut r1: i32;
     let mut r0 = (r + 127) >> 7;
 
-    match GAMMA2 {
-        MLDSA44_GAMMA2 => {
+    match P::GAMMA2 {
+        GAMMA2_Q_MINUS_1_OVER_88 => {
             // (q - 1) / 88
             r0 = (r0 * 11275 + (1 << 23)) >> 24;
             r0 ^= ((43 - r0) >> 31) & r0;
         }
         // ML-DSA65 and 87 have the same GAMMA2
-        MLDSA65_GAMMA2 => {
+        GAMMA2_Q_MINUS_1_OVER_32 => {
             // (q - 1) / 32;
             r0 = (r0 * 1025 + (1 << 21)) >> 22;
             r0 &= 15;
@@ -690,7 +679,7 @@ pub(crate) fn decompose<const GAMMA2: i32>(r: i32) -> (i32, i32) {
         }
     }
 
-    r1 = r - r0 * 2 * GAMMA2;
+    r1 = r - r0 * 2 * P::GAMMA2;
 
     // mutants note: the choice of (q - 1) is a bit arbitrary in that after doing the bit-shifting,
     // this seems to work out mathematically equivalent to doing q/2, or (q+3)/2, but here it is left as (q-1)/2
@@ -704,10 +693,10 @@ pub(crate) fn decompose<const GAMMA2: i32>(r: i32) -> (i32, i32) {
 /// Returns 𝑟1 from the output of Decompose (𝑟).
 /// Input: 𝑟 ∈ ℤ𝑞.
 /// Output: Integer 𝑟1.
-pub(crate) fn high_bits<const GAMMA2: i32>(r: i32) -> i32 {
+pub(crate) fn high_bits<P: MLDSAParams>(r: i32) -> i32 {
     // 1: (𝑟1, 𝑟0) ← Decompose(𝑟)
     // 2: return 𝑟1
-    let (r1, _) = decompose::<GAMMA2>(r);
+    let (r1, _) = decompose::<P>(r);
     r1
 }
 
@@ -715,10 +704,10 @@ pub(crate) fn high_bits<const GAMMA2: i32>(r: i32) -> i32 {
 /// Returns 𝑟0 from the output of Decompose (𝑟).
 /// Input: 𝑟 ∈ ℤ𝑞.
 /// Output: Integer 𝑟0.
-pub(crate) fn low_bits<const GAMMA2: i32>(r: i32) -> i32 {
+pub(crate) fn low_bits<P: MLDSAParams>(r: i32) -> i32 {
     // 1: (𝑟1, 𝑟0) ← Decompose(𝑟)
     // 2: return 𝑟0
-    let (_, r0) = decompose::<GAMMA2>(r);
+    let (_, r0) = decompose::<P>(r);
     r0
 }
 
@@ -726,27 +715,28 @@ pub(crate) fn low_bits<const GAMMA2: i32>(r: i32) -> i32 {
 /// Computes hint bit indicating whether adding 𝑧 to 𝑟 alters the high bits of 𝑟.
 /// Input: 𝑧, 𝑟 ∈ ℤ𝑞.
 /// Output: Boolean.
-pub(crate) fn make_hint<const GAMMA2: i32>(z: i32, r: i32) -> i32 {
+pub(crate) fn make_hint<P: MLDSAParams>(z: i32, r: i32) -> i32 {
+    // Naïve implementation:
     // // 1: 𝑟1 ← HighBits(𝑟)
-    // let r1 = high_bits::<GAMMA2>(r);
+    // let r1 = high_bits::<P>(r);
     //
     // // 2: 𝑣1 ← HighBits(𝑟 + 𝑧)
-    // let v1 = high_bits::<GAMMA2>(r + z);
+    // let v1 = high_bits::<P>(r + z);
     //
     // // 3: return [[𝑟1 ≠ 𝑣1]]
     // if r1 != v1 { 1 } else { 0 }
 
     // By the powers of someone much more clever than me, this is equivalent.
     // mutants note: we do not have KATs that exercise all branches of this if
-    if z <= GAMMA2 || z > q - GAMMA2 || (z == q - GAMMA2 && r == 0) { 0 } else { 1 }
+    if z <= P::GAMMA2 || z > q - P::GAMMA2 || (z == q - P::GAMMA2 && r == 0) { 0 } else { 1 }
 }
 
 /// Algorithm 40 UseHint(ℎ, 𝑟)
 /// Returns the high bits of 𝑟 adjusted according to hint ℎ.
 /// Input: Boolean ℎ, 𝑟 ∈ ℤ𝑞.
 /// Output: 𝑟1 ∈ ℤ with 0 ≤ 𝑟1 ≤ (𝑞−1) / 2*gamma2).
-pub(super) fn use_hint<const GAMMA2: i32>(a: i32, hint: i32) -> i32 {
-    let (a0, a1) = decompose::<GAMMA2>(a);
+pub(super) fn use_hint<P: MLDSAParams>(a: i32, hint: i32) -> i32 {
+    let (a0, a1) = decompose::<P>(a);
 
     if hint == 0 {
         return a0;
@@ -754,8 +744,9 @@ pub(super) fn use_hint<const GAMMA2: i32>(a: i32, hint: i32) -> i32 {
 
     debug_assert!(hint == 1);
 
-    match GAMMA2 {
-        MLDSA44_GAMMA2 => {
+    match P::GAMMA2 {
+        // MLDSA-44
+        GAMMA2_Q_MINUS_1_OVER_88 => {
             // mutants note: this passes unit tests if it's a1 >= 0
             //      it is left like this because it matches the spec
             if a1 > 0 {
@@ -764,8 +755,8 @@ pub(super) fn use_hint<const GAMMA2: i32>(a: i32, hint: i32) -> i32 {
                 if a0 == 0 { 43 } else { a0 - 1 }
             }
         }
-        // ML-DSA65 and 87 have the same GAMMA2
-        MLDSA65_GAMMA2 => {
+        // ML-DSA65 and -87 have the same GAMMA2
+        GAMMA2_Q_MINUS_1_OVER_32 => {
             // mutants note: this passes unit tests if it's a0 >= 0
             //      it is left like this because it matches the spec
             if a1 > 0 { (a0 + 1) & 15 } else { (a0 - 1) & 15 }

--- a/crypto/mldsa-lowmemory/src/aux_functions.rs
+++ b/crypto/mldsa-lowmemory/src/aux_functions.rs
@@ -339,6 +339,7 @@ pub(crate) fn unpack_c_tilde<P: MLDSAParams>(sig: &[u8]) -> P::SigCTilde {
     c_tilde.as_mut().copy_from_slice(&sig[..P::C_TILDE_LEN]);
     c_tilde
 }
+
 /// Part of unpacking the sig value
 pub(crate) fn unpack_z_row<P: MLDSAParams, const SIG_LEN: usize>(
     idx: usize,

--- a/crypto/mldsa-lowmemory/src/aux_functions.rs
+++ b/crypto/mldsa-lowmemory/src/aux_functions.rs
@@ -35,7 +35,7 @@ pub(crate) fn coeff_from_three_bytes(b: &[u8; 3]) -> Result<i32, ()> {
 /// Output: An integer between −𝜂 and 𝜂, or ⊥.
 #[inline(always)]
 pub(crate) fn coeff_from_half_byte<P: MLDSAParams>(b: u8) -> Result<i32, ()> {
-    if P::ETA == 2 && b < 15 {
+    if P::eta == 2 && b < 15 {
         // Original code is bad because '%' is not constant-time.
         // Ok(2 - (b % 5) as i32)
         // TODO: Verify whether this function is constant time and whether it can be further optimized
@@ -46,7 +46,7 @@ pub(crate) fn coeff_from_half_byte<P: MLDSAParams>(b: u8) -> Result<i32, ()> {
         };
         Ok(2 - b as i32)
     } else {
-        if P::ETA == 4 && b < 9 { Ok(4 - b as i32) } else { Err(()) }
+        if P::eta == 4 && b < 9 { Ok(4 - b as i32) } else { Err(()) }
     }
 }
 
@@ -66,16 +66,6 @@ pub(crate) fn simple_bit_pack_t1(w: &Polynomial) -> [u8; POLY_T1PACKED_LEN] {
     output
 }
 
-/// As defined in Algorithm 17, this gives the length of a packed bitstring representing a polynomial
-/// whose coefficients have been rounded to \[-eta, eta], which is 32*bitlen(2*eta).
-pub const fn bitlen_eta(eta: usize) -> usize {
-    match eta {
-        2 => 32 * 3,
-        4 => 32 * 4,
-        _ => panic!("Invalid eta value"),
-    }
-}
-
 /// A variant of Algorithm 17 BitPack specific to a=eta, b=eta
 /// Encodes a polynomial 𝑤 into a byte string.
 /// Input: 𝑎, 𝑏 ∈ ℕ and 𝑤 ∈ 𝑅 such that the coefficients of 𝑤 are all in \[−eta, eta].
@@ -84,12 +74,12 @@ pub const fn bitlen_eta(eta: usize) -> usize {
 // and ETA = 4 each compile to just their own arm, leaving no dispatch at runtime.
 #[inline(always)]
 pub(crate) fn bit_pack_eta<P: MLDSAParams>(w: &Polynomial, r: &mut [u8]) {
-    debug_assert_eq!(r.len(), bitlen_eta(P::ETA));
+    debug_assert_eq!(r.len(), P::POLY_ETA_PACKED_LEN);
 
     // temp swap space
     let mut t: [u8; 8] = [0; 8];
 
-    match P::ETA {
+    match P::eta {
         // MLDSA-44 and MLDSA-87
         2 => {
             let eta: i32 = 2;
@@ -173,14 +163,14 @@ pub(crate) fn bitpack_gamma1<P: MLDSAParams>(z: &Polynomial, out: &mut [u8]) {
     out.fill(0);
 
     let mut t: [u32; 4] = [0; 4];
-    match P::GAMMA1 {
+    match P::gamma1 {
         // MLDSA-44
         GAMMA1_2_POW_17 => {
             for i in 0..N / 4 {
-                t[0] = (P::GAMMA1 - z[4 * i]) as u32;
-                t[1] = (P::GAMMA1 - z[4 * i + 1]) as u32;
-                t[2] = (P::GAMMA1 - z[4 * i + 2]) as u32;
-                t[3] = (P::GAMMA1 - z[4 * i + 3]) as u32;
+                t[0] = (P::gamma1 - z[4 * i]) as u32;
+                t[1] = (P::gamma1 - z[4 * i + 1]) as u32;
+                t[2] = (P::gamma1 - z[4 * i + 2]) as u32;
+                t[3] = (P::gamma1 - z[4 * i + 3]) as u32;
 
                 out[9 * i] = t[0] as u8;
                 out[9 * i + 1] = (t[0] >> 8) as u8;
@@ -196,8 +186,8 @@ pub(crate) fn bitpack_gamma1<P: MLDSAParams>(z: &Polynomial, out: &mut [u8]) {
         // MLDSA-65 and -87 have the same GAMMA1 value
         GAMMA1_2_POW_19 => {
             for i in 0..N / 2 {
-                t[0] = (P::GAMMA1 - z[2 * i]) as u32;
-                t[1] = (P::GAMMA1 - z[2 * i + 1]) as u32;
+                t[0] = (P::gamma1 - z[2 * i]) as u32;
+                t[1] = (P::gamma1 - z[2 * i + 1]) as u32;
 
                 out[5 * i] = t[0] as u8;
                 out[5 * i + 1] = (t[0] >> 8) as u8;
@@ -219,8 +209,6 @@ pub(crate) fn bitpack_gamma1<P: MLDSAParams>(z: &Polynomial, out: &mut [u8]) {
 ///
 /// Note: caller is responsible for ensuring correct input array size
 pub(crate) fn simple_bit_unpack_t1(v: &[u8; POLY_T1PACKED_LEN]) -> Polynomial {
-    // debug_assert_eq!(v.len(), POLY_T1PACKED_LEN);
-
     let mut w = Polynomial::new();
 
     for i in 0..N / 4 {
@@ -244,9 +232,9 @@ pub(crate) fn simple_bit_unpack_t1(v: &[u8; POLY_T1PACKED_LEN]) -> Polynomial {
 // and ETA = 4 each compile to just their own arm, leaving no dispatch at runtime.
 #[inline(always)]
 pub(crate) fn bit_unpack_eta_out<P: MLDSAParams>(v: &[u8], w: &mut Polynomial) {
-    debug_assert_eq!(v.len(), bitlen_eta(P::ETA));
+    debug_assert_eq!(v.len(), P::POLY_ETA_PACKED_LEN);
 
-    match P::ETA {
+    match P::eta {
         // MLDSA44 and MLDSA87
         2 => {
             let eta: i32 = 2;
@@ -298,7 +286,7 @@ pub(crate) fn bit_unpack_eta_out<P: MLDSAParams>(v: &[u8], w: &mut Polynomial) {
 pub(crate) fn bit_unpack_gamma1<P: MLDSAParams>(v: &[u8]) -> Polynomial {
     let mut w = Polynomial::new();
 
-    match P::GAMMA1 {
+    match P::gamma1 {
         // MLDSA-44
         GAMMA1_2_POW_17 => {
             // const gamma1: i32 = 1<<17;
@@ -316,10 +304,10 @@ pub(crate) fn bit_unpack_gamma1<P: MLDSAParams>(v: &[u8]) -> Polynomial {
                     | ((v[9 * i + 8] as i32) << 10))
                     & 0x3FFFF;
 
-                w[4 * i] = P::GAMMA1 - w[4 * i];
-                w[4 * i + 1] = P::GAMMA1 - w[4 * i + 1];
-                w[4 * i + 2] = P::GAMMA1 - w[4 * i + 2];
-                w[4 * i + 3] = P::GAMMA1 - w[4 * i + 3];
+                w[4 * i] = P::gamma1 - w[4 * i];
+                w[4 * i + 1] = P::gamma1 - w[4 * i + 1];
+                w[4 * i + 2] = P::gamma1 - w[4 * i + 2];
+                w[4 * i + 3] = P::gamma1 - w[4 * i + 3];
             }
         }
         // MLDSA-65 and -87 have the same GAMMA1 value
@@ -333,8 +321,8 @@ pub(crate) fn bit_unpack_gamma1<P: MLDSAParams>(v: &[u8]) -> Polynomial {
                     | ((v[5 * i + 4] as i32) << 12))
                     & 0xFFFFF;
 
-                w[2 * i] = P::GAMMA1 - w[2 * i];
-                w[2 * i + 1] = P::GAMMA1 - w[2 * i + 1];
+                w[2 * i] = P::gamma1 - w[2 * i];
+                w[2 * i + 1] = P::gamma1 - w[2 * i + 1];
             }
         }
         _ => {
@@ -366,7 +354,7 @@ pub(crate) fn unpack_z_row<P: MLDSAParams, const SIG_LEN: usize>(
 
     // Perform the norm check from
     // Alg 8; Line 13 (first half) return [[ ||𝐳||∞ < 𝛾1 − 𝛽]]
-    if z.check_norm(P::GAMMA1_MINUS_BETA) { Err(()) } else { Ok(z) }
+    if z.check_norm(P::gamma1_minus_beta) { Err(()) } else { Ok(z) }
 }
 /// Part of unpacking the sig value
 pub(crate) fn unpack_h_row<P: MLDSAParams, const SIG_LEN: usize>(
@@ -387,15 +375,15 @@ pub(crate) fn unpack_h_row<P: MLDSAParams, const SIG_LEN: usize>(
     // let mut idx = 0usize;
     // This row calc is a bit weird because technically it's supposed to be done at the end
     // of the previous loop
-    let idx = if row == 0 { 0 } else { sig[pos + P::OMEGA as usize + row - 1] as usize };
+    let idx = if row == 0 { 0 } else { sig[pos + P::omega as usize + row - 1] as usize };
 
     // 3: for 𝑖 from 0 to 𝑘 − 1 do
     //  ▷ reconstruct 𝐡[𝑖]
     // for i in 0..k {
     // 4: if 𝑦[𝜔 + 𝑖] < Index or 𝑦[𝜔 + 𝑖] > 𝜔 then return ⊥
     // mutants note: don't have test vectors that exercise this condition
-    if sig[pos + (P::OMEGA as usize) + row] < (idx as u8)
-        || sig[pos + (P::OMEGA as usize) + row] > P::OMEGA as u8
+    if sig[pos + (P::omega as usize) + row] < (idx as u8)
+        || sig[pos + (P::omega as usize) + row] > P::omega as u8
     {
         return None;
     }
@@ -403,7 +391,7 @@ pub(crate) fn unpack_h_row<P: MLDSAParams, const SIG_LEN: usize>(
     // 6: First ← Index
     // 7: while Index < 𝑦[𝜔 + 𝑖] do
     //   ▷ 𝑦[𝜔 + 𝑖] says how far one can advance Index
-    for j in idx..sig[pos + P::OMEGA as usize + row] as usize {
+    for j in idx..sig[pos + P::omega as usize + row] as usize {
         // 8: if Index > First then
         // 9:   if 𝑦[Index − 1] ≥ 𝑦[Index] then return ⊥
         //       ▷ malformed input
@@ -421,8 +409,8 @@ pub(crate) fn unpack_h_row<P: MLDSAParams, const SIG_LEN: usize>(
     // ▷ read any leftover bytes in the first 𝜔 bytes of 𝑦 for malformed (nonzero) bytes
     // mutants note:
     if row == P::k - 1 {
-        let idx = sig[pos + P::OMEGA as usize + row] as usize;
-        for j in idx..P::OMEGA as usize {
+        let idx = sig[pos + P::omega as usize + row] as usize;
+        for j in idx..P::omega as usize {
             if sig[pos + j] != 0 {
                 return None;
             }
@@ -460,7 +448,7 @@ pub(crate) fn sample_in_ball<P: MLDSAParams>(rho: &P::SigCTilde) -> Polynomial {
     // let mut pos = 8;
     // let mut b;
     let mut j = [0u8];
-    for i in (N - P::TAU as usize)..N {
+    for i in (N - P::tau as usize)..N {
         // 7: (ctx, 𝑗) ← H.Squeeze(ctx, 1)
         // Note: At first, it might seem to be faster to pre-squeeze a buffer outside the loop.
         // However, after experimentation and testing, the difference is not noticeable.
@@ -661,13 +649,14 @@ pub(crate) fn decompose<P: MLDSAParams>(r: i32) -> (i32, i32) {
     let mut r1: i32;
     let mut r0 = (r + 127) >> 7;
 
-    match P::GAMMA2 {
+    match P::gamma2 {
+        // MLDSO-44
         GAMMA2_Q_MINUS_1_OVER_88 => {
             // (q - 1) / 88
             r0 = (r0 * 11275 + (1 << 23)) >> 24;
             r0 ^= ((43 - r0) >> 31) & r0;
         }
-        // ML-DSA65 and 87 have the same GAMMA2
+        // ML-DSA-65 and -87 have the same GAMMA2
         GAMMA2_Q_MINUS_1_OVER_32 => {
             // (q - 1) / 32;
             r0 = (r0 * 1025 + (1 << 21)) >> 22;
@@ -679,7 +668,7 @@ pub(crate) fn decompose<P: MLDSAParams>(r: i32) -> (i32, i32) {
         }
     }
 
-    r1 = r - r0 * 2 * P::GAMMA2;
+    r1 = r - r0 * 2 * P::gamma2;
 
     // mutants note: the choice of (q - 1) is a bit arbitrary in that after doing the bit-shifting,
     // this seems to work out mathematically equivalent to doing q/2, or (q+3)/2, but here it is left as (q-1)/2
@@ -728,7 +717,7 @@ pub(crate) fn make_hint<P: MLDSAParams>(z: i32, r: i32) -> i32 {
 
     // By the powers of someone much more clever than me, this is equivalent.
     // mutants note: we do not have KATs that exercise all branches of this if
-    if z <= P::GAMMA2 || z > q - P::GAMMA2 || (z == q - P::GAMMA2 && r == 0) { 0 } else { 1 }
+    if z <= P::gamma2 || z > q - P::gamma2 || (z == q - P::gamma2 && r == 0) { 0 } else { 1 }
 }
 
 /// Algorithm 40 UseHint(ℎ, 𝑟)
@@ -744,7 +733,7 @@ pub(super) fn use_hint<P: MLDSAParams>(a: i32, hint: i32) -> i32 {
 
     debug_assert!(hint == 1);
 
-    match P::GAMMA2 {
+    match P::gamma2 {
         // MLDSA-44
         GAMMA2_Q_MINUS_1_OVER_88 => {
             // mutants note: this passes unit tests if it's a1 >= 0

--- a/crypto/mldsa-lowmemory/src/hash_mldsa.rs
+++ b/crypto/mldsa-lowmemory/src/hash_mldsa.rs
@@ -87,7 +87,6 @@ use bouncycastle_core::traits::{
 };
 use bouncycastle_rng::HashDRBG_SHA512;
 use core::marker::PhantomData;
-
 // Imports needed only for docs
 #[allow(unused_imports)]
 use crate::mldsa::MuBuilder;
@@ -110,28 +109,28 @@ pub const HASH_ML_DSA_87_WITH_SHA512_NAME: &str = "HashML-DSA-87_with_SHA512";
 /*** Pub Types ***/
 
 impl<
-    HP: HashMLDSAParams,
-    PK: MLDSAPublicKeyTrait<HP::MLDSA, PK_LEN> + MLDSAPublicKeyInternalTrait<HP::MLDSA, PK_LEN>,
-    SK: MLDSAPrivateKeyTrait<HP::MLDSA, PK_LEN, SK_LEN, FULL_SK_LEN>
-        + MLDSAPrivateKeyInternalTrait<HP::MLDSA, PK_LEN, SK_LEN>,
+    P: HashMLDSAParams,
+    PK: MLDSAPublicKeyTrait<P::MLDSA, PK_LEN> + MLDSAPublicKeyInternalTrait<P::MLDSA, PK_LEN>,
+    SK: MLDSAPrivateKeyTrait<P::MLDSA, PK_LEN, SK_LEN, FULL_SK_LEN>
+        + MLDSAPrivateKeyInternalTrait<P::MLDSA, PK_LEN, SK_LEN>,
     const PH_LEN: usize,
     const PK_LEN: usize,
     const SK_LEN: usize,
     const FULL_SK_LEN: usize,
     const SIG_LEN: usize,
-> Algorithm for HashMLDSA<HP, PK, SK, PH_LEN, PK_LEN, SK_LEN, FULL_SK_LEN, SIG_LEN>
+> Algorithm for HashMLDSA<P, PK, SK, PH_LEN, PK_LEN, SK_LEN, FULL_SK_LEN, SIG_LEN>
 {
-    const ALG_NAME: &'static str = HP::ALG_NAME;
-    const MAX_SECURITY_STRENGTH: SecurityStrength = HP::MAX_SECURITY_STRENGTH;
+    const ALG_NAME: &'static str = P::ALG_NAME;
+    const MAX_SECURITY_STRENGTH: SecurityStrength = P::MAX_SECURITY_STRENGTH;
 }
 
-/// The HashML-DSA-44_with_SHA512 signature algorithm.
+/// The HashML-DSA-44_with_SHA256 signature algorithm.
 #[allow(non_camel_case_types)]
 pub type HashMLDSA44_with_SHA256 = HashMLDSA<
     HashMLDSA44_with_SHA256Params,
     MLDSA44PublicKey,
     MLDSA44PrivateKey,
-    32,
+    { HashMLDSA44_with_SHA256Params::PH_LEN },
     MLDSA44_PK_LEN,
     MLDSA44_SK_LEN,
     MLDSA44_FULL_SK_LEN,
@@ -144,7 +143,7 @@ pub type HashMLDSA65_with_SHA256 = HashMLDSA<
     HashMLDSA65_with_SHA256Params,
     MLDSA65PublicKey,
     MLDSA65PrivateKey,
-    32,
+    { HashMLDSA65_with_SHA256Params::PH_LEN },
     MLDSA65_PK_LEN,
     MLDSA65_SK_LEN,
     MLDSA65_FULL_SK_LEN,
@@ -157,7 +156,7 @@ pub type HashMLDSA87_with_SHA256 = HashMLDSA<
     HashMLDSA87_with_SHA256Params,
     MLDSA87PublicKey,
     MLDSA87PrivateKey,
-    32,
+    { HashMLDSA87_with_SHA256Params::PH_LEN },
     MLDSA87_PK_LEN,
     MLDSA87_SK_LEN,
     MLDSA87_FULL_SK_LEN,
@@ -170,7 +169,7 @@ pub type HashMLDSA44_with_SHA512 = HashMLDSA<
     HashMLDSA44_with_SHA512Params,
     MLDSA44PublicKey,
     MLDSA44PrivateKey,
-    64,
+    { HashMLDSA44_with_SHA512Params::PH_LEN },
     MLDSA44_PK_LEN,
     MLDSA44_SK_LEN,
     MLDSA44_FULL_SK_LEN,
@@ -189,7 +188,7 @@ pub type HashMLDSA65_with_SHA512 = HashMLDSA<
     HashMLDSA65_with_SHA512Params,
     MLDSA65PublicKey,
     MLDSA65PrivateKey,
-    64,
+    { HashMLDSA65_with_SHA512Params::PH_LEN },
     MLDSA65_PK_LEN,
     MLDSA65_SK_LEN,
     MLDSA65_FULL_SK_LEN,
@@ -208,7 +207,7 @@ pub type HashMLDSA87_with_SHA512 = HashMLDSA<
     HashMLDSA87_with_SHA512Params,
     MLDSA87PublicKey,
     MLDSA87PrivateKey,
-    64,
+    { HashMLDSA87_with_SHA512Params::PH_LEN },
     MLDSA87_PK_LEN,
     MLDSA87_SK_LEN,
     MLDSA87_FULL_SK_LEN,
@@ -228,17 +227,17 @@ impl AlgorithmOID for HashMLDSA87_with_SHA512 {
 /// by specifying the hash function to use (in the verifier), and specifying the bytes of the OID to
 /// to use as its domain separator in constructing the message representative M'.
 pub struct HashMLDSA<
-    HP: HashMLDSAParams,
-    PK: MLDSAPublicKeyTrait<HP::MLDSA, PK_LEN> + MLDSAPublicKeyInternalTrait<HP::MLDSA, PK_LEN>,
-    SK: MLDSAPrivateKeyTrait<HP::MLDSA, PK_LEN, SK_LEN, FULL_SK_LEN>
-        + MLDSAPrivateKeyInternalTrait<HP::MLDSA, PK_LEN, SK_LEN>,
+    P: HashMLDSAParams,
+    PK: MLDSAPublicKeyTrait<P::MLDSA, PK_LEN> + MLDSAPublicKeyInternalTrait<P::MLDSA, PK_LEN>,
+    SK: MLDSAPrivateKeyTrait<P::MLDSA, PK_LEN, SK_LEN, FULL_SK_LEN>
+        + MLDSAPrivateKeyInternalTrait<P::MLDSA, PK_LEN, SK_LEN>,
     const PH_LEN: usize,
     const PK_LEN: usize,
     const SK_LEN: usize,
     const FULL_SK_LEN: usize,
     const SIG_LEN: usize,
 > {
-    _phantom: PhantomData<(HP, PK, SK)>,
+    _phantom: PhantomData<(P, PK, SK)>,
 
     signer_rnd: Option<[u8; MLDSA_RND_LEN]>,
 
@@ -252,7 +251,7 @@ pub struct HashMLDSA<
     pk: Option<PK>,
 
     /// Hash function instance for streaming message hashing
-    hash: HP::PreHash,
+    hash: P::PreHash,
 
     /// Since HashML-DSA does message buffering in the external pre-hash, not in mu,
     /// this needs to be saved for later
@@ -261,16 +260,16 @@ pub struct HashMLDSA<
 }
 
 impl<
-    HP: HashMLDSAParams,
-    PK: MLDSAPublicKeyTrait<HP::MLDSA, PK_LEN> + MLDSAPublicKeyInternalTrait<HP::MLDSA, PK_LEN>,
-    SK: MLDSAPrivateKeyTrait<HP::MLDSA, PK_LEN, SK_LEN, FULL_SK_LEN>
-        + MLDSAPrivateKeyInternalTrait<HP::MLDSA, PK_LEN, SK_LEN>,
+    P: HashMLDSAParams,
+    PK: MLDSAPublicKeyTrait<P::MLDSA, PK_LEN> + MLDSAPublicKeyInternalTrait<P::MLDSA, PK_LEN>,
+    SK: MLDSAPrivateKeyTrait<P::MLDSA, PK_LEN, SK_LEN, FULL_SK_LEN>
+        + MLDSAPrivateKeyInternalTrait<P::MLDSA, PK_LEN, SK_LEN>,
     const PH_LEN: usize,
     const PK_LEN: usize,
     const SK_LEN: usize,
     const FULL_SK_LEN: usize,
     const SIG_LEN: usize,
-> HashMLDSA<HP, PK, SK, PH_LEN, PK_LEN, SK_LEN, FULL_SK_LEN, SIG_LEN>
+> HashMLDSA<P, PK, SK, PH_LEN, PK_LEN, SK_LEN, FULL_SK_LEN, SIG_LEN>
 {
     /// Generate a keypair, sourcing randomness from bouncycastle's default os-backed RNG.
     ///
@@ -279,12 +278,12 @@ impl<
     /// Keys are interchangeable between MLDSA and HashMLDSA.
     /// Error condition: basically only on RNG failures.
     pub fn keygen() -> Result<(PK, SK), SignatureError> {
-        MLDSA::<HP::MLDSA, PK, SK, PK_LEN, SK_LEN, FULL_SK_LEN, SIG_LEN>::keygen()
+        MLDSA::<P::MLDSA, PK, SK, PK_LEN, SK_LEN, FULL_SK_LEN, SIG_LEN>::keygen()
     }
 
     /// Imports a secret key from a seed.
     pub fn keygen_from_seed(seed: &KeyMaterial<32>) -> Result<(PK, SK), SignatureError> {
-        MLDSA::<HP::MLDSA, PK, SK, PK_LEN, SK_LEN, FULL_SK_LEN, SIG_LEN>::keygen_internal(seed)
+        MLDSA::<P::MLDSA, PK, SK, PK_LEN, SK_LEN, FULL_SK_LEN, SIG_LEN>::keygen_internal(seed)
     }
 
     /// Algorithm 7 ML-DSA.Sign_internal(𝑠𝑘, 𝑀′, 𝑟𝑛𝑑)
@@ -351,7 +350,7 @@ impl<
         h.absorb(&[1u8]).expect("absorb before squeeze is infallible");
         h.absorb(&[ctx.len() as u8]).expect("absorb before squeeze is infallible");
         h.absorb(ctx).expect("absorb before squeeze is infallible");
-        h.absorb(<HP::PreHash as AlgorithmOID>::OID_DER)
+        h.absorb(<P::PreHash as AlgorithmOID>::OID_DER)
             .expect("absorb before squeeze is infallible");
         h.absorb(ph).expect("absorb before squeeze is infallible");
         let mut mu = [0u8; MLDSA_MU_LEN];
@@ -359,7 +358,7 @@ impl<
         debug_assert_eq!(bytes_written, MLDSA_MU_LEN);
 
         // 24: 𝜎 ← ML-DSA.Sign_internal(𝑠𝑘, 𝑀', 𝑟𝑛𝑑)
-        let bytes_written = MLDSA::<HP::MLDSA, PK, SK, PK_LEN, SK_LEN, FULL_SK_LEN, SIG_LEN>::sign_mu_deterministic_out(sk, &mu, rnd, output)?;
+        let bytes_written = MLDSA::<P::MLDSA, PK, SK, PK_LEN, SK_LEN, FULL_SK_LEN, SIG_LEN>::sign_mu_deterministic_out(sk, &mu, rnd, output)?;
 
         Ok(bytes_written)
     }
@@ -400,7 +399,7 @@ impl<
             sk: None,
             seed: Some(seed.clone()),
             pk: None,
-            hash: <HP::PreHash as Default>::default(),
+            hash: <P::PreHash as Default>::default(),
             ctx,
             ctx_len,
         })
@@ -408,17 +407,17 @@ impl<
 }
 
 impl<
-    HP: HashMLDSAParams,
-    PK: MLDSAPublicKeyTrait<HP::MLDSA, PK_LEN> + MLDSAPublicKeyInternalTrait<HP::MLDSA, PK_LEN>,
-    SK: MLDSAPrivateKeyTrait<HP::MLDSA, PK_LEN, SK_LEN, FULL_SK_LEN>
-        + MLDSAPrivateKeyInternalTrait<HP::MLDSA, PK_LEN, SK_LEN>,
+    P: HashMLDSAParams,
+    PK: MLDSAPublicKeyTrait<P::MLDSA, PK_LEN> + MLDSAPublicKeyInternalTrait<P::MLDSA, PK_LEN>,
+    SK: MLDSAPrivateKeyTrait<P::MLDSA, PK_LEN, SK_LEN, FULL_SK_LEN>
+        + MLDSAPrivateKeyInternalTrait<P::MLDSA, PK_LEN, SK_LEN>,
     const PH_LEN: usize,
     const PK_LEN: usize,
     const SK_LEN: usize,
     const FULL_SK_LEN: usize,
     const SIG_LEN: usize,
 > Signer<SK, SK_LEN, SIG_LEN>
-    for HashMLDSA<HP, PK, SK, PH_LEN, PK_LEN, SK_LEN, FULL_SK_LEN, SIG_LEN>
+    for HashMLDSA<P, PK, SK, PH_LEN, PK_LEN, SK_LEN, FULL_SK_LEN, SIG_LEN>
 {
     /// Algorithm 4 HashML-DSA.Sign(𝑠𝑘, 𝑀 , 𝑐𝑡𝑥, PH)
     /// Generate a “pre-hash” ML-DSA signature.
@@ -438,7 +437,7 @@ impl<
         output.fill(0);
 
         let mut ph_m = [0u8; PH_LEN];
-        _ = <HP::PreHash as Default>::default().hash_out(msg, &mut ph_m);
+        _ = <P::PreHash as Default>::default().hash_out(msg, &mut ph_m);
         Self::sign_ph_out(sk, &ph_m, ctx, output)
     }
 
@@ -450,7 +449,7 @@ impl<
             sk: Some(sk.clone()),
             seed: None,
             pk: None,
-            hash: <HP::PreHash as Default>::default(),
+            hash: <P::PreHash as Default>::default(),
             ctx,
             ctx_len,
         })
@@ -508,21 +507,21 @@ impl<
 }
 
 impl<
-    HP: HashMLDSAParams,
-    PK: MLDSAPublicKeyTrait<HP::MLDSA, PK_LEN> + MLDSAPublicKeyInternalTrait<HP::MLDSA, PK_LEN>,
-    SK: MLDSAPrivateKeyTrait<HP::MLDSA, PK_LEN, SK_LEN, FULL_SK_LEN>
-        + MLDSAPrivateKeyInternalTrait<HP::MLDSA, PK_LEN, SK_LEN>,
+    P: HashMLDSAParams,
+    PK: MLDSAPublicKeyTrait<P::MLDSA, PK_LEN> + MLDSAPublicKeyInternalTrait<P::MLDSA, PK_LEN>,
+    SK: MLDSAPrivateKeyTrait<P::MLDSA, PK_LEN, SK_LEN, FULL_SK_LEN>
+        + MLDSAPrivateKeyInternalTrait<P::MLDSA, PK_LEN, SK_LEN>,
     const PH_LEN: usize,
     const PK_LEN: usize,
     const SK_LEN: usize,
     const FULL_SK_LEN: usize,
     const SIG_LEN: usize,
 > SignatureVerifier<PK, PK_LEN, SIG_LEN>
-    for HashMLDSA<HP, PK, SK, PH_LEN, PK_LEN, SK_LEN, FULL_SK_LEN, SIG_LEN>
+    for HashMLDSA<P, PK, SK, PH_LEN, PK_LEN, SK_LEN, FULL_SK_LEN, SIG_LEN>
 {
     fn verify(pk: &PK, msg: &[u8], ctx: Option<&[u8]>, sig: &[u8]) -> Result<(), SignatureError> {
         let mut ph_m = [0u8; PH_LEN];
-        _ = <HP::PreHash as Default>::default().hash_out(msg, &mut ph_m);
+        _ = <P::PreHash as Default>::default().hash_out(msg, &mut ph_m);
 
         Self::verify_ph(pk, &ph_m, ctx, sig)
     }
@@ -535,7 +534,7 @@ impl<
             sk: None,
             seed: None,
             pk: Some(pk.clone()),
-            hash: <HP::PreHash as Default>::default(),
+            hash: <P::PreHash as Default>::default(),
             ctx,
             ctx_len,
         })
@@ -556,17 +555,17 @@ impl<
 }
 
 impl<
-    HP: HashMLDSAParams,
-    PK: MLDSAPublicKeyTrait<HP::MLDSA, PK_LEN> + MLDSAPublicKeyInternalTrait<HP::MLDSA, PK_LEN>,
-    SK: MLDSAPrivateKeyTrait<HP::MLDSA, PK_LEN, SK_LEN, FULL_SK_LEN>
-        + MLDSAPrivateKeyInternalTrait<HP::MLDSA, PK_LEN, SK_LEN>,
+    P: HashMLDSAParams,
+    PK: MLDSAPublicKeyTrait<P::MLDSA, PK_LEN> + MLDSAPublicKeyInternalTrait<P::MLDSA, PK_LEN>,
+    SK: MLDSAPrivateKeyTrait<P::MLDSA, PK_LEN, SK_LEN, FULL_SK_LEN>
+        + MLDSAPrivateKeyInternalTrait<P::MLDSA, PK_LEN, SK_LEN>,
     const PH_LEN: usize,
     const PK_LEN: usize,
     const SK_LEN: usize,
     const FULL_SK_LEN: usize,
     const SIG_LEN: usize,
 > PHSigner<PK, SK, PK_LEN, SK_LEN, SIG_LEN, PH_LEN>
-    for HashMLDSA<HP, PK, SK, PH_LEN, PK_LEN, SK_LEN, FULL_SK_LEN, SIG_LEN>
+    for HashMLDSA<P, PK, SK, PH_LEN, PK_LEN, SK_LEN, FULL_SK_LEN, SIG_LEN>
 {
     fn sign_ph(
         sk: &SK,
@@ -598,17 +597,17 @@ impl<
 }
 
 impl<
-    HP: HashMLDSAParams,
-    PK: MLDSAPublicKeyTrait<HP::MLDSA, PK_LEN> + MLDSAPublicKeyInternalTrait<HP::MLDSA, PK_LEN>,
-    SK: MLDSAPrivateKeyTrait<HP::MLDSA, PK_LEN, SK_LEN, FULL_SK_LEN>
-        + MLDSAPrivateKeyInternalTrait<HP::MLDSA, PK_LEN, SK_LEN>,
+    P: HashMLDSAParams,
+    PK: MLDSAPublicKeyTrait<P::MLDSA, PK_LEN> + MLDSAPublicKeyInternalTrait<P::MLDSA, PK_LEN>,
+    SK: MLDSAPrivateKeyTrait<P::MLDSA, PK_LEN, SK_LEN, FULL_SK_LEN>
+        + MLDSAPrivateKeyInternalTrait<P::MLDSA, PK_LEN, SK_LEN>,
     const PH_LEN: usize,
     const PK_LEN: usize,
     const SK_LEN: usize,
     const FULL_SK_LEN: usize,
     const SIG_LEN: usize,
 > PHSignatureVerifier<PK, PK_LEN, SIG_LEN, PH_LEN>
-    for HashMLDSA<HP, PK, SK, PH_LEN, PK_LEN, SK_LEN, FULL_SK_LEN, SIG_LEN>
+    for HashMLDSA<P, PK, SK, PH_LEN, PK_LEN, SK_LEN, FULL_SK_LEN, SIG_LEN>
 {
     fn verify_ph(
         pk: &PK,
@@ -640,13 +639,13 @@ impl<
         h.absorb(&[1u8]).expect("absorb before squeeze is infallible");
         h.absorb(&[ctx.len() as u8]).expect("absorb before squeeze is infallible");
         h.absorb(ctx).expect("absorb before squeeze is infallible");
-        h.absorb(<HP::PreHash as AlgorithmOID>::OID_DER)
+        h.absorb(<P::PreHash as AlgorithmOID>::OID_DER)
             .expect("absorb before squeeze is infallible");
         h.absorb(ph).expect("absorb before squeeze is infallible");
         let mut mu = [0u8; MLDSA_MU_LEN];
         _ = h.squeeze_out(&mut mu);
 
-        MLDSA::<HP::MLDSA, PK, SK, PK_LEN, SK_LEN, FULL_SK_LEN, SIG_LEN>::verify_mu(
+        MLDSA::<P::MLDSA, PK, SK, PK_LEN, SK_LEN, FULL_SK_LEN, SIG_LEN>::verify_mu(
             pk, &mu, sig_sized,
         )
     }

--- a/crypto/mldsa-lowmemory/src/hash_mldsa.rs
+++ b/crypto/mldsa-lowmemory/src/hash_mldsa.rs
@@ -66,29 +66,15 @@
 //! But a simple [`HashMLDSA::keygen`] is provided.
 
 use crate::mldsa::{H, MLDSA_MU_LEN, MLDSA_RND_LEN, MLDSATrait};
-use crate::mldsa::{
-    MLDSA44_BETA, MLDSA44_C_TILDE, MLDSA44_ETA, MLDSA44_FULL_SK_LEN, MLDSA44_GAMMA1,
-    MLDSA44_GAMMA1_MASK_LEN, MLDSA44_GAMMA1_MINUS_BETA, MLDSA44_GAMMA2, MLDSA44_GAMMA2_MINUS_BETA,
-    MLDSA44_LAMBDA, MLDSA44_LAMBDA_over_4, MLDSA44_OMEGA, MLDSA44_PK_LEN,
-    MLDSA44_POLY_W1_PACKED_LEN, MLDSA44_POLY_Z_PACKED_LEN, MLDSA44_S1_PACKED_LEN,
-    MLDSA44_S2_PACKED_LEN, MLDSA44_SIG_LEN, MLDSA44_SK_LEN, MLDSA44_TAU, MLDSA44_k, MLDSA44_l,
-};
-use crate::mldsa::{MLDSA44_T1_PACKED_LEN, MLDSA65_T1_PACKED_LEN, MLDSA87_T1_PACKED_LEN};
-use crate::mldsa::{
-    MLDSA65_BETA, MLDSA65_C_TILDE, MLDSA65_ETA, MLDSA65_FULL_SK_LEN, MLDSA65_GAMMA1,
-    MLDSA65_GAMMA1_MASK_LEN, MLDSA65_GAMMA1_MINUS_BETA, MLDSA65_GAMMA2, MLDSA65_GAMMA2_MINUS_BETA,
-    MLDSA65_LAMBDA, MLDSA65_LAMBDA_over_4, MLDSA65_OMEGA, MLDSA65_PK_LEN,
-    MLDSA65_POLY_W1_PACKED_LEN, MLDSA65_POLY_Z_PACKED_LEN, MLDSA65_S1_PACKED_LEN,
-    MLDSA65_S2_PACKED_LEN, MLDSA65_SIG_LEN, MLDSA65_SK_LEN, MLDSA65_TAU, MLDSA65_k, MLDSA65_l,
-};
-use crate::mldsa::{
-    MLDSA87_BETA, MLDSA87_C_TILDE, MLDSA87_ETA, MLDSA87_FULL_SK_LEN, MLDSA87_GAMMA1,
-    MLDSA87_GAMMA1_MASK_LEN, MLDSA87_GAMMA1_MINUS_BETA, MLDSA87_GAMMA2, MLDSA87_GAMMA2_MINUS_BETA,
-    MLDSA87_LAMBDA, MLDSA87_LAMBDA_over_4, MLDSA87_OMEGA, MLDSA87_PK_LEN,
-    MLDSA87_POLY_W1_PACKED_LEN, MLDSA87_POLY_Z_PACKED_LEN, MLDSA87_S1_PACKED_LEN,
-    MLDSA87_S2_PACKED_LEN, MLDSA87_SIG_LEN, MLDSA87_SK_LEN, MLDSA87_TAU, MLDSA87_k, MLDSA87_l,
-};
+use crate::mldsa::{MLDSA44_FULL_SK_LEN, MLDSA44_PK_LEN, MLDSA44_SIG_LEN, MLDSA44_SK_LEN};
+use crate::mldsa::{MLDSA65_FULL_SK_LEN, MLDSA65_PK_LEN, MLDSA65_SIG_LEN, MLDSA65_SK_LEN};
+use crate::mldsa::{MLDSA87_FULL_SK_LEN, MLDSA87_PK_LEN, MLDSA87_SIG_LEN, MLDSA87_SK_LEN};
 use crate::mldsa_keys::{MLDSAPrivateKeyInternalTrait, MLDSAPublicKeyInternalTrait};
+use crate::params::{
+    HashMLDSA44_with_SHA256Params, HashMLDSA44_with_SHA512Params, HashMLDSA65_with_SHA256Params,
+    HashMLDSA65_with_SHA512Params, HashMLDSA87_with_SHA256Params, HashMLDSA87_with_SHA512Params,
+    HashMLDSAParams,
+};
 use crate::{
     MLDSA, MLDSA44PrivateKey, MLDSA44PublicKey, MLDSA65PrivateKey, MLDSA65PublicKey,
     MLDSA87PrivateKey, MLDSA87PublicKey, MLDSAPrivateKeyTrait, MLDSAPublicKeyTrait,
@@ -100,7 +86,6 @@ use bouncycastle_core::traits::{
     SignatureVerifier, Signer, XOF,
 };
 use bouncycastle_rng::HashDRBG_SHA512;
-use bouncycastle_sha2::{SHA256, SHA512};
 use core::marker::PhantomData;
 
 // Imports needed only for docs
@@ -124,153 +109,73 @@ pub const HASH_ML_DSA_87_WITH_SHA512_NAME: &str = "HashML-DSA-87_with_SHA512";
 
 /*** Pub Types ***/
 
+impl<
+    HP: HashMLDSAParams,
+    PK: MLDSAPublicKeyTrait<HP::MLDSA, PK_LEN> + MLDSAPublicKeyInternalTrait<HP::MLDSA, PK_LEN>,
+    SK: MLDSAPrivateKeyTrait<HP::MLDSA, PK_LEN, SK_LEN, FULL_SK_LEN>
+        + MLDSAPrivateKeyInternalTrait<HP::MLDSA, PK_LEN, SK_LEN>,
+    const PH_LEN: usize,
+    const PK_LEN: usize,
+    const SK_LEN: usize,
+    const FULL_SK_LEN: usize,
+    const SIG_LEN: usize,
+> Algorithm for HashMLDSA<HP, PK, SK, PH_LEN, PK_LEN, SK_LEN, FULL_SK_LEN, SIG_LEN>
+{
+    const ALG_NAME: &'static str = HP::ALG_NAME;
+    const MAX_SECURITY_STRENGTH: SecurityStrength = HP::MAX_SECURITY_STRENGTH;
+}
+
 /// The HashML-DSA-44_with_SHA512 signature algorithm.
 #[allow(non_camel_case_types)]
 pub type HashMLDSA44_with_SHA256 = HashMLDSA<
-    SHA256,
+    HashMLDSA44_with_SHA256Params,
+    MLDSA44PublicKey,
+    MLDSA44PrivateKey,
     32,
     MLDSA44_PK_LEN,
     MLDSA44_SK_LEN,
     MLDSA44_FULL_SK_LEN,
     MLDSA44_SIG_LEN,
-    MLDSA44PublicKey,
-    MLDSA44PrivateKey,
-    MLDSA44_TAU,
-    MLDSA44_LAMBDA,
-    MLDSA44_GAMMA1,
-    MLDSA44_GAMMA2,
-    MLDSA44_k,
-    MLDSA44_l,
-    MLDSA44_ETA,
-    MLDSA44_BETA,
-    MLDSA44_OMEGA,
-    MLDSA44_C_TILDE,
-    MLDSA44_POLY_Z_PACKED_LEN,
-    MLDSA44_POLY_W1_PACKED_LEN,
-    MLDSA44_S1_PACKED_LEN,
-    MLDSA44_S2_PACKED_LEN,
-    MLDSA44_T1_PACKED_LEN,
-    MLDSA44_LAMBDA_over_4,
-    MLDSA44_GAMMA1_MINUS_BETA,
-    MLDSA44_GAMMA2_MINUS_BETA,
-    MLDSA44_GAMMA1_MASK_LEN,
 >;
-
-impl Algorithm for HashMLDSA44_with_SHA256 {
-    const ALG_NAME: &'static str = HASH_ML_DSA_44_with_SHA256_NAME;
-    const MAX_SECURITY_STRENGTH: SecurityStrength = SecurityStrength::_128bit;
-}
 
 /// The HashML-DSA-65_with_SHA256 signature algorithm.
 #[allow(non_camel_case_types)]
 pub type HashMLDSA65_with_SHA256 = HashMLDSA<
-    SHA256,
+    HashMLDSA65_with_SHA256Params,
+    MLDSA65PublicKey,
+    MLDSA65PrivateKey,
     32,
     MLDSA65_PK_LEN,
     MLDSA65_SK_LEN,
     MLDSA65_FULL_SK_LEN,
     MLDSA65_SIG_LEN,
-    MLDSA65PublicKey,
-    MLDSA65PrivateKey,
-    MLDSA65_TAU,
-    MLDSA65_LAMBDA,
-    MLDSA65_GAMMA1,
-    MLDSA65_GAMMA2,
-    MLDSA65_k,
-    MLDSA65_l,
-    MLDSA65_ETA,
-    MLDSA65_BETA,
-    MLDSA65_OMEGA,
-    MLDSA65_C_TILDE,
-    MLDSA65_POLY_Z_PACKED_LEN,
-    MLDSA65_POLY_W1_PACKED_LEN,
-    MLDSA65_S1_PACKED_LEN,
-    MLDSA65_S2_PACKED_LEN,
-    MLDSA65_T1_PACKED_LEN,
-    MLDSA65_LAMBDA_over_4,
-    MLDSA65_GAMMA1_MINUS_BETA,
-    MLDSA65_GAMMA2_MINUS_BETA,
-    MLDSA65_GAMMA1_MASK_LEN,
 >;
-
-impl Algorithm for HashMLDSA65_with_SHA256 {
-    const ALG_NAME: &'static str = HASH_ML_DSA_65_WITH_SHA256_NAME;
-    const MAX_SECURITY_STRENGTH: SecurityStrength = SecurityStrength::_128bit;
-}
 
 /// The HashML-DSA-87_with_SHA256 signature algorithm.
 #[allow(non_camel_case_types)]
 pub type HashMLDSA87_with_SHA256 = HashMLDSA<
-    SHA256,
+    HashMLDSA87_with_SHA256Params,
+    MLDSA87PublicKey,
+    MLDSA87PrivateKey,
     32,
     MLDSA87_PK_LEN,
     MLDSA87_SK_LEN,
     MLDSA87_FULL_SK_LEN,
     MLDSA87_SIG_LEN,
-    MLDSA87PublicKey,
-    MLDSA87PrivateKey,
-    MLDSA87_TAU,
-    MLDSA87_LAMBDA,
-    MLDSA87_GAMMA1,
-    MLDSA87_GAMMA2,
-    MLDSA87_k,
-    MLDSA87_l,
-    MLDSA87_ETA,
-    MLDSA87_BETA,
-    MLDSA87_OMEGA,
-    MLDSA87_C_TILDE,
-    MLDSA87_POLY_Z_PACKED_LEN,
-    MLDSA87_POLY_W1_PACKED_LEN,
-    MLDSA87_S1_PACKED_LEN,
-    MLDSA87_S2_PACKED_LEN,
-    MLDSA87_T1_PACKED_LEN,
-    MLDSA87_LAMBDA_over_4,
-    MLDSA87_GAMMA1_MINUS_BETA,
-    MLDSA87_GAMMA2_MINUS_BETA,
-    MLDSA87_GAMMA1_MASK_LEN,
 >;
-
-impl Algorithm for HashMLDSA87_with_SHA256 {
-    const ALG_NAME: &'static str = HASH_ML_DSA_87_with_SHA256_NAME;
-    const MAX_SECURITY_STRENGTH: SecurityStrength = SecurityStrength::_128bit;
-}
 
 /// The HashML-DSA-44_with_SHA512 signature algorithm.
 #[allow(non_camel_case_types)]
 pub type HashMLDSA44_with_SHA512 = HashMLDSA<
-    SHA512,
+    HashMLDSA44_with_SHA512Params,
+    MLDSA44PublicKey,
+    MLDSA44PrivateKey,
     64,
     MLDSA44_PK_LEN,
     MLDSA44_SK_LEN,
     MLDSA44_FULL_SK_LEN,
     MLDSA44_SIG_LEN,
-    MLDSA44PublicKey,
-    MLDSA44PrivateKey,
-    MLDSA44_TAU,
-    MLDSA44_LAMBDA,
-    MLDSA44_GAMMA1,
-    MLDSA44_GAMMA2,
-    MLDSA44_k,
-    MLDSA44_l,
-    MLDSA44_ETA,
-    MLDSA44_BETA,
-    MLDSA44_OMEGA,
-    MLDSA44_C_TILDE,
-    MLDSA44_POLY_Z_PACKED_LEN,
-    MLDSA44_POLY_W1_PACKED_LEN,
-    MLDSA44_S1_PACKED_LEN,
-    MLDSA44_S2_PACKED_LEN,
-    MLDSA44_T1_PACKED_LEN,
-    MLDSA44_LAMBDA_over_4,
-    MLDSA44_GAMMA1_MINUS_BETA,
-    MLDSA44_GAMMA2_MINUS_BETA,
-    MLDSA44_GAMMA1_MASK_LEN,
 >;
-
-impl Algorithm for HashMLDSA44_with_SHA512 {
-    const ALG_NAME: &'static str = HASH_ML_DSA_44_with_SHA512_NAME;
-    const MAX_SECURITY_STRENGTH: SecurityStrength = SecurityStrength::_128bit;
-}
 /// Assigned by NIST in the Computer Security Objects Register: id-hash-ml-dsa-44-with-sha512 { sigAlgs 32 }
 impl AlgorithmOID for HashMLDSA44_with_SHA512 {
     const OID: &'static [u32] = &[2, 16, 840, 1, 101, 3, 4, 3, 32];
@@ -281,39 +186,15 @@ impl AlgorithmOID for HashMLDSA44_with_SHA512 {
 /// The HashML-DSA-65_with_SHA512 signature algorithm.
 #[allow(non_camel_case_types)]
 pub type HashMLDSA65_with_SHA512 = HashMLDSA<
-    SHA512,
+    HashMLDSA65_with_SHA512Params,
+    MLDSA65PublicKey,
+    MLDSA65PrivateKey,
     64,
     MLDSA65_PK_LEN,
     MLDSA65_SK_LEN,
     MLDSA65_FULL_SK_LEN,
     MLDSA65_SIG_LEN,
-    MLDSA65PublicKey,
-    MLDSA65PrivateKey,
-    MLDSA65_TAU,
-    MLDSA65_LAMBDA,
-    MLDSA65_GAMMA1,
-    MLDSA65_GAMMA2,
-    MLDSA65_k,
-    MLDSA65_l,
-    MLDSA65_ETA,
-    MLDSA65_BETA,
-    MLDSA65_OMEGA,
-    MLDSA65_C_TILDE,
-    MLDSA65_POLY_Z_PACKED_LEN,
-    MLDSA65_POLY_W1_PACKED_LEN,
-    MLDSA65_S1_PACKED_LEN,
-    MLDSA65_S2_PACKED_LEN,
-    MLDSA65_T1_PACKED_LEN,
-    MLDSA65_LAMBDA_over_4,
-    MLDSA65_GAMMA1_MINUS_BETA,
-    MLDSA65_GAMMA2_MINUS_BETA,
-    MLDSA65_GAMMA1_MASK_LEN,
 >;
-
-impl Algorithm for HashMLDSA65_with_SHA512 {
-    const ALG_NAME: &'static str = HASH_ML_DSA_65_WITH_SHA512_NAME;
-    const MAX_SECURITY_STRENGTH: SecurityStrength = SecurityStrength::_192bit;
-}
 /// Assigned by NIST in the Computer Security Objects Register: id-hash-ml-dsa-65-with-sha512 { sigAlgs 33 }
 impl AlgorithmOID for HashMLDSA65_with_SHA512 {
     const OID: &'static [u32] = &[2, 16, 840, 1, 101, 3, 4, 3, 33];
@@ -324,39 +205,15 @@ impl AlgorithmOID for HashMLDSA65_with_SHA512 {
 /// The HashML-DSA-87_with_SHA512 signature algorithm.
 #[allow(non_camel_case_types)]
 pub type HashMLDSA87_with_SHA512 = HashMLDSA<
-    SHA512,
+    HashMLDSA87_with_SHA512Params,
+    MLDSA87PublicKey,
+    MLDSA87PrivateKey,
     64,
     MLDSA87_PK_LEN,
     MLDSA87_SK_LEN,
     MLDSA87_FULL_SK_LEN,
     MLDSA87_SIG_LEN,
-    MLDSA87PublicKey,
-    MLDSA87PrivateKey,
-    MLDSA87_TAU,
-    MLDSA87_LAMBDA,
-    MLDSA87_GAMMA1,
-    MLDSA87_GAMMA2,
-    MLDSA87_k,
-    MLDSA87_l,
-    MLDSA87_ETA,
-    MLDSA87_BETA,
-    MLDSA87_OMEGA,
-    MLDSA87_C_TILDE,
-    MLDSA87_POLY_Z_PACKED_LEN,
-    MLDSA87_POLY_W1_PACKED_LEN,
-    MLDSA87_S1_PACKED_LEN,
-    MLDSA87_S2_PACKED_LEN,
-    MLDSA87_T1_PACKED_LEN,
-    MLDSA87_LAMBDA_over_4,
-    MLDSA87_GAMMA1_MINUS_BETA,
-    MLDSA87_GAMMA2_MINUS_BETA,
-    MLDSA87_GAMMA1_MASK_LEN,
 >;
-
-impl Algorithm for HashMLDSA87_with_SHA512 {
-    const ALG_NAME: &'static str = HASH_ML_DSA_87_WITH_SHA512_NAME;
-    const MAX_SECURITY_STRENGTH: SecurityStrength = SecurityStrength::_256bit;
-}
 /// Assigned by NIST in the Computer Security Objects Register: id-hash-ml-dsa-87-with-sha512 { sigAlgs 34 }
 impl AlgorithmOID for HashMLDSA87_with_SHA512 {
     const OID: &'static [u32] = &[2, 16, 840, 1, 101, 3, 4, 3, 34];
@@ -371,55 +228,17 @@ impl AlgorithmOID for HashMLDSA87_with_SHA512 {
 /// by specifying the hash function to use (in the verifier), and specifying the bytes of the OID to
 /// to use as its domain separator in constructing the message representative M'.
 pub struct HashMLDSA<
-    HASH: Hash + AlgorithmOID + Default,
-    const HASH_LEN: usize,
+    HP: HashMLDSAParams,
+    PK: MLDSAPublicKeyTrait<HP::MLDSA, PK_LEN> + MLDSAPublicKeyInternalTrait<HP::MLDSA, PK_LEN>,
+    SK: MLDSAPrivateKeyTrait<HP::MLDSA, PK_LEN, SK_LEN, FULL_SK_LEN>
+        + MLDSAPrivateKeyInternalTrait<HP::MLDSA, PK_LEN, SK_LEN>,
+    const PH_LEN: usize,
     const PK_LEN: usize,
     const SK_LEN: usize,
     const FULL_SK_LEN: usize,
     const SIG_LEN: usize,
-    PK: MLDSAPublicKeyTrait<k, T1_PACKED_LEN, PK_LEN>
-        + MLDSAPublicKeyInternalTrait<k, T1_PACKED_LEN, PK_LEN>,
-    SK: MLDSAPrivateKeyTrait<
-            k,
-            l,
-            S1_PACKED_LEN,
-            S2_PACKED_LEN,
-            T1_PACKED_LEN,
-            PK_LEN,
-            SK_LEN,
-            FULL_SK_LEN,
-        > + MLDSAPrivateKeyInternalTrait<
-            LAMBDA,
-            GAMMA2,
-            k,
-            l,
-            ETA,
-            S1_PACKED_LEN,
-            S2_PACKED_LEN,
-            PK_LEN,
-            SK_LEN,
-        >,
-    const TAU: i32,
-    const LAMBDA: i32,
-    const GAMMA1: i32,
-    const GAMMA2: i32,
-    const k: usize,
-    const l: usize,
-    const ETA: usize,
-    const BETA: i32,
-    const OMEGA: i32,
-    const C_TILDE: usize,
-    const POLY_Z_PACKED_LEN: usize,
-    const POLY_W1_PACKED_LEN: usize,
-    const S1_PACKED_LEN: usize,
-    const S2_PACKED_LEN: usize,
-    const T1_PACKED_LEN: usize,
-    const LAMBDA_over_4: usize,
-    const GAMMA1_MINUS_BETA: i32,
-    const GAMMA2_MINUS_BETA: i32,
-    const GAMMA1_MASK_LEN: usize,
 > {
-    _phantom: PhantomData<(PK, SK)>,
+    _phantom: PhantomData<(HP, PK, SK)>,
 
     signer_rnd: Option<[u8; MLDSA_RND_LEN]>,
 
@@ -433,7 +252,7 @@ pub struct HashMLDSA<
     pk: Option<PK>,
 
     /// Hash function instance for streaming message hashing
-    hash: HASH,
+    hash: HP::PreHash,
 
     /// Since HashML-DSA does message buffering in the external pre-hash, not in mu,
     /// this needs to be saved for later
@@ -442,83 +261,16 @@ pub struct HashMLDSA<
 }
 
 impl<
-    HASH: Hash + AlgorithmOID + Default,
+    HP: HashMLDSAParams,
+    PK: MLDSAPublicKeyTrait<HP::MLDSA, PK_LEN> + MLDSAPublicKeyInternalTrait<HP::MLDSA, PK_LEN>,
+    SK: MLDSAPrivateKeyTrait<HP::MLDSA, PK_LEN, SK_LEN, FULL_SK_LEN>
+        + MLDSAPrivateKeyInternalTrait<HP::MLDSA, PK_LEN, SK_LEN>,
     const PH_LEN: usize,
     const PK_LEN: usize,
     const SK_LEN: usize,
     const FULL_SK_LEN: usize,
     const SIG_LEN: usize,
-    PK: MLDSAPublicKeyTrait<k, T1_PACKED_LEN, PK_LEN>
-        + MLDSAPublicKeyInternalTrait<k, T1_PACKED_LEN, PK_LEN>,
-    SK: MLDSAPrivateKeyTrait<
-            k,
-            l,
-            S1_PACKED_LEN,
-            S2_PACKED_LEN,
-            T1_PACKED_LEN,
-            PK_LEN,
-            SK_LEN,
-            FULL_SK_LEN,
-        > + MLDSAPrivateKeyInternalTrait<
-            LAMBDA,
-            GAMMA2,
-            k,
-            l,
-            ETA,
-            S1_PACKED_LEN,
-            S2_PACKED_LEN,
-            PK_LEN,
-            SK_LEN,
-        >,
-    const TAU: i32,
-    const LAMBDA: i32,
-    const GAMMA1: i32,
-    const GAMMA2: i32,
-    const k: usize,
-    const l: usize,
-    const ETA: usize,
-    const BETA: i32,
-    const OMEGA: i32,
-    const C_TILDE: usize,
-    const POLY_Z_PACKED_LEN: usize,
-    const POLY_W1_PACKED_LEN: usize,
-    const S1_PACKED_LEN: usize,
-    const S2_PACKED_LEN: usize,
-    const T1_PACKED_LEN: usize,
-    const LAMBDA_over_4: usize,
-    const GAMMA1_MINUS_BETA: i32,
-    const GAMMA2_MINUS_BETA: i32,
-    const GAMMA1_MASK_LEN: usize,
->
-    HashMLDSA<
-        HASH,
-        PH_LEN,
-        PK_LEN,
-        SK_LEN,
-        FULL_SK_LEN,
-        SIG_LEN,
-        PK,
-        SK,
-        TAU,
-        LAMBDA,
-        GAMMA1,
-        GAMMA2,
-        k,
-        l,
-        ETA,
-        BETA,
-        OMEGA,
-        C_TILDE,
-        POLY_Z_PACKED_LEN,
-        POLY_W1_PACKED_LEN,
-        S1_PACKED_LEN,
-        S2_PACKED_LEN,
-        T1_PACKED_LEN,
-        LAMBDA_over_4,
-        GAMMA1_MINUS_BETA,
-        GAMMA2_MINUS_BETA,
-        GAMMA1_MASK_LEN,
-    >
+> HashMLDSA<HP, PK, SK, PH_LEN, PK_LEN, SK_LEN, FULL_SK_LEN, SIG_LEN>
 {
     /// Generate a keypair, sourcing randomness from bouncycastle's default os-backed RNG.
     ///
@@ -527,64 +279,12 @@ impl<
     /// Keys are interchangeable between MLDSA and HashMLDSA.
     /// Error condition: basically only on RNG failures.
     pub fn keygen() -> Result<(PK, SK), SignatureError> {
-        MLDSA::<
-            PK_LEN,
-            SK_LEN,
-            FULL_SK_LEN,
-            SIG_LEN,
-            PK,
-            SK,
-            TAU,
-            LAMBDA,
-            GAMMA1,
-            GAMMA2,
-            k,
-            l,
-            ETA,
-            BETA,
-            OMEGA,
-            C_TILDE,
-            POLY_Z_PACKED_LEN,
-            POLY_W1_PACKED_LEN,
-            S1_PACKED_LEN,
-            S2_PACKED_LEN,
-            T1_PACKED_LEN,
-            LAMBDA_over_4,
-            GAMMA1_MINUS_BETA,
-            GAMMA2_MINUS_BETA,
-            GAMMA1_MASK_LEN,
-        >::keygen()
+        MLDSA::<HP::MLDSA, PK, SK, PK_LEN, SK_LEN, FULL_SK_LEN, SIG_LEN>::keygen()
     }
 
     /// Imports a secret key from a seed.
     pub fn keygen_from_seed(seed: &KeyMaterial<32>) -> Result<(PK, SK), SignatureError> {
-        MLDSA::<
-            PK_LEN,
-            SK_LEN,
-            FULL_SK_LEN,
-            SIG_LEN,
-            PK,
-            SK,
-            TAU,
-            LAMBDA,
-            GAMMA1,
-            GAMMA2,
-            k,
-            l,
-            ETA,
-            BETA,
-            OMEGA,
-            C_TILDE,
-            POLY_Z_PACKED_LEN,
-            POLY_W1_PACKED_LEN,
-            S1_PACKED_LEN,
-            S2_PACKED_LEN,
-            T1_PACKED_LEN,
-            LAMBDA_over_4,
-            GAMMA1_MINUS_BETA,
-            GAMMA2_MINUS_BETA,
-            GAMMA1_MASK_LEN,
-        >::keygen_internal(seed)
+        MLDSA::<HP::MLDSA, PK, SK, PK_LEN, SK_LEN, FULL_SK_LEN, SIG_LEN>::keygen_internal(seed)
     }
 
     /// Algorithm 7 ML-DSA.Sign_internal(𝑠𝑘, 𝑀′, 𝑟𝑛𝑑)
@@ -651,40 +351,15 @@ impl<
         h.absorb(&[1u8]).expect("absorb before squeeze is infallible");
         h.absorb(&[ctx.len() as u8]).expect("absorb before squeeze is infallible");
         h.absorb(ctx).expect("absorb before squeeze is infallible");
-        h.absorb(HASH::OID_DER).expect("absorb before squeeze is infallible");
+        h.absorb(<HP::PreHash as AlgorithmOID>::OID_DER)
+            .expect("absorb before squeeze is infallible");
         h.absorb(ph).expect("absorb before squeeze is infallible");
         let mut mu = [0u8; MLDSA_MU_LEN];
         let bytes_written = h.squeeze_out(&mut mu);
         debug_assert_eq!(bytes_written, MLDSA_MU_LEN);
 
         // 24: 𝜎 ← ML-DSA.Sign_internal(𝑠𝑘, 𝑀', 𝑟𝑛𝑑)
-        let bytes_written = MLDSA::<
-            PK_LEN,
-            SK_LEN,
-            FULL_SK_LEN,
-            SIG_LEN,
-            PK,
-            SK,
-            TAU,
-            LAMBDA,
-            GAMMA1,
-            GAMMA2,
-            k,
-            l,
-            ETA,
-            BETA,
-            OMEGA,
-            C_TILDE,
-            POLY_Z_PACKED_LEN,
-            POLY_W1_PACKED_LEN,
-            S1_PACKED_LEN,
-            S2_PACKED_LEN,
-            T1_PACKED_LEN,
-            LAMBDA_over_4,
-            GAMMA1_MINUS_BETA,
-            GAMMA2_MINUS_BETA,
-            GAMMA1_MASK_LEN,
-        >::sign_mu_deterministic_out(sk, &mu, rnd, output)?;
+        let bytes_written = MLDSA::<HP::MLDSA, PK, SK, PK_LEN, SK_LEN, FULL_SK_LEN, SIG_LEN>::sign_mu_deterministic_out(sk, &mu, rnd, output)?;
 
         Ok(bytes_written)
     }
@@ -725,7 +400,7 @@ impl<
             sk: None,
             seed: Some(seed.clone()),
             pk: None,
-            hash: HASH::default(),
+            hash: <HP::PreHash as Default>::default(),
             ctx,
             ctx_len,
         })
@@ -733,83 +408,17 @@ impl<
 }
 
 impl<
-    HASH: Hash + AlgorithmOID + Default,
-    PK: MLDSAPublicKeyTrait<k, T1_PACKED_LEN, PK_LEN>
-        + MLDSAPublicKeyInternalTrait<k, T1_PACKED_LEN, PK_LEN>,
-    SK: MLDSAPrivateKeyTrait<
-            k,
-            l,
-            S1_PACKED_LEN,
-            S2_PACKED_LEN,
-            T1_PACKED_LEN,
-            PK_LEN,
-            SK_LEN,
-            FULL_SK_LEN,
-        > + MLDSAPrivateKeyInternalTrait<
-            LAMBDA,
-            GAMMA2,
-            k,
-            l,
-            ETA,
-            S1_PACKED_LEN,
-            S2_PACKED_LEN,
-            PK_LEN,
-            SK_LEN,
-        >,
+    HP: HashMLDSAParams,
+    PK: MLDSAPublicKeyTrait<HP::MLDSA, PK_LEN> + MLDSAPublicKeyInternalTrait<HP::MLDSA, PK_LEN>,
+    SK: MLDSAPrivateKeyTrait<HP::MLDSA, PK_LEN, SK_LEN, FULL_SK_LEN>
+        + MLDSAPrivateKeyInternalTrait<HP::MLDSA, PK_LEN, SK_LEN>,
     const PH_LEN: usize,
     const PK_LEN: usize,
     const SK_LEN: usize,
     const FULL_SK_LEN: usize,
     const SIG_LEN: usize,
-    const TAU: i32,
-    const LAMBDA: i32,
-    const GAMMA1: i32,
-    const GAMMA2: i32,
-    const k: usize,
-    const l: usize,
-    const ETA: usize,
-    const BETA: i32,
-    const OMEGA: i32,
-    const C_TILDE: usize,
-    const POLY_Z_PACKED_LEN: usize,
-    const POLY_W1_PACKED_LEN: usize,
-    const S1_PACKED_LEN: usize,
-    const S2_PACKED_LEN: usize,
-    const T1_PACKED_LEN: usize,
-    const LAMBDA_over_4: usize,
-    const GAMMA1_MINUS_BETA: i32,
-    const GAMMA2_MINUS_BETA: i32,
-    const GAMMA1_MASK_LEN: usize,
 > Signer<SK, SK_LEN, SIG_LEN>
-    for HashMLDSA<
-        HASH,
-        PH_LEN,
-        PK_LEN,
-        SK_LEN,
-        FULL_SK_LEN,
-        SIG_LEN,
-        PK,
-        SK,
-        TAU,
-        LAMBDA,
-        GAMMA1,
-        GAMMA2,
-        k,
-        l,
-        ETA,
-        BETA,
-        OMEGA,
-        C_TILDE,
-        POLY_Z_PACKED_LEN,
-        POLY_W1_PACKED_LEN,
-        S1_PACKED_LEN,
-        S2_PACKED_LEN,
-        T1_PACKED_LEN,
-        LAMBDA_over_4,
-        GAMMA1_MINUS_BETA,
-        GAMMA2_MINUS_BETA,
-        GAMMA1_MASK_LEN,
-    >
+    for HashMLDSA<HP, PK, SK, PH_LEN, PK_LEN, SK_LEN, FULL_SK_LEN, SIG_LEN>
 {
     /// Algorithm 4 HashML-DSA.Sign(𝑠𝑘, 𝑀 , 𝑐𝑡𝑥, PH)
     /// Generate a “pre-hash” ML-DSA signature.
@@ -829,7 +438,7 @@ impl<
         output.fill(0);
 
         let mut ph_m = [0u8; PH_LEN];
-        _ = HASH::default().hash_out(msg, &mut ph_m);
+        _ = <HP::PreHash as Default>::default().hash_out(msg, &mut ph_m);
         Self::sign_ph_out(sk, &ph_m, ctx, output)
     }
 
@@ -841,7 +450,7 @@ impl<
             sk: Some(sk.clone()),
             seed: None,
             pk: None,
-            hash: HASH::default(),
+            hash: <HP::PreHash as Default>::default(),
             ctx,
             ctx_len,
         })
@@ -899,87 +508,21 @@ impl<
 }
 
 impl<
-    HASH: Hash + AlgorithmOID + Default,
-    PK: MLDSAPublicKeyTrait<k, T1_PACKED_LEN, PK_LEN>
-        + MLDSAPublicKeyInternalTrait<k, T1_PACKED_LEN, PK_LEN>,
-    SK: MLDSAPrivateKeyTrait<
-            k,
-            l,
-            S1_PACKED_LEN,
-            S2_PACKED_LEN,
-            T1_PACKED_LEN,
-            PK_LEN,
-            SK_LEN,
-            FULL_SK_LEN,
-        > + MLDSAPrivateKeyInternalTrait<
-            LAMBDA,
-            GAMMA2,
-            k,
-            l,
-            ETA,
-            S1_PACKED_LEN,
-            S2_PACKED_LEN,
-            PK_LEN,
-            SK_LEN,
-        >,
+    HP: HashMLDSAParams,
+    PK: MLDSAPublicKeyTrait<HP::MLDSA, PK_LEN> + MLDSAPublicKeyInternalTrait<HP::MLDSA, PK_LEN>,
+    SK: MLDSAPrivateKeyTrait<HP::MLDSA, PK_LEN, SK_LEN, FULL_SK_LEN>
+        + MLDSAPrivateKeyInternalTrait<HP::MLDSA, PK_LEN, SK_LEN>,
     const PH_LEN: usize,
     const PK_LEN: usize,
     const SK_LEN: usize,
     const FULL_SK_LEN: usize,
     const SIG_LEN: usize,
-    const TAU: i32,
-    const LAMBDA: i32,
-    const GAMMA1: i32,
-    const GAMMA2: i32,
-    const k: usize,
-    const l: usize,
-    const ETA: usize,
-    const BETA: i32,
-    const OMEGA: i32,
-    const C_TILDE: usize,
-    const POLY_Z_PACKED_LEN: usize,
-    const POLY_W1_PACKED_LEN: usize,
-    const S1_PACKED_LEN: usize,
-    const S2_PACKED_LEN: usize,
-    const T1_PACKED_LEN: usize,
-    const LAMBDA_over_4: usize,
-    const GAMMA1_MINUS_BETA: i32,
-    const GAMMA2_MINUS_BETA: i32,
-    const GAMMA1_MASK_LEN: usize,
 > SignatureVerifier<PK, PK_LEN, SIG_LEN>
-    for HashMLDSA<
-        HASH,
-        PH_LEN,
-        PK_LEN,
-        SK_LEN,
-        FULL_SK_LEN,
-        SIG_LEN,
-        PK,
-        SK,
-        TAU,
-        LAMBDA,
-        GAMMA1,
-        GAMMA2,
-        k,
-        l,
-        ETA,
-        BETA,
-        OMEGA,
-        C_TILDE,
-        POLY_Z_PACKED_LEN,
-        POLY_W1_PACKED_LEN,
-        S1_PACKED_LEN,
-        S2_PACKED_LEN,
-        T1_PACKED_LEN,
-        LAMBDA_over_4,
-        GAMMA1_MINUS_BETA,
-        GAMMA2_MINUS_BETA,
-        GAMMA1_MASK_LEN,
-    >
+    for HashMLDSA<HP, PK, SK, PH_LEN, PK_LEN, SK_LEN, FULL_SK_LEN, SIG_LEN>
 {
     fn verify(pk: &PK, msg: &[u8], ctx: Option<&[u8]>, sig: &[u8]) -> Result<(), SignatureError> {
         let mut ph_m = [0u8; PH_LEN];
-        _ = HASH::default().hash_out(msg, &mut ph_m);
+        _ = <HP::PreHash as Default>::default().hash_out(msg, &mut ph_m);
 
         Self::verify_ph(pk, &ph_m, ctx, sig)
     }
@@ -992,7 +535,7 @@ impl<
             sk: None,
             seed: None,
             pk: Some(pk.clone()),
-            hash: HASH::default(),
+            hash: <HP::PreHash as Default>::default(),
             ctx,
             ctx_len,
         })
@@ -1013,83 +556,17 @@ impl<
 }
 
 impl<
-    HASH: Hash + AlgorithmOID + Default,
+    HP: HashMLDSAParams,
+    PK: MLDSAPublicKeyTrait<HP::MLDSA, PK_LEN> + MLDSAPublicKeyInternalTrait<HP::MLDSA, PK_LEN>,
+    SK: MLDSAPrivateKeyTrait<HP::MLDSA, PK_LEN, SK_LEN, FULL_SK_LEN>
+        + MLDSAPrivateKeyInternalTrait<HP::MLDSA, PK_LEN, SK_LEN>,
     const PH_LEN: usize,
     const PK_LEN: usize,
     const SK_LEN: usize,
     const FULL_SK_LEN: usize,
     const SIG_LEN: usize,
-    PK: MLDSAPublicKeyTrait<k, T1_PACKED_LEN, PK_LEN>
-        + MLDSAPublicKeyInternalTrait<k, T1_PACKED_LEN, PK_LEN>,
-    SK: MLDSAPrivateKeyTrait<
-            k,
-            l,
-            S1_PACKED_LEN,
-            S2_PACKED_LEN,
-            T1_PACKED_LEN,
-            PK_LEN,
-            SK_LEN,
-            FULL_SK_LEN,
-        > + MLDSAPrivateKeyInternalTrait<
-            LAMBDA,
-            GAMMA2,
-            k,
-            l,
-            ETA,
-            S1_PACKED_LEN,
-            S2_PACKED_LEN,
-            PK_LEN,
-            SK_LEN,
-        >,
-    const TAU: i32,
-    const LAMBDA: i32,
-    const GAMMA1: i32,
-    const GAMMA2: i32,
-    const k: usize,
-    const l: usize,
-    const ETA: usize,
-    const BETA: i32,
-    const OMEGA: i32,
-    const C_TILDE: usize,
-    const POLY_Z_PACKED_LEN: usize,
-    const POLY_W1_PACKED_LEN: usize,
-    const S1_PACKED_LEN: usize,
-    const S2_PACKED_LEN: usize,
-    const T1_PACKED_LEN: usize,
-    const LAMBDA_over_4: usize,
-    const GAMMA1_MINUS_BETA: i32,
-    const GAMMA2_MINUS_BETA: i32,
-    const GAMMA1_MASK_LEN: usize,
 > PHSigner<PK, SK, PK_LEN, SK_LEN, SIG_LEN, PH_LEN>
-    for HashMLDSA<
-        HASH,
-        PH_LEN,
-        PK_LEN,
-        SK_LEN,
-        FULL_SK_LEN,
-        SIG_LEN,
-        PK,
-        SK,
-        TAU,
-        LAMBDA,
-        GAMMA1,
-        GAMMA2,
-        k,
-        l,
-        ETA,
-        BETA,
-        OMEGA,
-        C_TILDE,
-        POLY_Z_PACKED_LEN,
-        POLY_W1_PACKED_LEN,
-        S1_PACKED_LEN,
-        S2_PACKED_LEN,
-        T1_PACKED_LEN,
-        LAMBDA_over_4,
-        GAMMA1_MINUS_BETA,
-        GAMMA2_MINUS_BETA,
-        GAMMA1_MASK_LEN,
-    >
+    for HashMLDSA<HP, PK, SK, PH_LEN, PK_LEN, SK_LEN, FULL_SK_LEN, SIG_LEN>
 {
     fn sign_ph(
         sk: &SK,
@@ -1121,83 +598,17 @@ impl<
 }
 
 impl<
-    HASH: Hash + AlgorithmOID + Default,
+    HP: HashMLDSAParams,
+    PK: MLDSAPublicKeyTrait<HP::MLDSA, PK_LEN> + MLDSAPublicKeyInternalTrait<HP::MLDSA, PK_LEN>,
+    SK: MLDSAPrivateKeyTrait<HP::MLDSA, PK_LEN, SK_LEN, FULL_SK_LEN>
+        + MLDSAPrivateKeyInternalTrait<HP::MLDSA, PK_LEN, SK_LEN>,
     const PH_LEN: usize,
     const PK_LEN: usize,
     const SK_LEN: usize,
     const FULL_SK_LEN: usize,
     const SIG_LEN: usize,
-    PK: MLDSAPublicKeyTrait<k, T1_PACKED_LEN, PK_LEN>
-        + MLDSAPublicKeyInternalTrait<k, T1_PACKED_LEN, PK_LEN>,
-    SK: MLDSAPrivateKeyTrait<
-            k,
-            l,
-            S1_PACKED_LEN,
-            S2_PACKED_LEN,
-            T1_PACKED_LEN,
-            PK_LEN,
-            SK_LEN,
-            FULL_SK_LEN,
-        > + MLDSAPrivateKeyInternalTrait<
-            LAMBDA,
-            GAMMA2,
-            k,
-            l,
-            ETA,
-            S1_PACKED_LEN,
-            S2_PACKED_LEN,
-            PK_LEN,
-            SK_LEN,
-        >,
-    const TAU: i32,
-    const LAMBDA: i32,
-    const GAMMA1: i32,
-    const GAMMA2: i32,
-    const k: usize,
-    const l: usize,
-    const ETA: usize,
-    const BETA: i32,
-    const OMEGA: i32,
-    const C_TILDE: usize,
-    const POLY_Z_PACKED_LEN: usize,
-    const POLY_W1_PACKED_LEN: usize,
-    const S1_PACKED_LEN: usize,
-    const S2_PACKED_LEN: usize,
-    const T1_PACKED_LEN: usize,
-    const LAMBDA_over_4: usize,
-    const GAMMA1_MINUS_BETA: i32,
-    const GAMMA2_MINUS_BETA: i32,
-    const GAMMA1_MASK_LEN: usize,
 > PHSignatureVerifier<PK, PK_LEN, SIG_LEN, PH_LEN>
-    for HashMLDSA<
-        HASH,
-        PH_LEN,
-        PK_LEN,
-        SK_LEN,
-        FULL_SK_LEN,
-        SIG_LEN,
-        PK,
-        SK,
-        TAU,
-        LAMBDA,
-        GAMMA1,
-        GAMMA2,
-        k,
-        l,
-        ETA,
-        BETA,
-        OMEGA,
-        C_TILDE,
-        POLY_Z_PACKED_LEN,
-        POLY_W1_PACKED_LEN,
-        S1_PACKED_LEN,
-        S2_PACKED_LEN,
-        T1_PACKED_LEN,
-        LAMBDA_over_4,
-        GAMMA1_MINUS_BETA,
-        GAMMA2_MINUS_BETA,
-        GAMMA1_MASK_LEN,
-    >
+    for HashMLDSA<HP, PK, SK, PH_LEN, PK_LEN, SK_LEN, FULL_SK_LEN, SIG_LEN>
 {
     fn verify_ph(
         pk: &PK,
@@ -1229,37 +640,14 @@ impl<
         h.absorb(&[1u8]).expect("absorb before squeeze is infallible");
         h.absorb(&[ctx.len() as u8]).expect("absorb before squeeze is infallible");
         h.absorb(ctx).expect("absorb before squeeze is infallible");
-        h.absorb(HASH::OID_DER).expect("absorb before squeeze is infallible");
+        h.absorb(<HP::PreHash as AlgorithmOID>::OID_DER)
+            .expect("absorb before squeeze is infallible");
         h.absorb(ph).expect("absorb before squeeze is infallible");
         let mut mu = [0u8; MLDSA_MU_LEN];
         _ = h.squeeze_out(&mut mu);
 
-        MLDSA::<
-            PK_LEN,
-            SK_LEN,
-            FULL_SK_LEN,
-            SIG_LEN,
-            PK,
-            SK,
-            TAU,
-            LAMBDA,
-            GAMMA1,
-            GAMMA2,
-            k,
-            l,
-            ETA,
-            BETA,
-            OMEGA,
-            C_TILDE,
-            POLY_Z_PACKED_LEN,
-            POLY_W1_PACKED_LEN,
-            S1_PACKED_LEN,
-            S2_PACKED_LEN,
-            T1_PACKED_LEN,
-            LAMBDA_over_4,
-            GAMMA1_MINUS_BETA,
-            GAMMA2_MINUS_BETA,
-            GAMMA1_MASK_LEN,
-        >::verify_mu(pk, &mu, sig_sized)
+        MLDSA::<HP::MLDSA, PK, SK, PK_LEN, SK_LEN, FULL_SK_LEN, SIG_LEN>::verify_mu(
+            pk, &mu, sig_sized,
+        )
     }
 }

--- a/crypto/mldsa-lowmemory/src/lib.rs
+++ b/crypto/mldsa-lowmemory/src/lib.rs
@@ -234,6 +234,7 @@ pub mod hash_mldsa;
 mod low_memory_helpers;
 pub mod mldsa;
 mod mldsa_keys;
+mod params;
 mod polynomial;
 
 /*** Exported types ***/
@@ -266,3 +267,10 @@ pub use mldsa::{MLDSA65_PK_LEN, MLDSA65_SIG_LEN, MLDSA65_SK_LEN};
 pub use mldsa::{MLDSA87_PK_LEN, MLDSA87_SIG_LEN, MLDSA87_SK_LEN};
 
 pub use mldsa::SUSPENDED_MU_BUILDER_STATE_LEN;
+
+/*** Parameter sets ***/
+pub use params::{
+    HashMLDSA44_with_SHA256Params, HashMLDSA44_with_SHA512Params, HashMLDSA65_with_SHA256Params,
+    HashMLDSA65_with_SHA512Params, HashMLDSA87_with_SHA256Params, HashMLDSA87_with_SHA512Params,
+};
+pub use params::{MLDSA44Params, MLDSA65Params, MLDSA87Params};

--- a/crypto/mldsa-lowmemory/src/lib.rs
+++ b/crypto/mldsa-lowmemory/src/lib.rs
@@ -267,10 +267,3 @@ pub use mldsa::{MLDSA65_PK_LEN, MLDSA65_SIG_LEN, MLDSA65_SK_LEN};
 pub use mldsa::{MLDSA87_PK_LEN, MLDSA87_SIG_LEN, MLDSA87_SK_LEN};
 
 pub use mldsa::SUSPENDED_MU_BUILDER_STATE_LEN;
-
-/*** Parameter sets ***/
-pub use params::{
-    HashMLDSA44_with_SHA256Params, HashMLDSA44_with_SHA512Params, HashMLDSA65_with_SHA256Params,
-    HashMLDSA65_with_SHA512Params, HashMLDSA87_with_SHA256Params, HashMLDSA87_with_SHA512Params,
-};
-pub use params::{MLDSA44Params, MLDSA65Params, MLDSA87Params};

--- a/crypto/mldsa-lowmemory/src/low_memory_helpers.rs
+++ b/crypto/mldsa-lowmemory/src/low_memory_helpers.rs
@@ -2,9 +2,7 @@
 //! and other intermediate values by never holding the whole thing in memory at once, but re-constructing
 //! what it needs in pieces, which generally means handling the matrices and vectors row-wise or entry-wise.
 
-use crate::aux_functions::{
-    bit_unpack_eta_out, bitlen_eta, expand_mask_poly, rej_ntt_poly, unpack_z_row,
-};
+use crate::aux_functions::{bit_unpack_eta_out, expand_mask_poly, rej_ntt_poly, unpack_z_row};
 use crate::params::MLDSAParams;
 use crate::polynomial::Polynomial;
 use bouncycastle_core::errors::SignatureError;
@@ -107,7 +105,7 @@ pub(crate) fn compute_z_component<P: MLDSAParams>(
     let mut z = cs1;
     z.add_ntt(&y);
 
-    if z.check_norm(P::GAMMA1_MINUS_BETA) { Ok(None) } else { Ok(Some(z)) }
+    if z.check_norm(P::gamma1_minus_beta) { Ok(None) } else { Ok(Some(z)) }
 }
 
 pub(crate) fn compute_w0cs2_component<P: MLDSAParams>(
@@ -130,7 +128,7 @@ pub(crate) fn compute_w0cs2_component<P: MLDSAParams>(
     let mut w0cs2 = w.clone();
     w0cs2.low_bits::<P>();
     w0cs2.sub(&cs2);
-    if w0cs2.check_norm(P::GAMMA2_MINUS_BETA) { None } else { Some(w0cs2) }
+    if w0cs2.check_norm(P::gamma2_minus_beta) { None } else { Some(w0cs2) }
 }
 
 pub(crate) fn compute_ct0_component<P: MLDSAParams>(
@@ -143,7 +141,7 @@ pub(crate) fn compute_ct0_component<P: MLDSAParams>(
     let mut ct0 = t0_hat; // rename
     ct0.inv_ntt();
 
-    if ct0.check_norm(P::GAMMA2) { None } else { Some(ct0) }
+    if ct0.check_norm(P::gamma2) { None } else { Some(ct0) }
 }
 
 /// Unpack a single s value from the packed representation.
@@ -156,7 +154,7 @@ pub(crate) fn s_unpack<P: MLDSAParams, B: ZeroizablePrimitive + AsRef<[u8]>>(
 ) -> Polynomial {
     let mut s = Polynomial::new();
     let packed = (**s_packed).as_ref();
-    let width = bitlen_eta(P::ETA);
+    let width = P::POLY_ETA_PACKED_LEN;
     bit_unpack_eta_out::<P>(&packed[idx * width..(idx + 1) * width], &mut s);
     s
 }

--- a/crypto/mldsa-lowmemory/src/low_memory_helpers.rs
+++ b/crypto/mldsa-lowmemory/src/low_memory_helpers.rs
@@ -5,10 +5,10 @@
 use crate::aux_functions::{
     bit_unpack_eta_out, bitlen_eta, expand_mask_poly, rej_ntt_poly, unpack_z_row,
 };
-use crate::mldsa::d;
+use crate::params::MLDSAParams;
 use crate::polynomial::Polynomial;
 use bouncycastle_core::errors::SignatureError;
-use bouncycastle_utils::secret::Secret;
+use bouncycastle_utils::secret::{Secret, ZeroizablePrimitive};
 
 #[inline(always)]
 pub(crate) fn expandA_elem(rho: &[u8; 32], i: usize, j: usize) -> Polynomial {
@@ -17,19 +17,19 @@ pub(crate) fn expandA_elem(rho: &[u8; 32], i: usize, j: usize) -> Polynomial {
 
 /// Compute a row of the core signing operation
 /// Alg 7: 12: 𝐰 ← NTT−1(𝐀_hat ∘ NTT(𝐲))
-pub(crate) fn compute_w_row<const l: usize, const GAMMA1: i32, const GAMMA1_MASK_LEN: usize>(
+pub(crate) fn compute_w_row<P: MLDSAParams>(
     rho: &[u8; 32],
     rho_p_p: &[u8; 64],
     kappa: u16,
     row: usize,
 ) -> Polynomial {
-    let mut y_hat = expand_mask_poly::<GAMMA1, GAMMA1_MASK_LEN>(rho_p_p, kappa);
+    let mut y_hat = expand_mask_poly::<P>(rho_p_p, kappa);
     y_hat.ntt();
     let mut acc = rej_ntt_poly(rho, &[0u8, row as u8]);
     acc.multiply_ntt(&y_hat);
 
-    for col in 1..l {
-        y_hat = expand_mask_poly::<GAMMA1, GAMMA1_MASK_LEN>(rho_p_p, kappa + col as u16);
+    for col in 1..P::l {
+        y_hat = expand_mask_poly::<P>(rho_p_p, kappa + col as u16);
         y_hat.ntt();
         let mut tmp = rej_ntt_poly(rho, &[col as u8, row as u8]);
         tmp.multiply_ntt(&y_hat);
@@ -42,14 +42,7 @@ pub(crate) fn compute_w_row<const l: usize, const GAMMA1: i32, const GAMMA1_MASK
 }
 
 /// Algorithm 8 Line 9
-pub(crate) fn compute_wp_approx_row<
-    const GAMMA1: i32,
-    const GAMMA1_MINUS_BETA: i32,
-    const l: usize,
-    const POLY_Z_PACKED_LEN: usize,
-    const LAMBDA_over_4: usize,
-    const SIG_LEN: usize,
->(
+pub(crate) fn compute_wp_approx_row<P: MLDSAParams, const SIG_LEN: usize>(
     rho: &[u8; 32],
     sig: &[u8; SIG_LEN],
     t1: &Polynomial,
@@ -64,18 +57,13 @@ pub(crate) fn compute_wp_approx_row<
     //   )
     // ▷ 𝐰'_approx = 𝐀𝐳 − 𝑐𝐭1 ⋅ 2^𝑑
 
-    let mut z_i =
-        unpack_z_row::<GAMMA1, GAMMA1_MINUS_BETA, LAMBDA_over_4, POLY_Z_PACKED_LEN, SIG_LEN>(
-            0, sig,
-        )?;
+    let mut z_i = unpack_z_row::<P, SIG_LEN>(0, sig)?;
     z_i.ntt();
     let mut Az_acc = rej_ntt_poly(rho, &[0u8, idx as u8]);
     Az_acc.multiply_ntt(&z_i);
 
-    for col in 1..l {
-        z_i = unpack_z_row::<GAMMA1, GAMMA1_MINUS_BETA, LAMBDA_over_4, POLY_Z_PACKED_LEN, SIG_LEN>(
-            col, sig,
-        )?;
+    for col in 1..P::l {
+        z_i = unpack_z_row::<P, SIG_LEN>(col, sig)?;
         z_i.ntt();
 
         // [Optimization Note]:
@@ -88,7 +76,7 @@ pub(crate) fn compute_wp_approx_row<
 
     let ct1 = compute_ct1(t1.clone(), c.clone());
     fn compute_ct1(mut t1_i: Polynomial, mut c: Polynomial) -> Polynomial {
-        t1_i.shift_left::<d>();
+        t1_i.shift_left_d();
         t1_i.ntt();
         c.ntt();
         t1_i.multiply_ntt(&c);
@@ -103,18 +91,14 @@ pub(crate) fn compute_wp_approx_row<
     Ok(Az_acc)
 }
 
-pub(crate) fn compute_z_component<
-    const GAMMA1: i32,
-    const GAMMA1_MASK_LEN: usize,
-    const GAMMA1_MINUS_BETA: i32,
->(
+pub(crate) fn compute_z_component<P: MLDSAParams>(
     s1: &Polynomial,
     rho_p_p: &[u8; 64],
     c_hat: &Polynomial,
     kappa: u16,
     col: usize,
 ) -> Result<Option<Polynomial>, SignatureError> {
-    let y = expand_mask_poly::<GAMMA1, GAMMA1_MASK_LEN>(rho_p_p, kappa + col as u16);
+    let y = expand_mask_poly::<P>(rho_p_p, kappa + col as u16);
     let mut s1_hat = s1.clone();
     s1_hat.ntt();
     s1_hat.multiply_ntt(c_hat);
@@ -123,10 +107,10 @@ pub(crate) fn compute_z_component<
     let mut z = cs1;
     z.add_ntt(&y);
 
-    if z.check_norm::<GAMMA1_MINUS_BETA>() { Ok(None) } else { Ok(Some(z)) }
+    if z.check_norm(P::GAMMA1_MINUS_BETA) { Ok(None) } else { Ok(Some(z)) }
 }
 
-pub(crate) fn compute_w0cs2_component<const GAMMA2: i32, const GAMMA2_MINUS_BETA: i32>(
+pub(crate) fn compute_w0cs2_component<P: MLDSAParams>(
     s2: &Polynomial,
     w: &Polynomial,
     c_hat: &Polynomial,
@@ -144,12 +128,12 @@ pub(crate) fn compute_w0cs2_component<const GAMMA2: i32, const GAMMA2_MINUS_BETA
     //      ‖w0 − cs2‖∞ < γ2 − β, where w0 is the low part of w. If this check passes, w0 − cs2
     //      is the low part of w − cs2."
     let mut w0cs2 = w.clone();
-    w0cs2.low_bits::<GAMMA2>();
+    w0cs2.low_bits::<P>();
     w0cs2.sub(&cs2);
-    if w0cs2.check_norm::<GAMMA2_MINUS_BETA>() { None } else { Some(w0cs2) }
+    if w0cs2.check_norm(P::GAMMA2_MINUS_BETA) { None } else { Some(w0cs2) }
 }
 
-pub(crate) fn compute_ct0_component<const GAMMA2: i32>(
+pub(crate) fn compute_ct0_component<P: MLDSAParams>(
     t0_row: &Polynomial,
     c_hat: &Polynomial,
 ) -> Option<Polynomial> {
@@ -159,18 +143,20 @@ pub(crate) fn compute_ct0_component<const GAMMA2: i32>(
     let mut ct0 = t0_hat; // rename
     ct0.inv_ntt();
 
-    if ct0.check_norm::<GAMMA2>() { None } else { Some(ct0) }
+    if ct0.check_norm(P::GAMMA2) { None } else { Some(ct0) }
 }
 
 /// Unpack a single s value from the packed representation.
-pub(crate) fn s_unpack<const eta: usize, const S_PACKED_LEN: usize>(
-    s_packed: &Secret<[u8; S_PACKED_LEN]>,
+///
+/// `B` is the packed buffer type, which is `P::S1Packed` or `P::S2Packed` depending on which of
+/// the two secret vectors is being unpacked.
+pub(crate) fn s_unpack<P: MLDSAParams, B: ZeroizablePrimitive + AsRef<[u8]>>(
+    s_packed: &Secret<B>,
     idx: usize,
 ) -> Polynomial {
     let mut s = Polynomial::new();
-    bit_unpack_eta_out::<eta>(
-        &s_packed[idx * bitlen_eta(eta)..(idx + 1) * bitlen_eta(eta)],
-        &mut s,
-    );
+    let packed = (**s_packed).as_ref();
+    let width = bitlen_eta(P::ETA);
+    bit_unpack_eta_out::<P>(&packed[idx * width..(idx + 1) * width], &mut s);
     s
 }

--- a/crypto/mldsa-lowmemory/src/mldsa.rs
+++ b/crypto/mldsa-lowmemory/src/mldsa.rs
@@ -442,31 +442,31 @@ pub(crate) const POLY_T1PACKED_LEN: usize = 320;
 
 /*** Re-exporting length constants that a caller will need instead of the entire Params objects which contains a bunch of internal algorithm detail ***/
 
-/// Length of the \[u8] holding a ML-DSA-44 public key.
+/// Length of the \[u8] holding an ML-DSA-44 public key.
 pub const MLDSA44_PK_LEN: usize = MLDSA44Params::PK_LEN;
-/// Length of the \[u8] holding a ML-DSA-44 private key, which in this implementation is just a 32-byte seed.
+/// Length of the \[u8] holding an ML-DSA-44 private key, which in this implementation is just a 32-byte seed.
 pub const MLDSA44_SK_LEN: usize = MLDSA44Params::SK_LEN;
 /// The length of the FIPS representation of the private key, which can be produced by [`MLDSAPrivateKeyTrait::encode_full_sk`]
 pub const MLDSA44_FULL_SK_LEN: usize = MLDSA44Params::FULL_SK_LEN;
-/// Length of the \[u8] holding a ML-DSA-44 signature value.
+/// Length of the \[u8] holding an ML-DSA-44 signature value.
 pub const MLDSA44_SIG_LEN: usize = MLDSA44Params::SIG_LEN;
 
-/// Length of the \[u8] holding a ML-DSA-65 public key.
+/// Length of the \[u8] holding an ML-DSA-65 public key.
 pub const MLDSA65_PK_LEN: usize = MLDSA65Params::PK_LEN;
-/// Length of the \[u8] holding a ML-DSA-65 private key, which in this implementation is just a 32-byte seed.
+/// Length of the \[u8] holding an ML-DSA-65 private key, which in this implementation is just a 32-byte seed.
 pub const MLDSA65_SK_LEN: usize = MLDSA65Params::SK_LEN;
 /// The length of the FIPS representation of the private key, which can be produced by [`MLDSAPrivateKeyTrait::encode_full_sk`]
 pub const MLDSA65_FULL_SK_LEN: usize = MLDSA65Params::FULL_SK_LEN;
-/// Length of the \[u8] holding a ML-DSA-65 signature value.
+/// Length of the \[u8] holding an ML-DSA-65 signature value.
 pub const MLDSA65_SIG_LEN: usize = MLDSA65Params::SIG_LEN;
 
-/// Length of the \[u8] holding a ML-DSA-87 public key.
+/// Length of the \[u8] holding an ML-DSA-87 public key.
 pub const MLDSA87_PK_LEN: usize = MLDSA87Params::PK_LEN;
-/// Length of the \[u8] holding a ML-DSA-87 private key, which in this implementation is just a 32-byte seed.
+/// Length of the \[u8] holding an ML-DSA-87 private key, which in this implementation is just a 32-byte seed.
 pub const MLDSA87_SK_LEN: usize = MLDSA87Params::SK_LEN;
 /// The length of the FIPS representation of the private key, which can be produced by [`MLDSAPrivateKeyTrait::encode_full_sk`]
 pub const MLDSA87_FULL_SK_LEN: usize = MLDSA87Params::FULL_SK_LEN;
-/// Length of the \[u8] holding a ML-DSA-87 signature value.
+/// Length of the \[u8] holding an ML-DSA-87 signature value.
 pub const MLDSA87_SIG_LEN: usize = MLDSA87Params::SIG_LEN;
 
 // Typedefs just to make the algorithms look more like the FIPS 204 sample code.

--- a/crypto/mldsa-lowmemory/src/mldsa.rs
+++ b/crypto/mldsa-lowmemory/src/mldsa.rs
@@ -915,7 +915,7 @@ impl<
 
                 // mutants note: don't have a test vector that exercises this condition,
                 //  not even in bc-test-data
-                if next_hint_count > P::OMEGA as usize {
+                if next_hint_count > P::omega as usize {
                     rejected = true;
                     break;
                 }
@@ -927,7 +927,7 @@ impl<
                     }
                 }
                 debug_assert_eq!(hint_count, next_hint_count);
-                output[hint_offset + P::OMEGA as usize + row] = hint_count as u8;
+                output[hint_offset + P::omega as usize + row] = hint_count as u8;
             }
 
             if rejected {
@@ -1080,7 +1080,7 @@ pub trait MLDSATrait<
     // Should still be ok in FIPS mode, provided that you're using the FIPS-approved RNG.
     fn keygen_from_rng(rng: &mut dyn RNG) -> Result<(PK, SK), SignatureError> {
         // Source the seed from the provided RNG
-        if rng.security_strength() < SecurityStrength::from_bits(P::LAMBDA as usize) {
+        if rng.security_strength() < P::MAX_SECURITY_STRENGTH {
             return Err(RNGError::SecurityStrengthInsufficientForAlgorithm)?;
         }
         let mut seed = KeyMaterial::<32>::new();

--- a/crypto/mldsa-lowmemory/src/mldsa.rs
+++ b/crypto/mldsa-lowmemory/src/mldsa.rs
@@ -384,15 +384,14 @@
 //! }
 //! ```
 
-use crate::aux_functions::{
-    bitlen_eta, bitpack_gamma1, sample_in_ball, unpack_c_tilde, unpack_h_row,
-};
+use crate::aux_functions::{bitpack_gamma1, sample_in_ball, unpack_c_tilde, unpack_h_row};
 use crate::low_memory_helpers::{
     compute_ct0_component, compute_w_row, compute_w0cs2_component, compute_wp_approx_row,
     compute_z_component, s_unpack,
 };
 use crate::mldsa_keys::{MLDSAPrivateKeyInternalTrait, MLDSAPrivateKeyTrait};
 use crate::mldsa_keys::{MLDSAPublicKeyInternalTrait, MLDSAPublicKeyTrait};
+use crate::params::{MLDSA44Params, MLDSA65Params, MLDSA87Params, MLDSAParams};
 use crate::{
     MLDSA44PrivateKey, MLDSA44PublicKey, MLDSA65PrivateKey, MLDSA65PublicKey, MLDSA87PrivateKey,
     MLDSA87PublicKey,
@@ -413,7 +412,7 @@ use crate::hash_mldsa;
 use bouncycastle_core::key_material::{KeyMaterial256, KeyMaterialTrait};
 #[allow(unused_imports)]
 use bouncycastle_core::traits::{PHSignatureVerifier, PHSigner};
-use bouncycastle_utils::secret::Secret;
+use bouncycastle_utils::secret::{Secret, ZeroizablePrimitive};
 /*** Constants ***/
 
 ///
@@ -441,110 +440,34 @@ pub const MLDSA_SEED_LEN: usize = 32;
 pub(crate) const POLY_T0PACKED_LEN: usize = 416;
 pub(crate) const POLY_T1PACKED_LEN: usize = 320;
 
-/* ML-DSA-44 params */
+/*** Re-exporting length constants that a caller will need instead of the entire Params objects which contains a bunch of internal algorithm detail ***/
 
 /// Length of the \[u8] holding a ML-DSA-44 public key.
-pub const MLDSA44_PK_LEN: usize = 1312;
+pub const MLDSA44_PK_LEN: usize = MLDSA44Params::PK_LEN;
 /// Length of the \[u8] holding a ML-DSA-44 private key, which in this implementation is just a 32-byte seed.
-pub const MLDSA44_SK_LEN: usize = MLDSA_SEED_LEN;
+pub const MLDSA44_SK_LEN: usize = MLDSA44Params::SK_LEN;
 /// The length of the FIPS representation of the private key, which can be produced by [`MLDSAPrivateKeyTrait::encode_full_sk`]
-pub const MLDSA44_FULL_SK_LEN: usize = 2560;
+pub const MLDSA44_FULL_SK_LEN: usize = MLDSA44Params::FULL_SK_LEN;
 /// Length of the \[u8] holding a ML-DSA-44 signature value.
-pub const MLDSA44_SIG_LEN: usize = 2420;
-pub(crate) const MLDSA44_TAU: i32 = 39;
-pub(crate) const MLDSA44_LAMBDA: i32 = 128;
-pub(crate) const MLDSA44_GAMMA1: i32 = 1 << 17;
-pub(crate) const MLDSA44_GAMMA2: i32 = (q - 1) / 88; // mutants note: because of the bitshifting, the "- 1" ends up not mattering
-pub(crate) const MLDSA44_k: usize = 4;
-pub(crate) const MLDSA44_l: usize = 4;
-pub(crate) const MLDSA44_ETA: usize = 2;
-pub(crate) const MLDSA44_BETA: i32 = 78;
-pub(crate) const MLDSA44_OMEGA: i32 = 80;
-
-// Useful derived values
-pub(crate) const MLDSA44_C_TILDE: usize = 32;
-pub(crate) const MLDSA44_POLY_Z_PACKED_LEN: usize = 576;
-pub(crate) const MLDSA44_POLY_W1_PACKED_LEN: usize = 192;
-pub(crate) const MLDSA44_S1_PACKED_LEN: usize = bitlen_eta(MLDSA44_ETA) * MLDSA44_l; // 384 bytes
-pub(crate) const MLDSA44_S2_PACKED_LEN: usize = bitlen_eta(MLDSA44_ETA) * MLDSA44_k; // 384 bytes
-pub(crate) const MLDSA44_T1_PACKED_LEN: usize = POLY_T1PACKED_LEN * MLDSA44_k; // 768 bytes
-pub(crate) const MLDSA44_LAMBDA_over_4: usize = 128 / 4;
-pub(crate) const MLDSA44_GAMMA1_MINUS_BETA: i32 = MLDSA44_GAMMA1 - MLDSA44_BETA; // mutants note: there is a test vector for this in the regular implementation, but its sk seed is not known here, so can't test it here.
-pub(crate) const MLDSA44_GAMMA2_MINUS_BETA: i32 = MLDSA44_GAMMA2 - MLDSA44_BETA; // mutants note: there is a test vector for this in the regular implementation, but its sk seed is not known here, so can't test it here.
-
-// Alg 32
-// 1: 𝑐 ← 1 + bitlen (𝛾1 − 1)
-pub(crate) const MLDSA44_GAMMA1_MASK_LEN: usize = 576; // 32*(1 + bitlen (𝛾1 − 1) )
-
-/* ML-DSA-65 params */
+pub const MLDSA44_SIG_LEN: usize = MLDSA44Params::SIG_LEN;
 
 /// Length of the \[u8] holding a ML-DSA-65 public key.
-pub const MLDSA65_PK_LEN: usize = 1952;
+pub const MLDSA65_PK_LEN: usize = MLDSA65Params::PK_LEN;
 /// Length of the \[u8] holding a ML-DSA-65 private key, which in this implementation is just a 32-byte seed.
-pub const MLDSA65_SK_LEN: usize = MLDSA_SEED_LEN;
+pub const MLDSA65_SK_LEN: usize = MLDSA65Params::SK_LEN;
 /// The length of the FIPS representation of the private key, which can be produced by [`MLDSAPrivateKeyTrait::encode_full_sk`]
-pub const MLDSA65_FULL_SK_LEN: usize = 4032;
+pub const MLDSA65_FULL_SK_LEN: usize = MLDSA65Params::FULL_SK_LEN;
 /// Length of the \[u8] holding a ML-DSA-65 signature value.
-pub const MLDSA65_SIG_LEN: usize = 3309;
-pub(crate) const MLDSA65_TAU: i32 = 49;
-pub(crate) const MLDSA65_LAMBDA: i32 = 192;
-pub(crate) const MLDSA65_GAMMA1: i32 = 1 << 19;
-pub(crate) const MLDSA65_GAMMA2: i32 = (q - 1) / 32; // mutants note: because of the bitshifting, the "- 1" ends up not mattering
-pub(crate) const MLDSA65_k: usize = 6;
-pub(crate) const MLDSA65_l: usize = 5;
-pub(crate) const MLDSA65_ETA: usize = 4;
-pub(crate) const MLDSA65_BETA: i32 = 196;
-pub(crate) const MLDSA65_OMEGA: i32 = 55;
-
-// Useful derived values
-pub(crate) const MLDSA65_C_TILDE: usize = 48;
-pub(crate) const MLDSA65_POLY_Z_PACKED_LEN: usize = 640;
-pub(crate) const MLDSA65_POLY_W1_PACKED_LEN: usize = 128;
-pub(crate) const MLDSA65_S1_PACKED_LEN: usize = bitlen_eta(MLDSA65_ETA) * MLDSA65_l; // 640 bytes
-pub(crate) const MLDSA65_S2_PACKED_LEN: usize = bitlen_eta(MLDSA65_ETA) * MLDSA65_k; // 768 bytes
-pub(crate) const MLDSA65_T1_PACKED_LEN: usize = POLY_T1PACKED_LEN * MLDSA65_k; // 1152 bytes
-pub(crate) const MLDSA65_LAMBDA_over_4: usize = 192 / 4;
-pub(crate) const MLDSA65_GAMMA1_MINUS_BETA: i32 = MLDSA65_GAMMA1 - MLDSA65_BETA; // mutants note: there is a test vector for this in the regular implementation, but its sk seed is not known here, so can't test it here.
-pub(crate) const MLDSA65_GAMMA2_MINUS_BETA: i32 = MLDSA65_GAMMA2 - MLDSA65_BETA; // mutants note: there is a test vector for this in the regular implementation, but its sk seed is not known here, so can't test it here.
-
-// Alg 32
-// 1: 𝑐 ← 1 + bitlen (𝛾1 − 1)
-pub(crate) const MLDSA65_GAMMA1_MASK_LEN: usize = 640;
-
-/* ML-DSA-87 params */
+pub const MLDSA65_SIG_LEN: usize = MLDSA65Params::SIG_LEN;
 
 /// Length of the \[u8] holding a ML-DSA-87 public key.
-pub const MLDSA87_PK_LEN: usize = 2592;
+pub const MLDSA87_PK_LEN: usize = MLDSA87Params::PK_LEN;
 /// Length of the \[u8] holding a ML-DSA-87 private key, which in this implementation is just a 32-byte seed.
-pub const MLDSA87_SK_LEN: usize = MLDSA_SEED_LEN;
+pub const MLDSA87_SK_LEN: usize = MLDSA87Params::SK_LEN;
 /// The length of the FIPS representation of the private key, which can be produced by [`MLDSAPrivateKeyTrait::encode_full_sk`]
-pub const MLDSA87_FULL_SK_LEN: usize = 4896;
+pub const MLDSA87_FULL_SK_LEN: usize = MLDSA87Params::FULL_SK_LEN;
 /// Length of the \[u8] holding a ML-DSA-87 signature value.
-pub const MLDSA87_SIG_LEN: usize = 4627;
-pub(crate) const MLDSA87_TAU: i32 = 60;
-pub(crate) const MLDSA87_LAMBDA: i32 = 256;
-pub(crate) const MLDSA87_GAMMA1: i32 = 1 << 19;
-pub(crate) const MLDSA87_GAMMA2: i32 = (q - 1) / 32; // mutants note: because of the bitshifting, the "- 1" ends up not mattering
-pub(crate) const MLDSA87_k: usize = 8;
-pub(crate) const MLDSA87_l: usize = 7;
-pub(crate) const MLDSA87_ETA: usize = 2;
-pub(crate) const MLDSA87_BETA: i32 = 120;
-pub(crate) const MLDSA87_OMEGA: i32 = 75;
-
-// Useful derived values
-pub(crate) const MLDSA87_C_TILDE: usize = 64;
-pub(crate) const MLDSA87_POLY_Z_PACKED_LEN: usize = 640;
-pub(crate) const MLDSA87_POLY_W1_PACKED_LEN: usize = 128;
-pub(crate) const MLDSA87_S1_PACKED_LEN: usize = bitlen_eta(MLDSA87_ETA) * MLDSA87_l; // 672 bytes
-pub(crate) const MLDSA87_S2_PACKED_LEN: usize = bitlen_eta(MLDSA87_ETA) * MLDSA87_k; // 768 bytes
-pub(crate) const MLDSA87_T1_PACKED_LEN: usize = POLY_T1PACKED_LEN * MLDSA87_k; // 1024 bytes
-pub(crate) const MLDSA87_LAMBDA_over_4: usize = 256 / 4;
-pub(crate) const MLDSA87_GAMMA1_MINUS_BETA: i32 = MLDSA87_GAMMA1 - MLDSA87_BETA; // mutants note: there is a test vector for this in the regular implementation, but its sk seed is not known here, so can't test it here.
-pub(crate) const MLDSA87_GAMMA2_MINUS_BETA: i32 = MLDSA87_GAMMA2 - MLDSA87_BETA; // mutants note: there is a test vector for this in the regular implementation, but its sk seed is not known here, so can't test it here.
-
-// Alg 32
-// 1: 𝑐 ← 1 + bitlen (𝛾1 − 1)
-pub(crate) const MLDSA87_GAMMA1_MASK_LEN: usize = 640;
+pub const MLDSA87_SIG_LEN: usize = MLDSA87Params::SIG_LEN;
 
 // Typedefs just to make the algorithms look more like the FIPS 204 sample code.
 pub(crate) type H = SHAKE256;
@@ -554,175 +477,84 @@ pub(crate) type G = SHAKE128;
 
 /// The ML-DSA-44 algorithm.
 pub type MLDSA44 = MLDSA<
+    MLDSA44Params,
+    MLDSA44PublicKey,
+    MLDSA44PrivateKey,
     MLDSA44_PK_LEN,
     MLDSA44_SK_LEN,
     MLDSA44_FULL_SK_LEN,
     MLDSA44_SIG_LEN,
-    MLDSA44PublicKey,
-    MLDSA44PrivateKey,
-    MLDSA44_TAU,
-    MLDSA44_LAMBDA,
-    MLDSA44_GAMMA1,
-    MLDSA44_GAMMA2,
-    MLDSA44_k,
-    MLDSA44_l,
-    MLDSA44_ETA,
-    MLDSA44_BETA,
-    MLDSA44_OMEGA,
-    MLDSA44_C_TILDE,
-    MLDSA44_POLY_Z_PACKED_LEN,
-    MLDSA44_POLY_W1_PACKED_LEN,
-    MLDSA44_S1_PACKED_LEN,
-    MLDSA44_S2_PACKED_LEN,
-    MLDSA44_T1_PACKED_LEN,
-    MLDSA44_LAMBDA_over_4,
-    MLDSA44_GAMMA1_MINUS_BETA,
-    MLDSA44_GAMMA2_MINUS_BETA,
-    MLDSA44_GAMMA1_MASK_LEN,
 >;
-
-impl Algorithm for MLDSA44 {
-    const ALG_NAME: &'static str = ML_DSA_44_NAME;
-    const MAX_SECURITY_STRENGTH: SecurityStrength = SecurityStrength::_128bit;
-}
-/// Assigned by NIST in the Computer Security Objects Register: id-ml-dsa-44 { sigAlgs 17 }
-impl AlgorithmOID for MLDSA44 {
-    const OID: &'static [u32] = &[2, 16, 840, 1, 101, 3, 4, 3, 17];
-    const OID_DER: &'static [u8] =
-        &[0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x03, 0x11];
-}
 
 /// The ML-DSA-65 algorithm.
 pub type MLDSA65 = MLDSA<
+    MLDSA65Params,
+    MLDSA65PublicKey,
+    MLDSA65PrivateKey,
     MLDSA65_PK_LEN,
     MLDSA65_SK_LEN,
     MLDSA65_FULL_SK_LEN,
     MLDSA65_SIG_LEN,
-    MLDSA65PublicKey,
-    MLDSA65PrivateKey,
-    MLDSA65_TAU,
-    MLDSA65_LAMBDA,
-    MLDSA65_GAMMA1,
-    MLDSA65_GAMMA2,
-    MLDSA65_k,
-    MLDSA65_l,
-    MLDSA65_ETA,
-    MLDSA65_BETA,
-    MLDSA65_OMEGA,
-    MLDSA65_C_TILDE,
-    MLDSA65_POLY_Z_PACKED_LEN,
-    MLDSA65_POLY_W1_PACKED_LEN,
-    MLDSA65_S1_PACKED_LEN,
-    MLDSA65_S2_PACKED_LEN,
-    MLDSA65_T1_PACKED_LEN,
-    MLDSA65_LAMBDA_over_4,
-    MLDSA65_GAMMA1_MINUS_BETA,
-    MLDSA65_GAMMA2_MINUS_BETA,
-    MLDSA65_GAMMA1_MASK_LEN,
 >;
-
-impl Algorithm for MLDSA65 {
-    const ALG_NAME: &'static str = ML_DSA_65_NAME;
-    const MAX_SECURITY_STRENGTH: SecurityStrength = SecurityStrength::_192bit;
-}
-/// Assigned by NIST in the Computer Security Objects Register: id-ml-dsa-65 { sigAlgs 18 }
-impl AlgorithmOID for MLDSA65 {
-    const OID: &'static [u32] = &[2, 16, 840, 1, 101, 3, 4, 3, 18];
-    const OID_DER: &'static [u8] =
-        &[0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x03, 0x12];
-}
 
 /// The ML-DSA-87 algorithm.
 pub type MLDSA87 = MLDSA<
+    MLDSA87Params,
+    MLDSA87PublicKey,
+    MLDSA87PrivateKey,
     MLDSA87_PK_LEN,
     MLDSA87_SK_LEN,
     MLDSA87_FULL_SK_LEN,
     MLDSA87_SIG_LEN,
-    MLDSA87PublicKey,
-    MLDSA87PrivateKey,
-    MLDSA87_TAU,
-    MLDSA87_LAMBDA,
-    MLDSA87_GAMMA1,
-    MLDSA87_GAMMA2,
-    MLDSA87_k,
-    MLDSA87_l,
-    MLDSA87_ETA,
-    MLDSA87_BETA,
-    MLDSA87_OMEGA,
-    MLDSA87_C_TILDE,
-    MLDSA87_POLY_Z_PACKED_LEN,
-    MLDSA87_POLY_W1_PACKED_LEN,
-    MLDSA87_S1_PACKED_LEN,
-    MLDSA87_S2_PACKED_LEN,
-    MLDSA87_T1_PACKED_LEN,
-    MLDSA87_LAMBDA_over_4,
-    MLDSA87_GAMMA1_MINUS_BETA,
-    MLDSA87_GAMMA2_MINUS_BETA,
-    MLDSA87_GAMMA1_MASK_LEN,
 >;
 
-impl Algorithm for MLDSA87 {
-    const ALG_NAME: &'static str = ML_DSA_87_NAME;
-    const MAX_SECURITY_STRENGTH: SecurityStrength = SecurityStrength::_256bit;
+impl<
+    P: MLDSAParams,
+    PK: MLDSAPublicKeyTrait<P, PK_LEN> + MLDSAPublicKeyInternalTrait<P, PK_LEN>,
+    SK: MLDSAPrivateKeyTrait<P, PK_LEN, SK_LEN, FULL_SK_LEN>
+        + MLDSAPrivateKeyInternalTrait<P, PK_LEN, SK_LEN>,
+    const PK_LEN: usize,
+    const SK_LEN: usize,
+    const FULL_SK_LEN: usize,
+    const SIG_LEN: usize,
+> Algorithm for MLDSA<P, PK, SK, PK_LEN, SK_LEN, FULL_SK_LEN, SIG_LEN>
+{
+    const ALG_NAME: &'static str = P::ALG_NAME;
+    const MAX_SECURITY_STRENGTH: SecurityStrength = P::MAX_SECURITY_STRENGTH;
 }
-/// Assigned by NIST in the Computer Security Objects Register: id-ml-dsa-87 { sigAlgs 19 }
-impl AlgorithmOID for MLDSA87 {
-    const OID: &'static [u32] = &[2, 16, 840, 1, 101, 3, 4, 3, 19];
-    const OID_DER: &'static [u8] =
-        &[0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x03, 0x13];
+
+/// The OIDs NIST assigned in the Computer Security Objects Register: id-ml-dsa-44 { sigAlgs 17 },
+/// id-ml-dsa-65 { sigAlgs 18 } and id-ml-dsa-87 { sigAlgs 19 }. As with [`Algorithm`], the values
+/// belong to the parameter set, so one impl covers all three.
+impl<
+    P: MLDSAParams,
+    PK: MLDSAPublicKeyTrait<P, PK_LEN> + MLDSAPublicKeyInternalTrait<P, PK_LEN>,
+    SK: MLDSAPrivateKeyTrait<P, PK_LEN, SK_LEN, FULL_SK_LEN>
+        + MLDSAPrivateKeyInternalTrait<P, PK_LEN, SK_LEN>,
+    const PK_LEN: usize,
+    const SK_LEN: usize,
+    const FULL_SK_LEN: usize,
+    const SIG_LEN: usize,
+> AlgorithmOID for MLDSA<P, PK, SK, PK_LEN, SK_LEN, FULL_SK_LEN, SIG_LEN>
+{
+    const OID: &'static [u32] = P::OID;
+    const OID_DER: &'static [u8] = P::OID_DER;
 }
 
 /// The core internal implementation of the ML-DSA algorithm.
 /// This needs to be public for the compiler to be able to find it, but there shouldn't ever
 /// be a need to use this directly. Please use the named public types.
 pub struct MLDSA<
+    P: MLDSAParams,
+    PK: MLDSAPublicKeyTrait<P, PK_LEN> + MLDSAPublicKeyInternalTrait<P, PK_LEN>,
+    SK: MLDSAPrivateKeyTrait<P, PK_LEN, SK_LEN, FULL_SK_LEN>
+        + MLDSAPrivateKeyInternalTrait<P, PK_LEN, SK_LEN>,
     const PK_LEN: usize,
     const SK_LEN: usize,
     const FULL_SK_LEN: usize,
     const SIG_LEN: usize,
-    PK: MLDSAPublicKeyTrait<k, T1_PACKED_LEN, PK_LEN>
-        + MLDSAPublicKeyInternalTrait<k, T1_PACKED_LEN, PK_LEN>,
-    SK: MLDSAPrivateKeyTrait<
-            k,
-            l,
-            S1_PACKED_LEN,
-            S2_PACKED_LEN,
-            T1_PACKED_LEN,
-            PK_LEN,
-            SK_LEN,
-            FULL_SK_LEN,
-        > + MLDSAPrivateKeyInternalTrait<
-            LAMBDA,
-            GAMMA2,
-            k,
-            l,
-            ETA,
-            S1_PACKED_LEN,
-            S2_PACKED_LEN,
-            PK_LEN,
-            SK_LEN,
-        >,
-    const TAU: i32,
-    const LAMBDA: i32,
-    const GAMMA1: i32,
-    const GAMMA2: i32,
-    const k: usize,
-    const l: usize,
-    const ETA: usize,
-    const BETA: i32,
-    const OMEGA: i32,
-    const C_TILDE: usize,
-    const POLY_VEC_H_PACKED_LEN: usize,
-    const POLY_W1_PACKED_LEN: usize,
-    const S1_PACKED_LEN: usize,
-    const S2_PACKED_LEN: usize,
-    const T1_PACKED_LEN: usize,
-    const LAMBDA_over_4: usize,
-    const GAMMA1_MINUS_BETA: i32,
-    const GAMMA2_MINUS_BETA: i32,
-    const GAMMA1_MASK_LEN: usize,
 > {
-    _phantom: PhantomData<(PK, SK)>,
+    _phantom: PhantomData<(P, PK, SK)>,
 
     /// used for streaming the message for both signing and verifying
     mu_builder: MuBuilder,
@@ -740,79 +572,15 @@ pub struct MLDSA<
 }
 
 impl<
+    P: MLDSAParams,
+    PK: MLDSAPublicKeyTrait<P, PK_LEN> + MLDSAPublicKeyInternalTrait<P, PK_LEN>,
+    SK: MLDSAPrivateKeyTrait<P, PK_LEN, SK_LEN, FULL_SK_LEN>
+        + MLDSAPrivateKeyInternalTrait<P, PK_LEN, SK_LEN>,
     const PK_LEN: usize,
     const SK_LEN: usize,
     const FULL_SK_LEN: usize,
     const SIG_LEN: usize,
-    PK: MLDSAPublicKeyTrait<k, T1_PACKED_LEN, PK_LEN>
-        + MLDSAPublicKeyInternalTrait<k, T1_PACKED_LEN, PK_LEN>,
-    SK: MLDSAPrivateKeyTrait<
-            k,
-            l,
-            S1_PACKED_LEN,
-            S2_PACKED_LEN,
-            T1_PACKED_LEN,
-            PK_LEN,
-            SK_LEN,
-            FULL_SK_LEN,
-        > + MLDSAPrivateKeyInternalTrait<
-            LAMBDA,
-            GAMMA2,
-            k,
-            l,
-            ETA,
-            S1_PACKED_LEN,
-            S2_PACKED_LEN,
-            PK_LEN,
-            SK_LEN,
-        >,
-    const TAU: i32,
-    const LAMBDA: i32,
-    const GAMMA1: i32,
-    const GAMMA2: i32,
-    const k: usize,
-    const l: usize,
-    const ETA: usize,
-    const BETA: i32,
-    const OMEGA: i32,
-    const C_TILDE: usize,
-    const POLY_Z_PACKED_LEN: usize,
-    const POLY_W1_PACKED_LEN: usize,
-    const S1_PACKED_LEN: usize,
-    const S2_PACKED_LEN: usize,
-    const T1_PACKED_LEN: usize,
-    const LAMBDA_over_4: usize,
-    const GAMMA1_MINUS_BETA: i32,
-    const GAMMA2_MINUS_BETA: i32,
-    const GAMMA1_MASK_LEN: usize,
->
-    MLDSA<
-        PK_LEN,
-        SK_LEN,
-        FULL_SK_LEN,
-        SIG_LEN,
-        PK,
-        SK,
-        TAU,
-        LAMBDA,
-        GAMMA1,
-        GAMMA2,
-        k,
-        l,
-        ETA,
-        BETA,
-        OMEGA,
-        C_TILDE,
-        POLY_Z_PACKED_LEN,
-        POLY_W1_PACKED_LEN,
-        S1_PACKED_LEN,
-        S2_PACKED_LEN,
-        T1_PACKED_LEN,
-        LAMBDA_over_4,
-        GAMMA1_MINUS_BETA,
-        GAMMA2_MINUS_BETA,
-        GAMMA1_MASK_LEN,
-    >
+> MLDSA<P, PK, SK, PK_LEN, SK_LEN, FULL_SK_LEN, SIG_LEN>
 {
     /// Performs the first step of key generation to transform the single provided seed into a set of internal intermediate seeds.
     ///
@@ -831,95 +599,16 @@ impl<
 }
 
 impl<
+    P: MLDSAParams,
+    PK: MLDSAPublicKeyTrait<P, PK_LEN> + MLDSAPublicKeyInternalTrait<P, PK_LEN>,
+    SK: MLDSAPrivateKeyTrait<P, PK_LEN, SK_LEN, FULL_SK_LEN>
+        + MLDSAPrivateKeyInternalTrait<P, PK_LEN, SK_LEN>,
     const PK_LEN: usize,
     const SK_LEN: usize,
     const FULL_SK_LEN: usize,
     const SIG_LEN: usize,
-    PK: MLDSAPublicKeyTrait<k, T1_PACKED_LEN, PK_LEN>
-        + MLDSAPublicKeyInternalTrait<k, T1_PACKED_LEN, PK_LEN>,
-    SK: MLDSAPrivateKeyTrait<
-            k,
-            l,
-            S1_PACKED_LEN,
-            S2_PACKED_LEN,
-            T1_PACKED_LEN,
-            PK_LEN,
-            SK_LEN,
-            FULL_SK_LEN,
-        > + MLDSAPrivateKeyInternalTrait<
-            LAMBDA,
-            GAMMA2,
-            k,
-            l,
-            eta,
-            S1_PACKED_LEN,
-            S2_PACKED_LEN,
-            PK_LEN,
-            SK_LEN,
-        >,
-    const TAU: i32,
-    const LAMBDA: i32,
-    const GAMMA1: i32,
-    const GAMMA2: i32,
-    const k: usize,
-    const l: usize,
-    const eta: usize,
-    const BETA: i32,
-    const OMEGA: i32,
-    const C_TILDE: usize,
-    const POLY_Z_PACKED_LEN: usize,
-    const POLY_W1_PACKED_LEN: usize,
-    const S1_PACKED_LEN: usize,
-    const S2_PACKED_LEN: usize,
-    const T1_PACKED_LEN: usize,
-    const LAMBDA_over_4: usize,
-    const GAMMA1_MINUS_BETA: i32,
-    const GAMMA2_MINUS_BETA: i32,
-    const GAMMA1_MASK_LEN: usize,
->
-    MLDSATrait<
-        PK_LEN,
-        SK_LEN,
-        FULL_SK_LEN,
-        SIG_LEN,
-        PK,
-        SK,
-        LAMBDA,
-        GAMMA2,
-        k,
-        l,
-        S1_PACKED_LEN,
-        S2_PACKED_LEN,
-        T1_PACKED_LEN,
-        eta,
-    >
-    for MLDSA<
-        PK_LEN,
-        SK_LEN,
-        FULL_SK_LEN,
-        SIG_LEN,
-        PK,
-        SK,
-        TAU,
-        LAMBDA,
-        GAMMA1,
-        GAMMA2,
-        k,
-        l,
-        eta,
-        BETA,
-        OMEGA,
-        C_TILDE,
-        POLY_Z_PACKED_LEN,
-        POLY_W1_PACKED_LEN,
-        S1_PACKED_LEN,
-        S2_PACKED_LEN,
-        T1_PACKED_LEN,
-        LAMBDA_over_4,
-        GAMMA1_MINUS_BETA,
-        GAMMA2_MINUS_BETA,
-        GAMMA1_MASK_LEN,
-    >
+> MLDSATrait<P, PK, SK, PK_LEN, SK_LEN, FULL_SK_LEN, SIG_LEN>
+    for MLDSA<P, PK, SK, PK_LEN, SK_LEN, FULL_SK_LEN, SIG_LEN>
 {
     /*** Key Generation and PK / SK consistency checks ***/
 
@@ -1089,8 +778,8 @@ impl<
         // They are uncompresso as-needed, and only one polynomial at a time.
         // Storing these in memory can be avoided, but then all the sites where they are used
         // will require calls to sk.compute_s1_row() and sk.compute_s2_row(), which are fairly expensive.
-        let s1_packed: Secret<[u8; S1_PACKED_LEN]> = sk.compute_s1_packed();
-        let s2_packed: Secret<[u8; S2_PACKED_LEN]> = sk.compute_s2_packed();
+        let s1_packed: Secret<P::S1Packed> = sk.compute_s1_packed();
+        let s2_packed: Secret<P::S2Packed> = sk.compute_s2_packed();
 
         // 6: 𝜇 ← H(BytesToBits(𝑡𝑟)||𝑀 ′, 64)
         // skip: mu has already been provided
@@ -1111,14 +800,14 @@ impl<
         //  ▷ initialize counter 𝜅
         let mut kappa: u16 = 0;
 
-        let z_offset = LAMBDA_over_4;
-        let hint_offset = LAMBDA_over_4 + l * POLY_Z_PACKED_LEN;
+        let z_offset = P::C_TILDE_LEN;
+        let hint_offset = P::C_TILDE_LEN + P::l * P::POLY_Z_PACKED_LEN;
 
         loop {
             // FIPS 204 s. 6.2 allows:
             //   "Implementations may limit the number of iterations in this loop to not exceed a finite maximum value."
             // mutants note: there is no test for this because we don't have access to a KAT that will exceed this limit.
-            if kappa > 1000 * k as u16 {
+            if kappa > 1000 * P::k as u16 {
                 return Err(SignatureError::GenericError(
                     "Rejection sampling loop exceeded max iterations, try again with a different signing nonce.",
                 ));
@@ -1129,45 +818,39 @@ impl<
                 // scope for hash
                 let mut hash = H::new();
                 hash.absorb(mu).expect("absorb before squeeze is infallible");
-                for row in 0..k {
-                    let mut w = compute_w_row::<l, GAMMA1, GAMMA1_MASK_LEN>(
-                        &sk.rho(),
-                        &rho_p_p,
-                        kappa,
-                        row,
-                    );
-                    w.high_bits::<GAMMA2>();
-                    hash.absorb(&w.w1_encode::<POLY_W1_PACKED_LEN>())
+                for row in 0..P::k {
+                    let mut w = compute_w_row::<P>(&sk.rho(), &rho_p_p, kappa, row);
+                    w.high_bits::<P>();
+                    hash.absorb(w.w1_encode::<P>().as_ref())
                         .expect("absorb before squeeze is infallible");
                 }
-                let mut sig_val_c_tilde = [0u8; LAMBDA_over_4];
-                hash.squeeze_out(&mut sig_val_c_tilde);
+                let mut sig_val_c_tilde = <P::SigCTilde as ZeroizablePrimitive>::ZEROED;
+                hash.squeeze_out(sig_val_c_tilde.as_mut());
                 sig_val_c_tilde
             };
             // 16: 𝑐 ∈ 𝑅𝑞 ← SampleInBall(c_tilde)
             // 17: 𝑐_hat ← NTT(𝑐)
             // optimization note: c_hat is used basically until the end, it can't really be scoped
-            let mut c_hat = sample_in_ball::<LAMBDA_over_4, TAU>(&sig_val_c_tilde);
+            let mut c_hat = sample_in_ball::<P>(&sig_val_c_tilde);
             c_hat.ntt();
 
             output.fill(0);
-            output[..LAMBDA_over_4].copy_from_slice(&sig_val_c_tilde);
+            output[..P::C_TILDE_LEN].copy_from_slice(sig_val_c_tilde.as_ref());
 
-            let (z_chunks, z_remainder) = output[z_offset..z_offset + l * POLY_Z_PACKED_LEN]
-                .as_chunks_mut::<POLY_Z_PACKED_LEN>();
-            debug_assert_eq!(z_chunks.len(), l);
-            debug_assert_eq!(z_remainder.len(), 0);
+            // The 𝐳 coordinates occupy `P::l` consecutive `P::POLY_Z_PACKED_LEN`-byte windows
+            // starting at `z_offset`.
+            debug_assert!(z_offset + P::l * P::POLY_Z_PACKED_LEN <= SIG_LEN);
 
             // 18-23 (z path): compute and encode each z polynomial directly into the caller buffer.
             let mut rejected = false;
-            for col in 0..l {
-                let z = match compute_z_component::<GAMMA1, GAMMA1_MASK_LEN, GAMMA1_MINUS_BETA>(
+            for col in 0..P::l {
+                let z = match compute_z_component::<P>(
                     // [Optimization Note]:
                     // This is one of the places that a row of s1 can be re-computed instead of unpacked from the compressed form.
                     // weirdly, in perf testing, this actually caused memory usage to go by a small amount;
                     // maybe because re-computing the intermediates adds more to the widest point of the alg?
                     // &sk.compute_s1_row(col),
-                    &s_unpack::<eta, S1_PACKED_LEN>(&s1_packed, col),
+                    &s_unpack::<P, _>(&s1_packed, col),
                     &rho_p_p,
                     &c_hat,
                     kappa,
@@ -1180,25 +863,25 @@ impl<
                     }
                 };
 
-                bitpack_gamma1::<POLY_Z_PACKED_LEN, GAMMA1>(&z, &mut z_chunks[col]);
+                let start = z_offset + col * P::POLY_Z_PACKED_LEN;
+                bitpack_gamma1::<P>(&z, &mut output[start..start + P::POLY_Z_PACKED_LEN]);
             }
 
             if rejected {
                 // mutants note: we don't have access to a test vector that exercises this
-                kappa += l as u16;
+                kappa += P::l as u16;
                 continue;
             }
 
             // 19-28 (hint path): recompute rows as needed and write the packed hint directly.
             let mut hint_count = 0usize;
-            for row in 0..k {
-                let mut w =
-                    compute_w_row::<l, GAMMA1, GAMMA1_MASK_LEN>(&sk.rho(), &rho_p_p, kappa, row);
-                let mut tmp = match compute_w0cs2_component::<GAMMA2, GAMMA2_MINUS_BETA>(
+            for row in 0..P::k {
+                let mut w = compute_w_row::<P>(&sk.rho(), &rho_p_p, kappa, row);
+                let mut tmp = match compute_w0cs2_component::<P>(
                     // [Optimization Note]:
                     // This is one of the places that a row of s1 can be re-computed instead of unpacked from the compressed form.
                     // &sk.compute_s2_row(row),
-                    &s_unpack::<eta, S2_PACKED_LEN>(&s2_packed, row),
+                    &s_unpack::<P, _>(&s2_packed, row),
                     &w,
                     &c_hat,
                 ) {
@@ -1209,7 +892,7 @@ impl<
                     }
                 };
 
-                let ct0 = match compute_ct0_component::<GAMMA2>(
+                let ct0 = match compute_ct0_component::<P>(
                     // [Optimization Note]:
                     // This is one of the places that a row of s1 can be re-computed instead of unpacked from the compressed form.
                     // &sk.compute_t0_row(row), &c_hat) {
@@ -1226,13 +909,13 @@ impl<
                 tmp.add_ntt(&ct0);
                 tmp.conditional_add_q();
 
-                w.high_bits::<GAMMA2>();
-                let (hint_row, weight) = tmp.make_hint_row::<GAMMA2>(&w);
+                w.high_bits::<P>();
+                let (hint_row, weight) = tmp.make_hint_row::<P>(&w);
                 let next_hint_count = hint_count + weight as usize;
 
                 // mutants note: don't have a test vector that exercises this condition,
                 //  not even in bc-test-data
-                if next_hint_count > OMEGA as usize {
+                if next_hint_count > P::OMEGA as usize {
                     rejected = true;
                     break;
                 }
@@ -1244,11 +927,11 @@ impl<
                     }
                 }
                 debug_assert_eq!(hint_count, next_hint_count);
-                output[hint_offset + OMEGA as usize + row] = hint_count as u8;
+                output[hint_offset + P::OMEGA as usize + row] = hint_count as u8;
             }
 
             if rejected {
-                kappa += l as u16;
+                kappa += P::l as u16;
                 continue;
             }
 
@@ -1325,40 +1008,24 @@ impl<
         // skip because this function is being handed mu
 
         // 8: 𝑐 ∈ 𝑅𝑞 ← SampleInBall(c_tilde)
-        let c = sample_in_ball::<LAMBDA_over_4, TAU>(unpack_c_tilde(sig));
+        let c = sample_in_ball::<P>(&unpack_c_tilde::<P>(sig));
 
         // 12: 𝑐_tilde_p ← H(𝜇||w1Encode(𝐰1'), 𝜆/4)
         // ▷ hash it; this should match 𝑐_tilde
         let mut hash = H::new();
         hash.absorb(mu).expect("absorb before squeeze is infallible");
 
-        for row in 0..k {
+        for row in 0..P::k {
             let mut wp_approx = match {
                 // 9: 𝐰′_approx ← NTT−1(𝐀_hat ∘ NTT(𝐳) − NTT(𝑐) ∘ NTT(𝐭1 ⋅ 2^𝑑))
-                compute_wp_approx_row::<
-                    GAMMA1,
-                    GAMMA1_MINUS_BETA,
-                    l,
-                    POLY_Z_PACKED_LEN,
-                    LAMBDA_over_4,
-                    SIG_LEN,
-                >(pk.rho(), sig, &pk.unpack_t1_row(row), &c, row)
+                compute_wp_approx_row::<P, SIG_LEN>(pk.rho(), sig, &pk.unpack_t1_row(row), &c, row)
             } {
                 Ok(wp_approx) => wp_approx,
                 // means the norm check on z failed
                 Err(_) => return Err(SignatureError::SignatureVerificationFailed),
             };
 
-            let h_i = match unpack_h_row::<
-                GAMMA1,
-                k,
-                l,
-                OMEGA,
-                LAMBDA_over_4,
-                POLY_Z_PACKED_LEN,
-                SIG_LEN,
-            >(row, &sig)
-            {
+            let h_i = match unpack_h_row::<P, SIG_LEN>(row, &sig) {
                 Some(h_i) => h_i,
                 // means there were more than OMEGA bits set in the hint
                 None => return Err(SignatureError::SignatureVerificationFailed),
@@ -1366,19 +1033,22 @@ impl<
 
             // 10: 𝐰1′ ← UseHint(𝐡, 𝐰'_approx)
             // ▷ reconstruction of signer’s commitment
-            wp_approx.use_hint::<GAMMA2>(&h_i);
-            hash.absorb(&wp_approx.w1_encode::<POLY_W1_PACKED_LEN>())
+            wp_approx.use_hint::<P>(&h_i);
+            hash.absorb(wp_approx.w1_encode::<P>().as_ref())
                 .expect("absorb before squeeze is infallible");
         }
 
-        let mut c_tilde_p = [0u8; LAMBDA_over_4];
-        hash.squeeze_out(&mut c_tilde_p);
+        let mut c_tilde_p = <P::SigCTilde as ZeroizablePrimitive>::ZEROED;
+        hash.squeeze_out(c_tilde_p.as_mut());
 
         // Verification is also done in constant time
         // 13 (second half): return [[ ||𝐳||∞ < 𝛾1 − 𝛽]] and [[𝑐 ̃ = 𝑐′ ]]
         //   note: the first half of this check (the norm check) is buried in unpack_z_row(),
         //         which is called from compute_wp_approx_row()
-        if bouncycastle_utils::ct::ct_eq_bytes(unpack_c_tilde::<LAMBDA_over_4>(sig), &c_tilde_p) {
+        if bouncycastle_utils::ct::ct_eq_bytes(
+            unpack_c_tilde::<P>(sig).as_ref(),
+            c_tilde_p.as_ref(),
+        ) {
             Ok(())
         } else {
             Err(SignatureError::SignatureVerificationFailed)
@@ -1388,40 +1058,14 @@ impl<
 
 /// Trait for all three of the ML-DSA algorithm variants.
 pub trait MLDSATrait<
+    P: MLDSAParams,
+    PK: MLDSAPublicKeyTrait<P, PK_LEN> + MLDSAPublicKeyInternalTrait<P, PK_LEN>,
+    SK: MLDSAPrivateKeyTrait<P, PK_LEN, SK_LEN, FULL_SK_LEN>
+        + MLDSAPrivateKeyInternalTrait<P, PK_LEN, SK_LEN>,
     const PK_LEN: usize,
     const SK_LEN: usize,
     const FULL_SK_LEN: usize,
     const SIG_LEN: usize,
-    PK: MLDSAPublicKeyTrait<k, T1_PACKED_LEN, PK_LEN>
-        + MLDSAPublicKeyInternalTrait<k, T1_PACKED_LEN, PK_LEN>,
-    SK: MLDSAPrivateKeyTrait<
-            k,
-            l,
-            S1_PACKED_LEN,
-            S2_PACKED_LEN,
-            T1_PACKED_LEN,
-            PK_LEN,
-            SK_LEN,
-            FULL_SK_LEN,
-        > + MLDSAPrivateKeyInternalTrait<
-            LAMBDA,
-            GAMMA2,
-            k,
-            l,
-            ETA,
-            S1_PACKED_LEN,
-            S2_PACKED_LEN,
-            PK_LEN,
-            SK_LEN,
-        >,
-    const LAMBDA: i32,
-    const GAMMA2: i32,
-    const k: usize,
-    const l: usize,
-    const S1_PACKED_LEN: usize,
-    const S2_PACKED_LEN: usize,
-    const T1_PACKED_LEN: usize,
-    const ETA: usize,
 >: Sized
 {
     /// Runs a key generation using the library's default RNG, seeded from the OS.
@@ -1436,7 +1080,7 @@ pub trait MLDSATrait<
     // Should still be ok in FIPS mode, provided that you're using the FIPS-approved RNG.
     fn keygen_from_rng(rng: &mut dyn RNG) -> Result<(PK, SK), SignatureError> {
         // Source the seed from the provided RNG
-        if rng.security_strength() < SecurityStrength::from_bits(LAMBDA as usize) {
+        if rng.security_strength() < SecurityStrength::from_bits(P::LAMBDA as usize) {
             return Err(RNGError::SecurityStrengthInsufficientForAlgorithm)?;
         }
         let mut seed = KeyMaterial::<32>::new();
@@ -1615,79 +1259,15 @@ pub trait MLDSATrait<
 }
 
 impl<
+    P: MLDSAParams,
+    PK: MLDSAPublicKeyTrait<P, PK_LEN> + MLDSAPublicKeyInternalTrait<P, PK_LEN>,
+    SK: MLDSAPrivateKeyTrait<P, PK_LEN, SK_LEN, FULL_SK_LEN>
+        + MLDSAPrivateKeyInternalTrait<P, PK_LEN, SK_LEN>,
     const PK_LEN: usize,
     const SK_LEN: usize,
     const FULL_SK_LEN: usize,
     const SIG_LEN: usize,
-    PK: MLDSAPublicKeyTrait<k, T1_PACKED_LEN, PK_LEN>
-        + MLDSAPublicKeyInternalTrait<k, T1_PACKED_LEN, PK_LEN>,
-    SK: MLDSAPrivateKeyTrait<
-            k,
-            l,
-            S1_PACKED_LEN,
-            S2_PACKED_LEN,
-            T1_PACKED_LEN,
-            PK_LEN,
-            SK_LEN,
-            FULL_SK_LEN,
-        > + MLDSAPrivateKeyInternalTrait<
-            LAMBDA,
-            GAMMA2,
-            k,
-            l,
-            ETA,
-            S1_PACKED_LEN,
-            S2_PACKED_LEN,
-            PK_LEN,
-            SK_LEN,
-        >,
-    const TAU: i32,
-    const LAMBDA: i32,
-    const GAMMA1: i32,
-    const GAMMA2: i32,
-    const k: usize,
-    const l: usize,
-    const ETA: usize,
-    const BETA: i32,
-    const OMEGA: i32,
-    const C_TILDE: usize,
-    const POLY_Z_PACKED_LEN: usize,
-    const POLY_W1_PACKED_LEN: usize,
-    const S1_PACKED_LEN: usize,
-    const S2_PACKED_LEN: usize,
-    const T1_PACKED_LEN: usize,
-    const LAMBDA_over_4: usize,
-    const GAMMA1_MINUS_BETA: i32,
-    const GAMMA2_MINUS_BETA: i32,
-    const GAMMA1_MASK_LEN: usize,
-> Signer<SK, SK_LEN, SIG_LEN>
-    for MLDSA<
-        PK_LEN,
-        SK_LEN,
-        FULL_SK_LEN,
-        SIG_LEN,
-        PK,
-        SK,
-        TAU,
-        LAMBDA,
-        GAMMA1,
-        GAMMA2,
-        k,
-        l,
-        ETA,
-        BETA,
-        OMEGA,
-        C_TILDE,
-        POLY_Z_PACKED_LEN,
-        POLY_W1_PACKED_LEN,
-        S1_PACKED_LEN,
-        S2_PACKED_LEN,
-        T1_PACKED_LEN,
-        LAMBDA_over_4,
-        GAMMA1_MINUS_BETA,
-        GAMMA2_MINUS_BETA,
-        GAMMA1_MASK_LEN,
-    >
+> Signer<SK, SK_LEN, SIG_LEN> for MLDSA<P, PK, SK, PK_LEN, SK_LEN, FULL_SK_LEN, SIG_LEN>
 {
     fn sign(sk: &SK, msg: &[u8], ctx: Option<&[u8]>) -> Result<[u8; SIG_LEN], SignatureError> {
         let mut out = [0u8; SIG_LEN];
@@ -1769,79 +1349,16 @@ impl<
 }
 
 impl<
+    P: MLDSAParams,
+    PK: MLDSAPublicKeyTrait<P, PK_LEN> + MLDSAPublicKeyInternalTrait<P, PK_LEN>,
+    SK: MLDSAPrivateKeyTrait<P, PK_LEN, SK_LEN, FULL_SK_LEN>
+        + MLDSAPrivateKeyInternalTrait<P, PK_LEN, SK_LEN>,
     const PK_LEN: usize,
     const SK_LEN: usize,
     const FULL_SK_LEN: usize,
     const SIG_LEN: usize,
-    PK: MLDSAPublicKeyTrait<k, T1_PACKED_LEN, PK_LEN>
-        + MLDSAPublicKeyInternalTrait<k, T1_PACKED_LEN, PK_LEN>,
-    SK: MLDSAPrivateKeyTrait<
-            k,
-            l,
-            S1_PACKED_LEN,
-            S2_PACKED_LEN,
-            T1_PACKED_LEN,
-            PK_LEN,
-            SK_LEN,
-            FULL_SK_LEN,
-        > + MLDSAPrivateKeyInternalTrait<
-            LAMBDA,
-            GAMMA2,
-            k,
-            l,
-            ETA,
-            S1_PACKED_LEN,
-            S2_PACKED_LEN,
-            PK_LEN,
-            SK_LEN,
-        >,
-    const TAU: i32,
-    const LAMBDA: i32,
-    const GAMMA1: i32,
-    const GAMMA2: i32,
-    const k: usize,
-    const l: usize,
-    const ETA: usize,
-    const BETA: i32,
-    const OMEGA: i32,
-    const C_TILDE: usize,
-    const POLY_Z_PACKED_LEN: usize,
-    const POLY_W1_PACKED_LEN: usize,
-    const S1_PACKED_LEN: usize,
-    const S2_PACKED_LEN: usize,
-    const T1_PACKED_LEN: usize,
-    const LAMBDA_over_4: usize,
-    const GAMMA1_MINUS_BETA: i32,
-    const GAMMA2_MINUS_BETA: i32,
-    const GAMMA1_MASK_LEN: usize,
 > SignatureVerifier<PK, PK_LEN, SIG_LEN>
-    for MLDSA<
-        PK_LEN,
-        SK_LEN,
-        FULL_SK_LEN,
-        SIG_LEN,
-        PK,
-        SK,
-        TAU,
-        LAMBDA,
-        GAMMA1,
-        GAMMA2,
-        k,
-        l,
-        ETA,
-        BETA,
-        OMEGA,
-        C_TILDE,
-        POLY_Z_PACKED_LEN,
-        POLY_W1_PACKED_LEN,
-        S1_PACKED_LEN,
-        S2_PACKED_LEN,
-        T1_PACKED_LEN,
-        LAMBDA_over_4,
-        GAMMA1_MINUS_BETA,
-        GAMMA2_MINUS_BETA,
-        GAMMA1_MASK_LEN,
-    >
+    for MLDSA<P, PK, SK, PK_LEN, SK_LEN, FULL_SK_LEN, SIG_LEN>
 {
     fn verify(pk: &PK, msg: &[u8], ctx: Option<&[u8]>, sig: &[u8]) -> Result<(), SignatureError> {
         let mu = MuBuilder::compute_mu(&pk.compute_tr(), msg, ctx)?;

--- a/crypto/mldsa-lowmemory/src/mldsa_keys.rs
+++ b/crypto/mldsa-lowmemory/src/mldsa_keys.rs
@@ -399,8 +399,6 @@ impl<P: MLDSAParams, const PK_LEN: usize, const SK_LEN: usize, const FULL_SK_LEN
 {
     /// Encodes the private key seed.
     fn encode(&self) -> [u8; SK_LEN] {
-        debug_assert_eq!(SK_LEN, /* seed */ 32);
-
         self.seed.ref_to_bytes().try_into().unwrap()
     }
 

--- a/crypto/mldsa-lowmemory/src/mldsa_keys.rs
+++ b/crypto/mldsa-lowmemory/src/mldsa_keys.rs
@@ -3,28 +3,16 @@ use crate::aux_functions::{
     simple_bit_unpack_t1,
 };
 use crate::low_memory_helpers::{expandA_elem, s_unpack};
-use crate::mldsa::{H, N, POLY_T0PACKED_LEN};
-use crate::mldsa::{
-    MLDSA44_ETA, MLDSA44_FULL_SK_LEN, MLDSA44_GAMMA2, MLDSA44_LAMBDA, MLDSA44_PK_LEN,
-    MLDSA44_S1_PACKED_LEN, MLDSA44_S2_PACKED_LEN, MLDSA44_SK_LEN, MLDSA44_k, MLDSA44_l,
-};
-use crate::mldsa::{
-    MLDSA44_T1_PACKED_LEN, MLDSA65_T1_PACKED_LEN, MLDSA87_T1_PACKED_LEN, POLY_T1PACKED_LEN,
-};
-use crate::mldsa::{
-    MLDSA65_ETA, MLDSA65_FULL_SK_LEN, MLDSA65_GAMMA2, MLDSA65_LAMBDA, MLDSA65_PK_LEN,
-    MLDSA65_S1_PACKED_LEN, MLDSA65_S2_PACKED_LEN, MLDSA65_SK_LEN, MLDSA65_k, MLDSA65_l,
-};
-use crate::mldsa::{
-    MLDSA87_ETA, MLDSA87_FULL_SK_LEN, MLDSA87_GAMMA2, MLDSA87_LAMBDA, MLDSA87_PK_LEN,
-    MLDSA87_S1_PACKED_LEN, MLDSA87_S2_PACKED_LEN, MLDSA87_SK_LEN, MLDSA87_k, MLDSA87_l,
-};
-use crate::{ML_DSA_44_NAME, ML_DSA_65_NAME, ML_DSA_87_NAME};
+use crate::mldsa::{H, N, POLY_T0PACKED_LEN, POLY_T1PACKED_LEN};
+use crate::mldsa::{MLDSA44_FULL_SK_LEN, MLDSA44_PK_LEN, MLDSA44_SK_LEN};
+use crate::mldsa::{MLDSA65_FULL_SK_LEN, MLDSA65_PK_LEN, MLDSA65_SK_LEN};
+use crate::mldsa::{MLDSA87_FULL_SK_LEN, MLDSA87_PK_LEN, MLDSA87_SK_LEN};
+use crate::params::{MLDSA44Params, MLDSA65Params, MLDSA87Params, MLDSAParams};
 use bouncycastle_core::errors::SignatureError;
 use bouncycastle_core::key_material;
 use bouncycastle_core::key_material::{KeyMaterial, KeyMaterialTrait, KeyType};
 use bouncycastle_core::traits::{SecurityStrength, SignaturePrivateKey, SignaturePublicKey, XOF};
-use bouncycastle_utils::secret::Secret;
+use bouncycastle_utils::secret::{Secret, ZeroizablePrimitive};
 use core::fmt;
 use core::fmt::{Debug, Display, Formatter};
 use core::ops::DerefMut;
@@ -36,63 +24,37 @@ use crate::polynomial::Polynomial;
 /* Pub Types */
 
 /// ML-DSA-44 Public Key
-pub type MLDSA44PublicKey = MLDSAPublicKey<MLDSA44_k, MLDSA44_T1_PACKED_LEN, MLDSA44_PK_LEN>;
+pub type MLDSA44PublicKey = MLDSAPublicKey<MLDSA44Params, MLDSA44_PK_LEN>;
 /// ML-DSA-44 Private Key
-pub type MLDSA44PrivateKey = MLDSASeedPrivateKey<
-    MLDSA44_LAMBDA,
-    MLDSA44_GAMMA2,
-    MLDSA44_k,
-    MLDSA44_l,
-    MLDSA44_ETA,
-    MLDSA44_S1_PACKED_LEN,
-    MLDSA44_S2_PACKED_LEN,
-    MLDSA44_T1_PACKED_LEN,
-    MLDSA44_PK_LEN,
-    MLDSA44_SK_LEN,
-    MLDSA44_FULL_SK_LEN,
->;
+pub type MLDSA44PrivateKey =
+    MLDSASeedPrivateKey<MLDSA44Params, MLDSA44_PK_LEN, MLDSA44_SK_LEN, MLDSA44_FULL_SK_LEN>;
 /// ML-DSA-65 Public Key
-pub type MLDSA65PublicKey = MLDSAPublicKey<MLDSA65_k, MLDSA65_T1_PACKED_LEN, MLDSA65_PK_LEN>;
+pub type MLDSA65PublicKey = MLDSAPublicKey<MLDSA65Params, MLDSA65_PK_LEN>;
 /// ML-DSA-65 Private Key
-pub type MLDSA65PrivateKey = MLDSASeedPrivateKey<
-    MLDSA65_LAMBDA,
-    MLDSA65_GAMMA2,
-    MLDSA65_k,
-    MLDSA65_l,
-    MLDSA65_ETA,
-    MLDSA65_S1_PACKED_LEN,
-    MLDSA65_S2_PACKED_LEN,
-    MLDSA65_T1_PACKED_LEN,
-    MLDSA65_PK_LEN,
-    MLDSA65_SK_LEN,
-    MLDSA65_FULL_SK_LEN,
->;
+pub type MLDSA65PrivateKey =
+    MLDSASeedPrivateKey<MLDSA65Params, MLDSA65_PK_LEN, MLDSA65_SK_LEN, MLDSA65_FULL_SK_LEN>;
 /// ML-DSA-87 Public Key
-pub type MLDSA87PublicKey = MLDSAPublicKey<MLDSA87_k, MLDSA87_T1_PACKED_LEN, MLDSA87_PK_LEN>;
+pub type MLDSA87PublicKey = MLDSAPublicKey<MLDSA87Params, MLDSA87_PK_LEN>;
 /// ML-DSA-87 Private Key
-pub type MLDSA87PrivateKey = MLDSASeedPrivateKey<
-    MLDSA87_LAMBDA,
-    MLDSA87_GAMMA2,
-    MLDSA87_k,
-    MLDSA87_l,
-    MLDSA87_ETA,
-    MLDSA87_S1_PACKED_LEN,
-    MLDSA87_S2_PACKED_LEN,
-    MLDSA87_T1_PACKED_LEN,
-    MLDSA87_PK_LEN,
-    MLDSA87_SK_LEN,
-    MLDSA87_FULL_SK_LEN,
->;
+pub type MLDSA87PrivateKey =
+    MLDSASeedPrivateKey<MLDSA87Params, MLDSA87_PK_LEN, MLDSA87_SK_LEN, MLDSA87_FULL_SK_LEN>;
 
 /// An ML-DSA public key.
-#[derive(Clone)]
-pub struct MLDSAPublicKey<const k: usize, const T1_PACKED_LEN: usize, const PK_LEN: usize> {
+pub struct MLDSAPublicKey<P: MLDSAParams, const PK_LEN: usize> {
     pub(crate) rho: [u8; 32],
-    pub(crate) t1_packed: [u8; T1_PACKED_LEN],
+    pub(crate) t1_packed: P::T1Packed,
+}
+
+// Written out rather than derived: `#[derive(Clone)]` would demand `P: Clone`, and `P` is a
+// marker for the parameter set that is never stored, only used to name the field types.
+impl<P: MLDSAParams, const PK_LEN: usize> Clone for MLDSAPublicKey<P, PK_LEN> {
+    fn clone(&self) -> Self {
+        Self { rho: self.rho, t1_packed: self.t1_packed }
+    }
 }
 
 /// General trait for all ML-DSA public keys types.
-pub trait MLDSAPublicKeyTrait<const k: usize, const T1_PACKED_LEN: usize, const PK_LEN: usize>:
+pub trait MLDSAPublicKeyTrait<P: MLDSAParams, const PK_LEN: usize>:
     SignaturePublicKey<PK_LEN>
 {
     /// Algorithm 23 pkDecode(𝑝𝑘)
@@ -110,15 +72,10 @@ pub trait MLDSAPublicKeyTrait<const k: usize, const T1_PACKED_LEN: usize, const 
     fn compute_tr(&self) -> [u8; 64];
 }
 
-pub(crate) trait MLDSAPublicKeyInternalTrait<
-    const k: usize,
-    const T1_PACKED_LEN: usize,
-    const PK_LEN: usize,
->
-{
+pub(crate) trait MLDSAPublicKeyInternalTrait<P: MLDSAParams, const PK_LEN: usize> {
     /// Not exposing a constructor publicly because the user should get an instance either by
     /// running a keygen, or by decoding an existing key.
-    fn new(rho: [u8; 32], t1_packed: [u8; T1_PACKED_LEN]) -> Self;
+    fn new(rho: [u8; 32], t1_packed: P::T1Packed) -> Self;
 
     /// Get a ref to rho
     fn rho(&self) -> &[u8; 32];
@@ -127,11 +84,13 @@ pub(crate) trait MLDSAPublicKeyInternalTrait<
     fn unpack_t1_row(&self, row: usize) -> Polynomial;
 }
 
-impl<const k: usize, const T1_PACKED_LEN: usize, const PK_LEN: usize>
-    MLDSAPublicKeyTrait<k, T1_PACKED_LEN, PK_LEN> for MLDSAPublicKey<k, T1_PACKED_LEN, PK_LEN>
+impl<P: MLDSAParams, const PK_LEN: usize> MLDSAPublicKeyTrait<P, PK_LEN>
+    for MLDSAPublicKey<P, PK_LEN>
 {
     fn pk_decode(pk: &[u8; PK_LEN]) -> Self {
-        Self { rho: pk[..32].try_into().unwrap(), t1_packed: pk[32..].try_into().unwrap() }
+        let mut t1_packed = <P::T1Packed as ZeroizablePrimitive>::ZEROED;
+        t1_packed.as_mut().copy_from_slice(&pk[32..]);
+        Self { rho: pk[..32].try_into().unwrap(), t1_packed }
     }
 
     fn compute_tr(&self) -> [u8; 64] {
@@ -142,11 +101,10 @@ impl<const k: usize, const T1_PACKED_LEN: usize, const PK_LEN: usize>
     }
 }
 
-impl<const k: usize, const T1_PACKED_LEN: usize, const PK_LEN: usize>
-    MLDSAPublicKeyInternalTrait<k, T1_PACKED_LEN, PK_LEN>
-    for MLDSAPublicKey<k, T1_PACKED_LEN, PK_LEN>
+impl<P: MLDSAParams, const PK_LEN: usize> MLDSAPublicKeyInternalTrait<P, PK_LEN>
+    for MLDSAPublicKey<P, PK_LEN>
 {
-    fn new(rho: [u8; 32], t1_packed: [u8; T1_PACKED_LEN]) -> Self {
+    fn new(rho: [u8; 32], t1_packed: P::T1Packed) -> Self {
         Self { rho, t1_packed }
     }
 
@@ -156,16 +114,14 @@ impl<const k: usize, const T1_PACKED_LEN: usize, const PK_LEN: usize>
 
     fn unpack_t1_row(&self, row: usize) -> Polynomial {
         simple_bit_unpack_t1(
-            &self.t1_packed[row * POLY_T1PACKED_LEN..(row + 1) * POLY_T1PACKED_LEN]
+            self.t1_packed.as_ref()[row * POLY_T1PACKED_LEN..(row + 1) * POLY_T1PACKED_LEN]
                 .try_into()
-                .unwrap(),
+                .expect("a T1Packed row is exactly POLY_T1PACKED_LEN bytes"),
         )
     }
 }
 
-impl<const k: usize, const T1_PACKED_LEN: usize, const PK_LEN: usize> SignaturePublicKey<PK_LEN>
-    for MLDSAPublicKey<k, T1_PACKED_LEN, PK_LEN>
-{
+impl<P: MLDSAParams, const PK_LEN: usize> SignaturePublicKey<PK_LEN> for MLDSAPublicKey<P, PK_LEN> {
     /// Algorithm 22 pkEncode(𝜌, 𝐭1)
     /// Encodes a public key for ML-DSA into a byte string.
     /// Input:𝜌 ∈ 𝔹32, 𝐭1 ∈ 𝑅𝑘 with coefficients in [0, 2bitlen (𝑞−1)−𝑑 − 1].
@@ -186,7 +142,7 @@ impl<const k: usize, const T1_PACKED_LEN: usize, const PK_LEN: usize> SignatureP
         out.fill(0);
 
         out[..32].copy_from_slice(&self.rho);
-        out[32..].copy_from_slice(&self.t1_packed);
+        out[32..].copy_from_slice(self.t1_packed.as_ref());
 
         PK_LEN
     }
@@ -202,14 +158,9 @@ impl<const k: usize, const T1_PACKED_LEN: usize, const PK_LEN: usize> SignatureP
     }
 }
 
-impl<const k: usize, const T1_PACKED_LEN: usize, const PK_LEN: usize> Eq
-    for MLDSAPublicKey<k, T1_PACKED_LEN, PK_LEN>
-{
-}
+impl<P: MLDSAParams, const PK_LEN: usize> Eq for MLDSAPublicKey<P, PK_LEN> {}
 
-impl<const k: usize, const T1_PACKED_LEN: usize, const PK_LEN: usize> PartialEq
-    for MLDSAPublicKey<k, T1_PACKED_LEN, PK_LEN>
-{
+impl<P: MLDSAParams, const PK_LEN: usize> PartialEq for MLDSAPublicKey<P, PK_LEN> {
     fn eq(&self, other: &Self) -> bool {
         let self_encoded = self.encode();
         let other_encoded = other.encode();
@@ -217,41 +168,31 @@ impl<const k: usize, const T1_PACKED_LEN: usize, const PK_LEN: usize> PartialEq
     }
 }
 
-impl<const k: usize, const T1_PACKED_LEN: usize, const PK_LEN: usize> fmt::Debug
-    for MLDSAPublicKey<k, T1_PACKED_LEN, PK_LEN>
-{
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let alg = match k {
-            4 => ML_DSA_44_NAME,
-            6 => ML_DSA_65_NAME,
-            8 => ML_DSA_87_NAME,
-            _ => panic!("Unsupported key length"),
-        };
-        write!(f, "MLDSAPublicKey {{ alg: {}, pub_key_hash (tr): {:x?} }}", alg, self.compute_tr(),)
+impl<P: MLDSAParams, const PK_LEN: usize> fmt::Debug for MLDSAPublicKey<P, PK_LEN> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "MLDSAPublicKey {{ alg: {}, pub_key_hash (tr): {:x?} }}",
+            P::ALG_NAME,
+            self.compute_tr(),
+        )
     }
 }
 
-impl<const k: usize, const T1_PACKED_LEN: usize, const PK_LEN: usize> Display
-    for MLDSAPublicKey<k, T1_PACKED_LEN, PK_LEN>
-{
+impl<P: MLDSAParams, const PK_LEN: usize> Display for MLDSAPublicKey<P, PK_LEN> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        let alg = match k {
-            4 => ML_DSA_44_NAME,
-            6 => ML_DSA_65_NAME,
-            8 => ML_DSA_87_NAME,
-            _ => panic!("Unsupported key length"),
-        };
-        write!(f, "MLDSAPublicKey {{ alg: {}, pub_key_hash (tr): {:x?} }}", alg, self.compute_tr(),)
+        write!(
+            f,
+            "MLDSAPublicKey {{ alg: {}, pub_key_hash (tr): {:x?} }}",
+            P::ALG_NAME,
+            self.compute_tr(),
+        )
     }
 }
 
 /// General trait for all ML-DSA private keys types.
 pub trait MLDSAPrivateKeyTrait<
-    const k: usize,
-    const l: usize,
-    const S1_PACKED_LEN: usize,
-    const S2_PACKED_LEN: usize,
-    const T1_PACKED_LEN: usize,
+    P: MLDSAParams,
     const PK_LEN: usize,
     const SK_LEN: usize,
     const FULL_SK_LEN: usize,
@@ -269,7 +210,7 @@ pub trait MLDSAPrivateKeyTrait<
     /// or else compute `tr` once and store it.
     fn tr(&self) -> [u8; 64];
     /// Returns the full public key, and has the side-effect of setting the public key hash tr in this MLDSASeedSK object.
-    fn derive_pk(&self) -> MLDSAPublicKey<k, T1_PACKED_LEN, PK_LEN>;
+    fn derive_pk(&self) -> MLDSAPublicKey<P, PK_LEN>;
     /// This produces the full private key in the encoding specified in FIPS 204 Algorithm 24 skEncode()
     /// so that it is compatible with other implementations.
     ///
@@ -294,20 +235,13 @@ pub trait MLDSAPrivateKeyTrait<
 }
 
 /// Internal structure for holding a seed-based private key for ML-DSA.
-#[derive(Clone, PartialEq, Eq)]
 pub struct MLDSASeedPrivateKey<
-    const LAMBDA: i32,
-    const GAMMA2: i32,
-    const k: usize,
-    const l: usize,
-    const eta: usize,
-    const S1_PACKED_LEN: usize,
-    const S2_PACKED_LEN: usize,
-    const T1_PACKED_LEN: usize,
+    P: MLDSAParams,
     const PK_LEN: usize,
     const SK_LEN: usize,
     const FULL_SK_LEN: usize,
 > {
+    _phantom: core::marker::PhantomData<P>,
     // note: KeyMaterial is inherently Secret
     seed: KeyMaterial<32>,
     // public seed rho does not need to be secret
@@ -315,108 +249,58 @@ pub struct MLDSASeedPrivateKey<
     rho_prime: Secret<[u8; 64]>,
     K: Secret<[u8; 32]>,
 }
-impl<
-    const LAMBDA: i32,
-    const GAMMA2: i32,
-    const k: usize,
-    const l: usize,
-    const eta: usize,
-    const S1_PACKED_LEN: usize,
-    const S2_PACKED_LEN: usize,
-    const T1_PACKED_LEN: usize,
-    const PK_LEN: usize,
-    const SK_LEN: usize,
-    const FULL_SK_LEN: usize,
-> Debug
-    for MLDSASeedPrivateKey<
-        LAMBDA,
-        GAMMA2,
-        k,
-        l,
-        eta,
-        S1_PACKED_LEN,
-        S2_PACKED_LEN,
-        T1_PACKED_LEN,
-        PK_LEN,
-        SK_LEN,
-        FULL_SK_LEN,
-    >
+// Written out rather than derived: the derives would demand `P: Clone` / `P: Eq`, and `P` is a
+// marker for the parameter set that is never stored, only used to name the field types.
+impl<P: MLDSAParams, const PK_LEN: usize, const SK_LEN: usize, const FULL_SK_LEN: usize> Clone
+    for MLDSASeedPrivateKey<P, PK_LEN, SK_LEN, FULL_SK_LEN>
+{
+    fn clone(&self) -> Self {
+        Self {
+            _phantom: core::marker::PhantomData,
+            seed: self.seed.clone(),
+            rho: self.rho,
+            rho_prime: self.rho_prime.clone(),
+            K: self.K.clone(),
+        }
+    }
+}
+
+impl<P: MLDSAParams, const PK_LEN: usize, const SK_LEN: usize, const FULL_SK_LEN: usize> PartialEq
+    for MLDSASeedPrivateKey<P, PK_LEN, SK_LEN, FULL_SK_LEN>
+{
+    fn eq(&self, other: &Self) -> bool {
+        self.seed == other.seed
+            && self.rho == other.rho
+            && *self.rho_prime == *other.rho_prime
+            && *self.K == *other.K
+    }
+}
+
+impl<P: MLDSAParams, const PK_LEN: usize, const SK_LEN: usize, const FULL_SK_LEN: usize> Eq
+    for MLDSASeedPrivateKey<P, PK_LEN, SK_LEN, FULL_SK_LEN>
+{
+}
+
+impl<P: MLDSAParams, const PK_LEN: usize, const SK_LEN: usize, const FULL_SK_LEN: usize> Debug
+    for MLDSASeedPrivateKey<P, PK_LEN, SK_LEN, FULL_SK_LEN>
 {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        let alg = match k {
-            4 => ML_DSA_44_NAME,
-            6 => ML_DSA_65_NAME,
-            8 => ML_DSA_87_NAME,
-            _ => panic!("Unsupported key length"),
-        };
+        let alg = P::ALG_NAME;
         write!(f, "MLDSASeedPrivateKey {{ alg: {}, pub_key_hash (tr): {:x?} }}", alg, self.tr(),)
     }
 }
 
-impl<
-    const LAMBDA: i32,
-    const GAMMA2: i32,
-    const k: usize,
-    const l: usize,
-    const eta: usize,
-    const S1_PACKED_LEN: usize,
-    const S2_PACKED_LEN: usize,
-    const T1_PACKED_LEN: usize,
-    const PK_LEN: usize,
-    const SK_LEN: usize,
-    const FULL_SK_LEN: usize,
-> Display
-    for MLDSASeedPrivateKey<
-        LAMBDA,
-        GAMMA2,
-        k,
-        l,
-        eta,
-        S1_PACKED_LEN,
-        S2_PACKED_LEN,
-        T1_PACKED_LEN,
-        PK_LEN,
-        SK_LEN,
-        FULL_SK_LEN,
-    >
+impl<P: MLDSAParams, const PK_LEN: usize, const SK_LEN: usize, const FULL_SK_LEN: usize> Display
+    for MLDSASeedPrivateKey<P, PK_LEN, SK_LEN, FULL_SK_LEN>
 {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        let alg = match k {
-            4 => ML_DSA_44_NAME,
-            6 => ML_DSA_65_NAME,
-            8 => ML_DSA_87_NAME,
-            _ => panic!("Unsupported key length"),
-        };
+        let alg = P::ALG_NAME;
         write!(f, "MLDSASeedPrivateKey {{ alg: {}, pub_key_hash (tr): {:x?} }}", alg, self.tr(),)
     }
 }
 
-impl<
-    const LAMBDA: i32,
-    const GAMMA2: i32,
-    const k: usize,
-    const l: usize,
-    const eta: usize,
-    const S1_PACKED_LEN: usize,
-    const S2_PACKED_LEN: usize,
-    const T1_PACKED_LEN: usize,
-    const PK_LEN: usize,
-    const SK_LEN: usize,
-    const FULL_SK_LEN: usize,
->
-    MLDSASeedPrivateKey<
-        LAMBDA,
-        GAMMA2,
-        k,
-        l,
-        eta,
-        S1_PACKED_LEN,
-        S2_PACKED_LEN,
-        T1_PACKED_LEN,
-        PK_LEN,
-        SK_LEN,
-        FULL_SK_LEN,
-    >
+impl<P: MLDSAParams, const PK_LEN: usize, const SK_LEN: usize, const FULL_SK_LEN: usize>
+    MLDSASeedPrivateKey<P, PK_LEN, SK_LEN, FULL_SK_LEN>
 {
     /// Create a new MLDSASeedPrivateKey from a 32-byte KeyMaterial.
     /// Seed SecurityStrength must match algorithm security strength: 128-bit (ML-DSA-44), 192-bit (ML-DSA-65), or 256-bit (ML-DSA-87),
@@ -430,13 +314,13 @@ impl<
             ));
         }
 
-        if seed.security_strength() < SecurityStrength::from_bits(LAMBDA as usize) {
+        if seed.security_strength() < SecurityStrength::from_bits(P::LAMBDA as usize) {
             return Err(SignatureError::KeyGenError("SecurityStrength"));
         }
 
         let (rho, rho_prime, K) = Self::compute_rhos_and_K(&seed);
 
-        Ok(Self { seed: seed.clone(), rho, rho_prime, K })
+        Ok(Self { _phantom: core::marker::PhantomData, seed: seed.clone(), rho, rho_prime, K })
     }
 
     fn compute_rhos_and_K(
@@ -451,8 +335,8 @@ impl<
 
         let mut h = H::default();
         h.absorb(seed.ref_to_bytes()).expect("absorb before squeeze is infallible");
-        h.absorb(&(k as u8).to_le_bytes()).expect("absorb before squeeze is infallible");
-        h.absorb(&(l as u8).to_le_bytes()).expect("absorb before squeeze is infallible");
+        h.absorb(&(P::k as u8).to_le_bytes()).expect("absorb before squeeze is infallible");
+        h.absorb(&(P::l as u8).to_le_bytes()).expect("absorb before squeeze is infallible");
         let bytes_written = h.squeeze_out(&mut rho);
         debug_assert_eq!(bytes_written, 32);
         let bytes_written = h.squeeze_out(rho_prime.deref_mut());
@@ -466,26 +350,26 @@ impl<
     fn compute_t_row(
         &self,
         idx: usize,
-        s1_packed: &Secret<[u8; S1_PACKED_LEN]>,
-        s2_packed: &Secret<[u8; S2_PACKED_LEN]>,
+        s1_packed: &Secret<P::S1Packed>,
+        s2_packed: &Secret<P::S2Packed>,
     ) -> Polynomial {
-        debug_assert!(idx < k);
+        debug_assert!(idx < P::k);
 
         // [Optimization Note]:
         // This is one of the places that a row of s1 can be re-computed instead of expanded from the compressed form.
         // let mut s1 = self.compute_s1_row(0);
-        let mut s1_hat_i = s_unpack::<eta, S1_PACKED_LEN>(s1_packed, 0);
+        let mut s1_hat_i = s_unpack::<P, _>(s1_packed, 0);
         s1_hat_i.ntt();
 
         let mut t_i = {
             let mut t_hat_i = expandA_elem(&self.rho, idx, 0);
             t_hat_i.multiply_ntt(&s1_hat_i);
 
-            for col in 1..l {
+            for col in 1..P::l {
                 // [Optimization Note]:
                 // This is one of the places that a row of s1 can be re-computed instead of expanded from the compressed form.
                 // s1 = self.compute_s1_row(col);
-                let mut s1_hat = s_unpack::<eta, S1_PACKED_LEN>(s1_packed, col);
+                let mut s1_hat = s_unpack::<P, _>(s1_packed, col);
                 s1_hat.ntt();
                 let mut A_elem = expandA_elem(&self.rho, idx, col);
                 A_elem.multiply_ntt(&s1_hat);
@@ -499,7 +383,7 @@ impl<
         // [Optimization Note]:
         // This is one of the places that a row of s2 can be re-computed instead of unpacked from the compressed form.
         // let s2 = self.compute_s2_row(idx);
-        let s2 = s_unpack::<eta, S2_PACKED_LEN>(s2_packed, idx);
+        let s2 = s_unpack::<P, _>(s2_packed, idx);
         t_i.add_ntt(&s2);
         t_i.conditional_add_q();
 
@@ -507,32 +391,8 @@ impl<
     }
 }
 
-impl<
-    const LAMBDA: i32,
-    const GAMMA2: i32,
-    const k: usize,
-    const l: usize,
-    const eta: usize,
-    const S1_PACKED_LEN: usize,
-    const S2_PACKED_LEN: usize,
-    const T1_PACKED_LEN: usize,
-    const PK_LEN: usize,
-    const SK_LEN: usize,
-    const FULL_SK_LEN: usize,
-> SignaturePrivateKey<SK_LEN>
-    for MLDSASeedPrivateKey<
-        LAMBDA,
-        GAMMA2,
-        k,
-        l,
-        eta,
-        S1_PACKED_LEN,
-        S2_PACKED_LEN,
-        T1_PACKED_LEN,
-        PK_LEN,
-        SK_LEN,
-        FULL_SK_LEN,
-    >
+impl<P: MLDSAParams, const PK_LEN: usize, const SK_LEN: usize, const FULL_SK_LEN: usize>
+    SignaturePrivateKey<SK_LEN> for MLDSASeedPrivateKey<P, PK_LEN, SK_LEN, FULL_SK_LEN>
 {
     /// Encodes the private key seed.
     fn encode(&self) -> [u8; SK_LEN] {
@@ -564,42 +424,9 @@ impl<
     }
 }
 
-impl<
-    const LAMBDA: i32,
-    const GAMMA2: i32,
-    const k: usize,
-    const l: usize,
-    const eta: usize,
-    const S1_PACKED_LEN: usize,
-    const S2_PACKED_LEN: usize,
-    const T1_PACKED_LEN: usize,
-    const PK_LEN: usize,
-    const SK_LEN: usize,
-    const FULL_SK_LEN: usize,
->
-    MLDSAPrivateKeyTrait<
-        k,
-        l,
-        S1_PACKED_LEN,
-        S2_PACKED_LEN,
-        T1_PACKED_LEN,
-        PK_LEN,
-        SK_LEN,
-        FULL_SK_LEN,
-    >
-    for MLDSASeedPrivateKey<
-        LAMBDA,
-        GAMMA2,
-        k,
-        l,
-        eta,
-        S1_PACKED_LEN,
-        S2_PACKED_LEN,
-        T1_PACKED_LEN,
-        PK_LEN,
-        SK_LEN,
-        FULL_SK_LEN,
-    >
+impl<P: MLDSAParams, const PK_LEN: usize, const SK_LEN: usize, const FULL_SK_LEN: usize>
+    MLDSAPrivateKeyTrait<P, PK_LEN, SK_LEN, FULL_SK_LEN>
+    for MLDSASeedPrivateKey<P, PK_LEN, SK_LEN, FULL_SK_LEN>
 {
     fn from_keymaterial(seed: &KeyMaterial<32>) -> Result<Self, SignatureError> {
         Self::new(seed)
@@ -610,26 +437,26 @@ impl<
     }
 
     fn tr(&self) -> [u8; 64] {
-        let pk: MLDSAPublicKey<k, T1_PACKED_LEN, PK_LEN> = self.derive_pk();
+        let pk: MLDSAPublicKey<P, PK_LEN> = self.derive_pk();
         pk.compute_tr()
     }
 
-    fn derive_pk(&self) -> MLDSAPublicKey<k, T1_PACKED_LEN, PK_LEN> {
+    fn derive_pk(&self) -> MLDSAPublicKey<P, PK_LEN> {
         // The goal here is to get t1, which is built and compressed one row at a time.
 
-        let s1_packed: Secret<[u8; S1_PACKED_LEN]> = self.compute_s1_packed();
-        let s2_packed: Secret<[u8; S2_PACKED_LEN]> = self.compute_s2_packed();
+        let s1_packed: Secret<P::S1Packed> = self.compute_s1_packed();
+        let s2_packed: Secret<P::S2Packed> = self.compute_s2_packed();
 
-        let mut t1_packed = [0u8; T1_PACKED_LEN];
-        debug_assert_eq!(T1_PACKED_LEN, POLY_T1PACKED_LEN * k);
+        let mut t1_packed = <P::T1Packed as ZeroizablePrimitive>::ZEROED;
+        debug_assert_eq!(P::T1_PACKED_LEN, POLY_T1PACKED_LEN * P::k);
 
-        for i in 0..k {
-            t1_packed[i * POLY_T1PACKED_LEN..(i + 1) * POLY_T1PACKED_LEN].copy_from_slice(
+        for i in 0..P::k {
+            t1_packed.as_mut()[i * POLY_T1PACKED_LEN..(i + 1) * POLY_T1PACKED_LEN].copy_from_slice(
                 &simple_bit_pack_t1(&self.compute_t1_row(i, &s1_packed, &s2_packed)),
             );
         }
 
-        MLDSAPublicKey::<k, T1_PACKED_LEN, PK_LEN>::new(self.rho.clone(), t1_packed)
+        MLDSAPublicKey::<P, PK_LEN>::new(self.rho.clone(), t1_packed)
     }
     fn encode_full_sk(&self) -> [u8; FULL_SK_LEN] {
         let mut out = [0; FULL_SK_LEN];
@@ -655,21 +482,21 @@ impl<
         // 3:   𝑠𝑘 ← 𝑠𝑘 || BitPack (𝐬1[𝑖], 𝜂, 𝜂)
         // 4: end for
         let s1_packed = self.compute_s1_packed();
-        out[off..off + S1_PACKED_LEN].copy_from_slice(&*s1_packed);
-        off += S1_PACKED_LEN;
+        out[off..off + P::S1_PACKED_LEN].copy_from_slice((*s1_packed).as_ref());
+        off += P::S1_PACKED_LEN;
 
         // 5: for 𝑖 from 0 to 𝑘 − 1 do
         // 6:   𝑠𝑘 ← 𝑠𝑘 || BitPack (𝐬2[𝑖], 𝜂, 𝜂)
         // 7: end for
         let s2_packed = self.compute_s2_packed();
-        out[off..off + S2_PACKED_LEN].copy_from_slice(&*s2_packed);
-        off += S2_PACKED_LEN;
+        out[off..off + P::S2_PACKED_LEN].copy_from_slice((*s2_packed).as_ref());
+        off += P::S2_PACKED_LEN;
 
         // 8: for 𝑖 from 0 to 𝑘 − 1 do
         // 9:   𝑠𝑘 ← 𝑠𝑘 || BitPack (𝐭0[𝑖], 2𝑑−1 − 1, 2𝑑−1)
         // 10: end for
-        debug_assert_eq!(off + k * POLY_T0PACKED_LEN, FULL_SK_LEN);
-        for row in 0..k {
+        debug_assert_eq!(off + P::k * POLY_T0PACKED_LEN, FULL_SK_LEN);
+        for row in 0..P::k {
             let t0_i = self.compute_t0_row(row, &s1_packed, &s2_packed);
             out[off..off + POLY_T0PACKED_LEN].copy_from_slice(&bit_pack_t0(&t0_i));
             off += POLY_T0PACKED_LEN;
@@ -685,13 +512,7 @@ impl<
 }
 
 pub(crate) trait MLDSAPrivateKeyInternalTrait<
-    const LAMBDA: i32,
-    const GAMMA2: i32,
-    const k: usize,
-    const l: usize,
-    const eta: usize,
-    const S1_PACKED_LEN: usize,
-    const S2_PACKED_LEN: usize,
+    P: MLDSAParams,
     const PK_LEN: usize,
     const SK_LEN: usize,
 >: Sized
@@ -706,7 +527,7 @@ pub(crate) trait MLDSAPrivateKeyInternalTrait<
     /// Private key component.
     /// The packed representation sticks around for the whole computation, so
     /// we'll wrap in as a Secret.
-    fn compute_s1_packed(&self) -> Secret<[u8; S1_PACKED_LEN]>;
+    fn compute_s1_packed(&self) -> Secret<P::S1Packed>;
 
     /// A single entry of a privacy key vector.
     /// These tend to be used very transiently, so we won't bother wrapping it as a Secret.
@@ -715,62 +536,28 @@ pub(crate) trait MLDSAPrivateKeyInternalTrait<
     /// Private key component.
     /// The packed representation sticks around for the whole computation, so
     /// we'll wrap in as a Secret.
-    fn compute_s2_packed(&self) -> Secret<[u8; S2_PACKED_LEN]>;
+    fn compute_s2_packed(&self) -> Secret<P::S2Packed>;
 
     /// Public key component.
     fn compute_t0_row(
         &self,
         idx: usize,
-        s1_packed: &Secret<[u8; S1_PACKED_LEN]>,
-        s2_packed: &Secret<[u8; S2_PACKED_LEN]>,
+        s1_packed: &Secret<P::S1Packed>,
+        s2_packed: &Secret<P::S2Packed>,
     ) -> Polynomial;
 
     /// Public key component.
     fn compute_t1_row(
         &self,
         idx: usize,
-        s1_packed: &Secret<[u8; S1_PACKED_LEN]>,
-        s2_packed: &Secret<[u8; S2_PACKED_LEN]>,
+        s1_packed: &Secret<P::S1Packed>,
+        s2_packed: &Secret<P::S2Packed>,
     ) -> Polynomial;
 }
 
-impl<
-    const LAMBDA: i32,
-    const GAMMA2: i32,
-    const k: usize,
-    const l: usize,
-    const eta: usize,
-    const S1_PACKED_LEN: usize,
-    const S2_PACKED_LEN: usize,
-    const T1_PACKED_LEN: usize,
-    const PK_LEN: usize,
-    const SK_LEN: usize,
-    const FULL_SK_LEN: usize,
->
-    MLDSAPrivateKeyInternalTrait<
-        LAMBDA,
-        GAMMA2,
-        k,
-        l,
-        eta,
-        S1_PACKED_LEN,
-        S2_PACKED_LEN,
-        PK_LEN,
-        SK_LEN,
-    >
-    for MLDSASeedPrivateKey<
-        LAMBDA,
-        GAMMA2,
-        k,
-        l,
-        eta,
-        S1_PACKED_LEN,
-        S2_PACKED_LEN,
-        T1_PACKED_LEN,
-        PK_LEN,
-        SK_LEN,
-        FULL_SK_LEN,
-    >
+impl<P: MLDSAParams, const PK_LEN: usize, const SK_LEN: usize, const FULL_SK_LEN: usize>
+    MLDSAPrivateKeyInternalTrait<P, PK_LEN, SK_LEN>
+    for MLDSASeedPrivateKey<P, PK_LEN, SK_LEN, FULL_SK_LEN>
 {
     fn rho(&self) -> &[u8; 32] {
         &self.rho
@@ -781,34 +568,34 @@ impl<
     }
 
     fn compute_s1_row(&self, idx: usize) -> Polynomial {
-        debug_assert!(idx < l);
-        rej_bounded_poly::<eta>(&self.rho_prime, &(idx as u16).to_le_bytes())
+        debug_assert!(idx < P::l);
+        rej_bounded_poly::<P>(&self.rho_prime, &(idx as u16).to_le_bytes())
     }
 
-    fn compute_s1_packed(&self) -> Secret<[u8; S1_PACKED_LEN]> {
-        let mut s1_packed: Secret<[u8; S1_PACKED_LEN]> = Secret::new();
-        for idx in 0..l {
+    fn compute_s1_packed(&self) -> Secret<P::S1Packed> {
+        let mut s1_packed: Secret<P::S1Packed> = Secret::new();
+        for idx in 0..P::l {
             let s1_i = self.compute_s1_row(idx);
-            bit_pack_eta::<eta>(
+            bit_pack_eta::<P>(
                 &s1_i,
-                &mut s1_packed[idx * bitlen_eta(eta)..(idx + 1) * bitlen_eta(eta)],
+                &mut s1_packed.as_mut()[idx * bitlen_eta(P::ETA)..(idx + 1) * bitlen_eta(P::ETA)],
             );
         }
         s1_packed
     }
 
     fn compute_s2_row(&self, idx: usize) -> Polynomial {
-        debug_assert!(idx < k);
-        rej_bounded_poly::<eta>(&self.rho_prime, &((idx + l) as u16).to_le_bytes())
+        debug_assert!(idx < P::k);
+        rej_bounded_poly::<P>(&self.rho_prime, &((idx + P::l) as u16).to_le_bytes())
     }
 
-    fn compute_s2_packed(&self) -> Secret<[u8; S2_PACKED_LEN]> {
-        let mut s2_packed: Secret<[u8; S2_PACKED_LEN]> = Secret::new();
-        for idx in 0..k {
+    fn compute_s2_packed(&self) -> Secret<P::S2Packed> {
+        let mut s2_packed: Secret<P::S2Packed> = Secret::new();
+        for idx in 0..P::k {
             let s2_i = self.compute_s2_row(idx);
-            bit_pack_eta::<eta>(
+            bit_pack_eta::<P>(
                 &s2_i,
-                &mut s2_packed[idx * bitlen_eta(eta)..(idx + 1) * bitlen_eta(eta)],
+                &mut s2_packed.as_mut()[idx * bitlen_eta(P::ETA)..(idx + 1) * bitlen_eta(P::ETA)],
             );
         }
         s2_packed
@@ -817,8 +604,8 @@ impl<
     fn compute_t0_row(
         &self,
         idx: usize,
-        s1_packed: &Secret<[u8; S1_PACKED_LEN]>,
-        s2_packed: &Secret<[u8; S2_PACKED_LEN]>,
+        s1_packed: &Secret<P::S1Packed>,
+        s2_packed: &Secret<P::S2Packed>,
     ) -> Polynomial {
         let mut t0 = self.compute_t_row(idx, s1_packed, s2_packed);
         for j in 0..N {
@@ -831,8 +618,8 @@ impl<
     fn compute_t1_row(
         &self,
         idx: usize,
-        s1_packed: &Secret<[u8; S1_PACKED_LEN]>,
-        s2_packed: &Secret<[u8; S2_PACKED_LEN]>,
+        s1_packed: &Secret<P::S1Packed>,
+        s2_packed: &Secret<P::S2Packed>,
     ) -> Polynomial {
         let mut t1 = self.compute_t_row(idx, s1_packed, s2_packed);
         for j in 0..N {

--- a/crypto/mldsa-lowmemory/src/mldsa_keys.rs
+++ b/crypto/mldsa-lowmemory/src/mldsa_keys.rs
@@ -269,10 +269,13 @@ impl<P: MLDSAParams, const PK_LEN: usize, const SK_LEN: usize, const FULL_SK_LEN
     for MLDSASeedPrivateKey<P, PK_LEN, SK_LEN, FULL_SK_LEN>
 {
     fn eq(&self, other: &Self) -> bool {
-        self.seed == other.seed
-            && self.rho == other.rho
-            && *self.rho_prime == *other.rho_prime
-            && *self.K == *other.K
+        // Compared through `KeyMaterial`/`Secret`'s own `PartialEq`, which is constant-time: do
+        // not deref to the inner arrays, as that would select the array's variable-time `==`.
+        let seed = self.seed == other.seed;
+        let rho = self.rho == other.rho;
+        let rho_prime = self.rho_prime == other.rho_prime;
+        let K = self.K == other.K;
+        seed & rho & rho_prime & K
     }
 }
 

--- a/crypto/mldsa-lowmemory/src/mldsa_keys.rs
+++ b/crypto/mldsa-lowmemory/src/mldsa_keys.rs
@@ -1,5 +1,5 @@
 use crate::aux_functions::{
-    bit_pack_eta, bit_pack_t0, bitlen_eta, power_2_round, rej_bounded_poly, simple_bit_pack_t1,
+    bit_pack_eta, bit_pack_t0, power_2_round, rej_bounded_poly, simple_bit_pack_t1,
     simple_bit_unpack_t1,
 };
 use crate::low_memory_helpers::{expandA_elem, s_unpack};
@@ -314,7 +314,7 @@ impl<P: MLDSAParams, const PK_LEN: usize, const SK_LEN: usize, const FULL_SK_LEN
             ));
         }
 
-        if seed.security_strength() < SecurityStrength::from_bits(P::LAMBDA as usize) {
+        if seed.security_strength() < P::MAX_SECURITY_STRENGTH {
             return Err(SignatureError::KeyGenError("SecurityStrength"));
         }
 
@@ -574,12 +574,10 @@ impl<P: MLDSAParams, const PK_LEN: usize, const SK_LEN: usize, const FULL_SK_LEN
 
     fn compute_s1_packed(&self) -> Secret<P::S1Packed> {
         let mut s1_packed: Secret<P::S1Packed> = Secret::new();
+        let width = P::POLY_ETA_PACKED_LEN;
         for idx in 0..P::l {
             let s1_i = self.compute_s1_row(idx);
-            bit_pack_eta::<P>(
-                &s1_i,
-                &mut s1_packed.as_mut()[idx * bitlen_eta(P::ETA)..(idx + 1) * bitlen_eta(P::ETA)],
-            );
+            bit_pack_eta::<P>(&s1_i, &mut s1_packed.as_mut()[idx * width..(idx + 1) * width]);
         }
         s1_packed
     }
@@ -591,12 +589,10 @@ impl<P: MLDSAParams, const PK_LEN: usize, const SK_LEN: usize, const FULL_SK_LEN
 
     fn compute_s2_packed(&self) -> Secret<P::S2Packed> {
         let mut s2_packed: Secret<P::S2Packed> = Secret::new();
+        let width = P::POLY_ETA_PACKED_LEN;
         for idx in 0..P::k {
             let s2_i = self.compute_s2_row(idx);
-            bit_pack_eta::<P>(
-                &s2_i,
-                &mut s2_packed.as_mut()[idx * bitlen_eta(P::ETA)..(idx + 1) * bitlen_eta(P::ETA)],
-            );
+            bit_pack_eta::<P>(&s2_i, &mut s2_packed.as_mut()[idx * width..(idx + 1) * width]);
         }
         s2_packed
     }

--- a/crypto/mldsa-lowmemory/src/params.rs
+++ b/crypto/mldsa-lowmemory/src/params.rs
@@ -11,7 +11,6 @@
 //! is written once as a defaulted associated const rather than three times as a hand-computed
 //! number. `params::tests` checks every derivation against the values tabulated in FIPS 204.
 
-use crate::aux_functions::bitlen_eta;
 use crate::hash_mldsa::{
     HASH_ML_DSA_44_with_SHA256_NAME, HASH_ML_DSA_44_with_SHA512_NAME,
     HASH_ML_DSA_65_WITH_SHA256_NAME, HASH_ML_DSA_65_WITH_SHA512_NAME,
@@ -51,21 +50,21 @@ pub trait MLDSAParams: MLDSAParamsInternalTrait {
     /* FIPS 204, Table 1: the values assigned by each parameter set. */
 
     /// 𝜏, the number of ±1's in the polynomial 𝑐.
-    const TAU: i32;
+    const tau: i32;
     /// 𝜆, the collision strength of 𝑐̃, in bits.
-    const LAMBDA: i32;
+    const lambda: i32;
     /// 𝛾1, the coefficient range of 𝐲. Always a power of two.
-    const GAMMA1: i32;
+    const gamma1: i32;
     /// 𝛾2, the low-order rounding range.
-    const GAMMA2: i32;
+    const gamma2: i32;
     /// 𝑘, the number of rows of 𝐀.
     const k: usize;
     /// ℓ, the number of columns of 𝐀.
     const l: usize;
     /// 𝜂, the private key range.
-    const ETA: usize;
+    const eta: usize;
     /// 𝜔, the maximum number of 1's in the hint 𝐡.
-    const OMEGA: i32;
+    const omega: i32;
 
     /* FIPS 204, Table 2: sizes in bytes of keys and signatures. */
 
@@ -79,7 +78,7 @@ pub trait MLDSAParams: MLDSAParamsInternalTrait {
     /// The length of a signature.
     const SIG_LEN: usize;
 
-    /* Identity. */
+    /* Algorithm meta-data */
 
     /// The algorithm name, as reported by `Algorithm::ALG_NAME`.
     const ALG_NAME: &'static str;
@@ -98,37 +97,42 @@ pub trait MLDSAParams: MLDSAParamsInternalTrait {
     const SK_LEN: usize = MLDSA_SEED_LEN;
 
     /// 𝛽, which FIPS 204, Table 1 defines as "𝛽 = 𝜏 ⋅ 𝜂".
-    const BETA: i32 = Self::TAU * Self::ETA as i32;
+    const beta: i32 = Self::tau * Self::eta as i32;
 
     /// The length of the commitment hash 𝑐̃, which FIPS 204, Algorithm 26 (sigEncode) gives as
     /// 𝑐̃ ∈ 𝔹^(𝜆/4).
-    const C_TILDE_LEN: usize = Self::LAMBDA as usize / 4;
+    const C_TILDE_LEN: usize = Self::lambda as usize / 4;
 
     /// The packed length of one coordinate of 𝐳: FIPS 204, Algorithm 26 (sigEncode) writes each of
     /// the ℓ coordinates as 𝔹^(32⋅(1+bitlen (𝛾1−1))).
     ///
     /// This is also the number of bytes ExpandMask squeezes per coordinate: FIPS 204,
     /// Algorithm 34, line 1 sets 𝑐 ← 1 + bitlen (𝛾1 − 1) and line 4 squeezes 32𝑐 bytes.
-    const POLY_Z_PACKED_LEN: usize = 32 * (1 + bitlen(Self::GAMMA1 as u32 - 1));
+    const POLY_Z_PACKED_LEN: usize = 32 * (1 + bitlen(Self::gamma1 as u32 - 1));
 
     /// The packed length of one coordinate of 𝐰1: FIPS 204, Algorithm 28 (w1Encode) outputs
     /// 𝔹^(32𝑘⋅bitlen ((𝑞−1)/(2𝛾2)−1)) for all 𝑘 coordinates together.
-    const POLY_W1_PACKED_LEN: usize = 32 * bitlen(((q - 1) / (2 * Self::GAMMA2)) as u32 - 1);
+    const POLY_W1_PACKED_LEN: usize = 32 * bitlen(((q - 1) / (2 * Self::gamma2)) as u32 - 1);
 
-    /// The packed length of the whole of 𝐬1, i.e. ℓ coordinates each of 32⋅bitlen (2𝜂) bytes.
-    const S1_PACKED_LEN: usize = bitlen_eta(Self::ETA) * Self::l;
+    /// The packed length of one coordinate of 𝐬1 or 𝐬2: FIPS 204, Algorithm 24 (skEncode), line 3
+    /// packs each with BitPack(𝐬1[𝑖], 𝜂, 𝜂), and Algorithm 17 (BitPack) outputs
+    /// 𝔹^(32⋅bitlen (𝑎+𝑏)), so 32⋅bitlen (2𝜂).
+    const POLY_ETA_PACKED_LEN: usize = 32 * bitlen(2 * Self::eta as u32);
 
-    /// The packed length of the whole of 𝐬2, i.e. 𝑘 coordinates each of 32⋅bitlen (2𝜂) bytes.
-    const S2_PACKED_LEN: usize = bitlen_eta(Self::ETA) * Self::k;
+    /// The packed length of the whole of 𝐬1, i.e. all ℓ coordinates.
+    const S1_PACKED_LEN: usize = Self::POLY_ETA_PACKED_LEN * Self::l;
+
+    /// The packed length of the whole of 𝐬2, i.e. all 𝑘 coordinates.
+    const S2_PACKED_LEN: usize = Self::POLY_ETA_PACKED_LEN * Self::k;
 
     /// The packed length of the whole of 𝐭1, i.e. 𝑘 coordinates of SimpleBitPack output.
     const T1_PACKED_LEN: usize = POLY_T1PACKED_LEN * Self::k;
 
     /// 𝛾1 − 𝛽, the rejection bound on ‖𝐳‖∞ (FIPS 204, Algorithm 7, line 23).
-    const GAMMA1_MINUS_BETA: i32 = Self::GAMMA1 - Self::BETA;
+    const gamma1_minus_beta: i32 = Self::gamma1 - Self::beta;
 
     /// 𝛾2 − 𝛽, the rejection bound on ‖𝐫0‖∞ (FIPS 204, Algorithm 7, line 23).
-    const GAMMA2_MINUS_BETA: i32 = Self::GAMMA2 - Self::BETA;
+    const gamma2_minus_beta: i32 = Self::gamma2 - Self::beta;
 
     /* Types whose size depends on the parameter set. */
 
@@ -164,15 +168,15 @@ impl MLDSAParamsInternalTrait for MLDSA65Params {}
 impl MLDSAParamsInternalTrait for MLDSA87Params {}
 
 impl MLDSAParams for MLDSA44Params {
-    const TAU: i32 = 39;
-    const LAMBDA: i32 = 128;
-    const GAMMA1: i32 = 1 << 17;
+    const tau: i32 = 39;
+    const lambda: i32 = 128;
+    const gamma1: i32 = 1 << 17;
     // mutants note: because 𝛾1 is applied by bit-shifting, the "- 1" ends up not mattering.
-    const GAMMA2: i32 = (q - 1) / 88;
+    const gamma2: i32 = (q - 1) / 88;
     const k: usize = 4;
     const l: usize = 4;
-    const ETA: usize = 2;
-    const OMEGA: i32 = 80;
+    const eta: usize = 2;
+    const omega: i32 = 80;
 
     const PK_LEN: usize = 1312;
     const FULL_SK_LEN: usize = 2560;
@@ -188,21 +192,21 @@ impl MLDSAParams for MLDSA44Params {
     type SigCTilde = [u8; 32]; // 𝜆/4 = 128/4
     type PolyZPacked = [u8; 576]; // 32 * (1 + bitlen(2^17 - 1)) = 32 * 18
     type PolyW1Packed = [u8; 192]; // 32 * bitlen(44 - 1) = 32 * 6
-    type S1Packed = [u8; 384]; // bitlen_eta(2) * 4 = 96 * 4
-    type S2Packed = [u8; 384]; // bitlen_eta(2) * 4 = 96 * 4
+    type S1Packed = [u8; 384]; // 96 * 4
+    type S2Packed = [u8; 384]; // 96 * 4
     type T1Packed = [u8; 1280]; // 320 * 4
 }
 
 impl MLDSAParams for MLDSA65Params {
-    const TAU: i32 = 49;
-    const LAMBDA: i32 = 192;
-    const GAMMA1: i32 = 1 << 19;
+    const tau: i32 = 49;
+    const lambda: i32 = 192;
+    const gamma1: i32 = 1 << 19;
     // mutants note: because 𝛾1 is applied by bit-shifting, the "- 1" ends up not mattering.
-    const GAMMA2: i32 = (q - 1) / 32;
+    const gamma2: i32 = (q - 1) / 32;
     const k: usize = 6;
     const l: usize = 5;
-    const ETA: usize = 4;
-    const OMEGA: i32 = 55;
+    const eta: usize = 4;
+    const omega: i32 = 55;
 
     const PK_LEN: usize = 1952;
     const FULL_SK_LEN: usize = 4032;
@@ -218,21 +222,21 @@ impl MLDSAParams for MLDSA65Params {
     type SigCTilde = [u8; 48]; // 𝜆/4 = 192/4
     type PolyZPacked = [u8; 640]; // 32 * (1 + bitlen(2^19 - 1)) = 32 * 20
     type PolyW1Packed = [u8; 128]; // 32 * bitlen(16 - 1) = 32 * 4
-    type S1Packed = [u8; 640]; // bitlen_eta(4) * 5 = 128 * 5
-    type S2Packed = [u8; 768]; // bitlen_eta(4) * 6 = 128 * 6
+    type S1Packed = [u8; 640]; // 128 * 5
+    type S2Packed = [u8; 768]; // 128 * 6
     type T1Packed = [u8; 1920]; // 320 * 6
 }
 
 impl MLDSAParams for MLDSA87Params {
-    const TAU: i32 = 60;
-    const LAMBDA: i32 = 256;
-    const GAMMA1: i32 = 1 << 19;
+    const tau: i32 = 60;
+    const lambda: i32 = 256;
+    const gamma1: i32 = 1 << 19;
     // mutants note: because 𝛾1 is applied by bit-shifting, the "- 1" ends up not mattering.
-    const GAMMA2: i32 = (q - 1) / 32;
+    const gamma2: i32 = (q - 1) / 32;
     const k: usize = 8;
     const l: usize = 7;
-    const ETA: usize = 2;
-    const OMEGA: i32 = 75;
+    const eta: usize = 2;
+    const omega: i32 = 75;
 
     const PK_LEN: usize = 2592;
     const FULL_SK_LEN: usize = 4896;
@@ -248,8 +252,8 @@ impl MLDSAParams for MLDSA87Params {
     type SigCTilde = [u8; 64]; // 𝜆/4 = 256/4
     type PolyZPacked = [u8; 640]; // 32 * (1 + bitlen(2^19 - 1)) = 32 * 20
     type PolyW1Packed = [u8; 128]; // 32 * bitlen(16 - 1) = 32 * 4
-    type S1Packed = [u8; 672]; // bitlen_eta(2) * 7 = 96 * 7
-    type S2Packed = [u8; 768]; // bitlen_eta(2) * 8 = 96 * 8
+    type S1Packed = [u8; 672]; // 96 * 7
+    type S2Packed = [u8; 768]; // 96 * 8
     type T1Packed = [u8; 2560]; // 320 * 8
 }
 
@@ -257,17 +261,17 @@ impl MLDSAParams for MLDSA87Params {
 ///
 /// The bit-packing routines have one layout per distinct 𝛾1, so they dispatch on these rather than
 /// on the parameter set. ML-DSA-65 and ML-DSA-87 share the second value.
-pub(crate) const GAMMA1_2_POW_17: i32 = MLDSA44Params::GAMMA1;
+pub(crate) const GAMMA1_2_POW_17: i32 = MLDSA44Params::gamma1;
 /// See [`GAMMA1_2_POW_17`].
-pub(crate) const GAMMA1_2_POW_19: i32 = MLDSA65Params::GAMMA1;
+pub(crate) const GAMMA1_2_POW_19: i32 = MLDSA65Params::gamma1;
 
 /// The two distinct values 𝛾2 takes across the three parameter sets (FIPS 204, Table 1).
 ///
 /// As with 𝛾1, the routines that depend on 𝛾2 have one form per distinct value rather than one per
 /// parameter set. ML-DSA-65 and ML-DSA-87 share the second value.
-pub(crate) const GAMMA2_Q_MINUS_1_OVER_88: i32 = MLDSA44Params::GAMMA2;
+pub(crate) const GAMMA2_Q_MINUS_1_OVER_88: i32 = MLDSA44Params::gamma2;
 /// See [`GAMMA2_Q_MINUS_1_OVER_88`].
-pub(crate) const GAMMA2_Q_MINUS_1_OVER_32: i32 = MLDSA65Params::GAMMA2;
+pub(crate) const GAMMA2_Q_MINUS_1_OVER_32: i32 = MLDSA65Params::gamma2;
 
 /// The weaker of two security strengths.
 ///
@@ -403,15 +407,15 @@ mod tests {
 
     fn check_table_1<P: MLDSAParams>(i: usize) {
         let (tau, lambda, gamma1, gamma2, k, l, eta, omega) = TABLE_1[i];
-        assert_eq!(P::TAU, tau, "{}: 𝜏", P::ALG_NAME);
-        assert_eq!(P::LAMBDA, lambda, "{}: 𝜆", P::ALG_NAME);
-        assert_eq!(P::GAMMA1, gamma1, "{}: 𝛾1", P::ALG_NAME);
-        assert_eq!(P::GAMMA2, gamma2, "{}: 𝛾2", P::ALG_NAME);
+        assert_eq!(P::tau, tau, "{}: 𝜏", P::ALG_NAME);
+        assert_eq!(P::lambda, lambda, "{}: 𝜆", P::ALG_NAME);
+        assert_eq!(P::gamma1, gamma1, "{}: 𝛾1", P::ALG_NAME);
+        assert_eq!(P::gamma2, gamma2, "{}: 𝛾2", P::ALG_NAME);
         assert_eq!(P::k, k, "{}: 𝑘", P::ALG_NAME);
         assert_eq!(P::l, l, "{}: ℓ", P::ALG_NAME);
-        assert_eq!(P::ETA, eta, "{}: 𝜂", P::ALG_NAME);
-        assert_eq!(P::OMEGA, omega, "{}: 𝜔", P::ALG_NAME);
-        assert_eq!(P::BETA, TABLE_1_BETA[i], "{}: 𝛽 = 𝜏 ⋅ 𝜂", P::ALG_NAME);
+        assert_eq!(P::eta, eta, "{}: 𝜂", P::ALG_NAME);
+        assert_eq!(P::omega, omega, "{}: 𝜔", P::ALG_NAME);
+        assert_eq!(P::beta, TABLE_1_BETA[i], "{}: 𝛽 = 𝜏 ⋅ 𝜂", P::ALG_NAME);
     }
 
     fn check_table_2<P: MLDSAParams>(i: usize) {
@@ -432,13 +436,13 @@ mod tests {
 
         // Algorithm 24 (skEncode): 𝑠𝑘 ∈ 𝔹^(32+32+64+32⋅((𝑘+ℓ)⋅bitlen (2𝜂)+𝑑𝑘)).
         let full_sk_len =
-            32 + 32 + 64 + 32 * ((P::k + P::l) * bitlen(2 * P::ETA as u32) + d as usize * P::k);
+            32 + 32 + 64 + 32 * ((P::k + P::l) * bitlen(2 * P::eta as u32) + d as usize * P::k);
         assert_eq!(P::FULL_SK_LEN, full_sk_len, "{}: Algorithm 24 output size", P::ALG_NAME);
 
         // Algorithm 26 (sigEncode): 𝜎 ∈ 𝔹^(𝜆/4+ℓ⋅32⋅(1+bitlen (𝛾1−1))+𝜔+𝑘).
-        let sig_len = P::LAMBDA as usize / 4
-            + P::l * 32 * (1 + bitlen(P::GAMMA1 as u32 - 1))
-            + P::OMEGA as usize
+        let sig_len = P::lambda as usize / 4
+            + P::l * 32 * (1 + bitlen(P::gamma1 as u32 - 1))
+            + P::omega as usize
             + P::k;
         assert_eq!(P::SIG_LEN, sig_len, "{}: Algorithm 26 output size", P::ALG_NAME);
     }
@@ -487,73 +491,6 @@ mod tests {
     }
 
     #[test]
-    fn test_derived_lengths_match_the_values_they_replaced() {
-        // These were hand-written per parameter set before the derivations above existed. They are
-        // pinned here so that a change to a formula cannot silently move them.
-        assert_eq!(
-            [MLDSA44Params::C_TILDE_LEN, MLDSA65Params::C_TILDE_LEN, MLDSA87Params::C_TILDE_LEN],
-            [32, 48, 64]
-        );
-        assert_eq!(
-            [
-                MLDSA44Params::POLY_Z_PACKED_LEN,
-                MLDSA65Params::POLY_Z_PACKED_LEN,
-                MLDSA87Params::POLY_Z_PACKED_LEN
-            ],
-            [576, 640, 640]
-        );
-        assert_eq!(
-            [
-                MLDSA44Params::POLY_W1_PACKED_LEN,
-                MLDSA65Params::POLY_W1_PACKED_LEN,
-                MLDSA87Params::POLY_W1_PACKED_LEN
-            ],
-            [192, 128, 128]
-        );
-        // The three whole-vector packed lengths, from the comments on the constants they replaced.
-        assert_eq!(
-            [
-                MLDSA44Params::S1_PACKED_LEN,
-                MLDSA65Params::S1_PACKED_LEN,
-                MLDSA87Params::S1_PACKED_LEN
-            ],
-            [384, 640, 672]
-        );
-        assert_eq!(
-            [
-                MLDSA44Params::S2_PACKED_LEN,
-                MLDSA65Params::S2_PACKED_LEN,
-                MLDSA87Params::S2_PACKED_LEN
-            ],
-            [384, 768, 768]
-        );
-        assert_eq!(
-            [
-                MLDSA44Params::T1_PACKED_LEN,
-                MLDSA65Params::T1_PACKED_LEN,
-                MLDSA87Params::T1_PACKED_LEN
-            ],
-            [1280, 1920, 2560]
-        );
-        assert_eq!(
-            [
-                MLDSA44Params::GAMMA1_MINUS_BETA,
-                MLDSA65Params::GAMMA1_MINUS_BETA,
-                MLDSA87Params::GAMMA1_MINUS_BETA
-            ],
-            [131072 - 78, 524288 - 196, 524288 - 120]
-        );
-        assert_eq!(
-            [
-                MLDSA44Params::GAMMA2_MINUS_BETA,
-                MLDSA65Params::GAMMA2_MINUS_BETA,
-                MLDSA87Params::GAMMA2_MINUS_BETA
-            ],
-            [(q - 1) / 88 - 78, (q - 1) / 32 - 196, (q - 1) / 32 - 120]
-        );
-    }
-
-    #[test]
     fn test_bitlen_matches_its_definition() {
         // FIPS 204 Section 2.3 defines bitlen 𝑥 as the length of the binary expansion of 𝑥.
         assert_eq!(bitlen(0), 0);
@@ -571,10 +508,10 @@ mod tests {
     fn test_gamma_dispatch_constants_cover_every_parameter_set() {
         // The packing routines dispatch on these; a parameter set whose 𝛾 is neither value would
         // fall through to a panic at runtime rather than fail to compile, so pin them here.
-        for gamma1 in [MLDSA44Params::GAMMA1, MLDSA65Params::GAMMA1, MLDSA87Params::GAMMA1] {
+        for gamma1 in [MLDSA44Params::gamma1, MLDSA65Params::gamma1, MLDSA87Params::gamma1] {
             assert!(gamma1 == GAMMA1_2_POW_17 || gamma1 == GAMMA1_2_POW_19);
         }
-        for gamma2 in [MLDSA44Params::GAMMA2, MLDSA65Params::GAMMA2, MLDSA87Params::GAMMA2] {
+        for gamma2 in [MLDSA44Params::gamma2, MLDSA65Params::gamma2, MLDSA87Params::gamma2] {
             assert!(gamma2 == GAMMA2_Q_MINUS_1_OVER_88 || gamma2 == GAMMA2_Q_MINUS_1_OVER_32);
         }
         assert_ne!(GAMMA1_2_POW_17, GAMMA1_2_POW_19);

--- a/crypto/mldsa-lowmemory/src/params.rs
+++ b/crypto/mldsa-lowmemory/src/params.rs
@@ -171,7 +171,7 @@ impl MLDSAParams for MLDSA44Params {
     const tau: i32 = 39;
     const lambda: i32 = 128;
     const gamma1: i32 = 1 << 17;
-    // mutants note: because 𝛾1 is applied by bit-shifting, the "- 1" ends up not mattering.
+    // mutants note: because of the bitshifting, the "- 1" ends up not mattering.
     const gamma2: i32 = (q - 1) / 88;
     const k: usize = 4;
     const l: usize = 4;
@@ -201,7 +201,7 @@ impl MLDSAParams for MLDSA65Params {
     const tau: i32 = 49;
     const lambda: i32 = 192;
     const gamma1: i32 = 1 << 19;
-    // mutants note: because 𝛾1 is applied by bit-shifting, the "- 1" ends up not mattering.
+    // mutants note: because of the bitshifting, the "- 1" ends up not mattering.
     const gamma2: i32 = (q - 1) / 32;
     const k: usize = 6;
     const l: usize = 5;
@@ -231,7 +231,7 @@ impl MLDSAParams for MLDSA87Params {
     const tau: i32 = 60;
     const lambda: i32 = 256;
     const gamma1: i32 = 1 << 19;
-    // mutants note: because 𝛾1 is applied by bit-shifting, the "- 1" ends up not mattering.
+    // mutants note: because of the bitshifting, the "- 1" ends up not mattering.
     const gamma2: i32 = (q - 1) / 32;
     const k: usize = 8;
     const l: usize = 7;

--- a/crypto/mldsa-lowmemory/src/params.rs
+++ b/crypto/mldsa-lowmemory/src/params.rs
@@ -1,0 +1,583 @@
+//! The three ML-DSA parameter sets of FIPS 204, Section 4, as a sealed trait with one type per set.
+//!
+//! This mirrors `bouncycastle_mldsa::params`, minus the vector and matrix types: this crate never
+//! materializes 𝐀̂ or a whole polynomial vector, so the only parameter-sized types it needs are
+//! byte buffers.
+//!
+//! # Derived parameters
+//!
+//! FIPS 204, Table 1 assigns eight independent values per set (𝜏, 𝜆, 𝛾1, 𝛾2, (𝑘, ℓ), 𝜂, 𝜔) plus the
+//! three sizes of Table 2. Everything else this implementation needs is a function of those, so it
+//! is written once as a defaulted associated const rather than three times as a hand-computed
+//! number. `params::tests` checks every derivation against the values tabulated in FIPS 204.
+
+use crate::aux_functions::bitlen_eta;
+use crate::hash_mldsa::{
+    HASH_ML_DSA_44_with_SHA256_NAME, HASH_ML_DSA_44_with_SHA512_NAME,
+    HASH_ML_DSA_65_WITH_SHA256_NAME, HASH_ML_DSA_65_WITH_SHA512_NAME,
+    HASH_ML_DSA_87_WITH_SHA512_NAME, HASH_ML_DSA_87_with_SHA256_NAME,
+};
+use crate::mldsa::{
+    ML_DSA_44_NAME, ML_DSA_65_NAME, ML_DSA_87_NAME, MLDSA_SEED_LEN, POLY_T1PACKED_LEN, q,
+};
+use bouncycastle_core::traits::{Algorithm, AlgorithmOID, Hash, HashAlgParams, SecurityStrength};
+use bouncycastle_sha2::{SHA256, SHA512};
+use bouncycastle_utils::secret::ZeroizablePrimitive;
+
+/// `bitlen 𝑥`, the length of the binary expansion of 𝑥 (FIPS 204, Section 2.3).
+///
+/// `bitlen 0` is 0; every use below has a positive argument.
+pub(crate) const fn bitlen(x: u32) -> usize {
+    if x == 0 { 0 } else { x.ilog2() as usize + 1 }
+}
+
+/// A fixed-size byte buffer whose length depends on the parameter set.
+///
+/// [`ZeroizablePrimitive`] rather than [`Default`] supplies the all-zero value, because `Default`
+/// for arrays stops at 32 elements and every buffer here is longer than that.
+trait ByteBuffer: ZeroizablePrimitive + AsRef<[u8]> + AsMut<[u8]> {}
+impl<const N: usize> ByteBuffer for [u8; N] {}
+
+/// A crate-private (aka "sealed") trait that prevents a new ML-DSA parameter set from being defined
+/// outside this crate.
+trait MLDSAParamsInternalTrait {}
+
+/// One ML-DSA parameter set: the values of FIPS 204, Table 1 and Table 2, and the types whose size
+/// they determine.
+///
+/// Sealed via a private supertrait, so [`MLDSA44Params`], [`MLDSA65Params`] and [`MLDSA87Params`]
+/// are the only implementations.
+pub trait MLDSAParams: MLDSAParamsInternalTrait {
+    /* FIPS 204, Table 1: the values assigned by each parameter set. */
+
+    /// 𝜏, the number of ±1's in the polynomial 𝑐.
+    const TAU: i32;
+    /// 𝜆, the collision strength of 𝑐̃, in bits.
+    const LAMBDA: i32;
+    /// 𝛾1, the coefficient range of 𝐲. Always a power of two.
+    const GAMMA1: i32;
+    /// 𝛾2, the low-order rounding range.
+    const GAMMA2: i32;
+    /// 𝑘, the number of rows of 𝐀.
+    const k: usize;
+    /// ℓ, the number of columns of 𝐀.
+    const l: usize;
+    /// 𝜂, the private key range.
+    const ETA: usize;
+    /// 𝜔, the maximum number of 1's in the hint 𝐡.
+    const OMEGA: i32;
+
+    /* FIPS 204, Table 2: sizes in bytes of keys and signatures. */
+
+    /// The length of an encoded public key.
+    const PK_LEN: usize;
+    /// The length of the FIPS 204 encoding of a private key.
+    ///
+    /// Named `FULL_SK_LEN` rather than `SK_LEN` because this crate's private keys are held as the
+    /// 32-byte seed 𝜉 and expanded on demand; see [`MLDSAParams::SK_LEN`].
+    const FULL_SK_LEN: usize;
+    /// The length of a signature.
+    const SIG_LEN: usize;
+
+    /* Identity. */
+
+    /// The algorithm name, as reported by `Algorithm::ALG_NAME`.
+    const ALG_NAME: &'static str;
+    /// The strength claimed for this parameter set, as reported by `Algorithm::MAX_SECURITY_STRENGTH`.
+    const MAX_SECURITY_STRENGTH: SecurityStrength;
+    /// The OID in component form, as reported by `AlgorithmOID::OID`.
+    const OID: &'static [u32];
+    /// The DER encoding of [`MLDSAParams::OID`], as reported by `AlgorithmOID::OID_DER`.
+    const OID_DER: &'static [u8];
+
+    /* Derived. Never written out per parameter set -- see the module docs. */
+
+    /// The length of a private key as this crate stores it: the 32-byte seed 𝜉, for every
+    /// parameter set. FIPS 204, Section 4 notes that 𝜉 "is sufficient to generate the other parts
+    /// of the private key".
+    const SK_LEN: usize = MLDSA_SEED_LEN;
+
+    /// 𝛽, which FIPS 204, Table 1 defines as "𝛽 = 𝜏 ⋅ 𝜂".
+    const BETA: i32 = Self::TAU * Self::ETA as i32;
+
+    /// The length of the commitment hash 𝑐̃, which FIPS 204, Algorithm 26 (sigEncode) gives as
+    /// 𝑐̃ ∈ 𝔹^(𝜆/4).
+    const C_TILDE_LEN: usize = Self::LAMBDA as usize / 4;
+
+    /// The packed length of one coordinate of 𝐳: FIPS 204, Algorithm 26 (sigEncode) writes each of
+    /// the ℓ coordinates as 𝔹^(32⋅(1+bitlen (𝛾1−1))).
+    ///
+    /// This is also the number of bytes ExpandMask squeezes per coordinate: FIPS 204,
+    /// Algorithm 34, line 1 sets 𝑐 ← 1 + bitlen (𝛾1 − 1) and line 4 squeezes 32𝑐 bytes.
+    const POLY_Z_PACKED_LEN: usize = 32 * (1 + bitlen(Self::GAMMA1 as u32 - 1));
+
+    /// The packed length of one coordinate of 𝐰1: FIPS 204, Algorithm 28 (w1Encode) outputs
+    /// 𝔹^(32𝑘⋅bitlen ((𝑞−1)/(2𝛾2)−1)) for all 𝑘 coordinates together.
+    const POLY_W1_PACKED_LEN: usize = 32 * bitlen(((q - 1) / (2 * Self::GAMMA2)) as u32 - 1);
+
+    /// The packed length of the whole of 𝐬1, i.e. ℓ coordinates each of 32⋅bitlen (2𝜂) bytes.
+    const S1_PACKED_LEN: usize = bitlen_eta(Self::ETA) * Self::l;
+
+    /// The packed length of the whole of 𝐬2, i.e. 𝑘 coordinates each of 32⋅bitlen (2𝜂) bytes.
+    const S2_PACKED_LEN: usize = bitlen_eta(Self::ETA) * Self::k;
+
+    /// The packed length of the whole of 𝐭1, i.e. 𝑘 coordinates of SimpleBitPack output.
+    const T1_PACKED_LEN: usize = POLY_T1PACKED_LEN * Self::k;
+
+    /// 𝛾1 − 𝛽, the rejection bound on ‖𝐳‖∞ (FIPS 204, Algorithm 7, line 23).
+    const GAMMA1_MINUS_BETA: i32 = Self::GAMMA1 - Self::BETA;
+
+    /// 𝛾2 − 𝛽, the rejection bound on ‖𝐫0‖∞ (FIPS 204, Algorithm 7, line 23).
+    const GAMMA2_MINUS_BETA: i32 = Self::GAMMA2 - Self::BETA;
+
+    /* Types whose size depends on the parameter set. */
+
+    /// The commitment hash 𝑐̃, of [`MLDSAParams::C_TILDE_LEN`] bytes.
+    type SigCTilde: ByteBuffer;
+    /// One packed coordinate of 𝐳, of [`MLDSAParams::POLY_Z_PACKED_LEN`] bytes.
+    ///
+    /// ExpandMask squeezes into a buffer of this same length; see
+    /// [`MLDSAParams::POLY_Z_PACKED_LEN`].
+    type PolyZPacked: ByteBuffer;
+    /// One packed coordinate of 𝐰1, of [`MLDSAParams::POLY_W1_PACKED_LEN`] bytes.
+    type PolyW1Packed: ByteBuffer;
+    /// The whole of 𝐬1 packed, of [`MLDSAParams::S1_PACKED_LEN`] bytes.
+    type S1Packed: ByteBuffer;
+    /// The whole of 𝐬2 packed, of [`MLDSAParams::S2_PACKED_LEN`] bytes.
+    type S2Packed: ByteBuffer;
+    /// The whole of 𝐭1 packed, of [`MLDSAParams::T1_PACKED_LEN`] bytes.
+    type T1Packed: ByteBuffer;
+}
+
+/// The ML-DSA-44 parameter set (FIPS 204, Table 1).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MLDSA44Params;
+/// The ML-DSA-65 parameter set (FIPS 204, Table 1).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MLDSA65Params;
+/// The ML-DSA-87 parameter set (FIPS 204, Table 1).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MLDSA87Params;
+
+impl MLDSAParamsInternalTrait for MLDSA44Params {}
+impl MLDSAParamsInternalTrait for MLDSA65Params {}
+impl MLDSAParamsInternalTrait for MLDSA87Params {}
+
+impl MLDSAParams for MLDSA44Params {
+    const TAU: i32 = 39;
+    const LAMBDA: i32 = 128;
+    const GAMMA1: i32 = 1 << 17;
+    // mutants note: because 𝛾1 is applied by bit-shifting, the "- 1" ends up not mattering.
+    const GAMMA2: i32 = (q - 1) / 88;
+    const k: usize = 4;
+    const l: usize = 4;
+    const ETA: usize = 2;
+    const OMEGA: i32 = 80;
+
+    const PK_LEN: usize = 1312;
+    const FULL_SK_LEN: usize = 2560;
+    const SIG_LEN: usize = 2420;
+
+    const ALG_NAME: &'static str = ML_DSA_44_NAME;
+    const MAX_SECURITY_STRENGTH: SecurityStrength = SecurityStrength::_128bit;
+    /// Assigned by NIST in the Computer Security Objects Register: id-ml-dsa-44 { sigAlgs 17 }
+    const OID: &'static [u32] = &[2, 16, 840, 1, 101, 3, 4, 3, 17];
+    const OID_DER: &'static [u8] =
+        &[0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x03, 0x11];
+
+    type SigCTilde = [u8; 32]; // 𝜆/4 = 128/4
+    type PolyZPacked = [u8; 576]; // 32 * (1 + bitlen(2^17 - 1)) = 32 * 18
+    type PolyW1Packed = [u8; 192]; // 32 * bitlen(44 - 1) = 32 * 6
+    type S1Packed = [u8; 384]; // bitlen_eta(2) * 4 = 96 * 4
+    type S2Packed = [u8; 384]; // bitlen_eta(2) * 4 = 96 * 4
+    type T1Packed = [u8; 1280]; // 320 * 4
+}
+
+impl MLDSAParams for MLDSA65Params {
+    const TAU: i32 = 49;
+    const LAMBDA: i32 = 192;
+    const GAMMA1: i32 = 1 << 19;
+    // mutants note: because 𝛾1 is applied by bit-shifting, the "- 1" ends up not mattering.
+    const GAMMA2: i32 = (q - 1) / 32;
+    const k: usize = 6;
+    const l: usize = 5;
+    const ETA: usize = 4;
+    const OMEGA: i32 = 55;
+
+    const PK_LEN: usize = 1952;
+    const FULL_SK_LEN: usize = 4032;
+    const SIG_LEN: usize = 3309;
+
+    const ALG_NAME: &'static str = ML_DSA_65_NAME;
+    const MAX_SECURITY_STRENGTH: SecurityStrength = SecurityStrength::_192bit;
+    /// Assigned by NIST in the Computer Security Objects Register: id-ml-dsa-65 { sigAlgs 18 }
+    const OID: &'static [u32] = &[2, 16, 840, 1, 101, 3, 4, 3, 18];
+    const OID_DER: &'static [u8] =
+        &[0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x03, 0x12];
+
+    type SigCTilde = [u8; 48]; // 𝜆/4 = 192/4
+    type PolyZPacked = [u8; 640]; // 32 * (1 + bitlen(2^19 - 1)) = 32 * 20
+    type PolyW1Packed = [u8; 128]; // 32 * bitlen(16 - 1) = 32 * 4
+    type S1Packed = [u8; 640]; // bitlen_eta(4) * 5 = 128 * 5
+    type S2Packed = [u8; 768]; // bitlen_eta(4) * 6 = 128 * 6
+    type T1Packed = [u8; 1920]; // 320 * 6
+}
+
+impl MLDSAParams for MLDSA87Params {
+    const TAU: i32 = 60;
+    const LAMBDA: i32 = 256;
+    const GAMMA1: i32 = 1 << 19;
+    // mutants note: because 𝛾1 is applied by bit-shifting, the "- 1" ends up not mattering.
+    const GAMMA2: i32 = (q - 1) / 32;
+    const k: usize = 8;
+    const l: usize = 7;
+    const ETA: usize = 2;
+    const OMEGA: i32 = 75;
+
+    const PK_LEN: usize = 2592;
+    const FULL_SK_LEN: usize = 4896;
+    const SIG_LEN: usize = 4627;
+
+    const ALG_NAME: &'static str = ML_DSA_87_NAME;
+    const MAX_SECURITY_STRENGTH: SecurityStrength = SecurityStrength::_256bit;
+    /// Assigned by NIST in the Computer Security Objects Register: id-ml-dsa-87 { sigAlgs 19 }
+    const OID: &'static [u32] = &[2, 16, 840, 1, 101, 3, 4, 3, 19];
+    const OID_DER: &'static [u8] =
+        &[0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x03, 0x13];
+
+    type SigCTilde = [u8; 64]; // 𝜆/4 = 256/4
+    type PolyZPacked = [u8; 640]; // 32 * (1 + bitlen(2^19 - 1)) = 32 * 20
+    type PolyW1Packed = [u8; 128]; // 32 * bitlen(16 - 1) = 32 * 4
+    type S1Packed = [u8; 672]; // bitlen_eta(2) * 7 = 96 * 7
+    type S2Packed = [u8; 768]; // bitlen_eta(2) * 8 = 96 * 8
+    type T1Packed = [u8; 2560]; // 320 * 8
+}
+
+/// The two distinct values 𝛾1 takes across the three parameter sets (FIPS 204, Table 1).
+///
+/// The bit-packing routines have one layout per distinct 𝛾1, so they dispatch on these rather than
+/// on the parameter set. ML-DSA-65 and ML-DSA-87 share the second value.
+pub(crate) const GAMMA1_2_POW_17: i32 = MLDSA44Params::GAMMA1;
+/// See [`GAMMA1_2_POW_17`].
+pub(crate) const GAMMA1_2_POW_19: i32 = MLDSA65Params::GAMMA1;
+
+/// The two distinct values 𝛾2 takes across the three parameter sets (FIPS 204, Table 1).
+///
+/// As with 𝛾1, the routines that depend on 𝛾2 have one form per distinct value rather than one per
+/// parameter set. ML-DSA-65 and ML-DSA-87 share the second value.
+pub(crate) const GAMMA2_Q_MINUS_1_OVER_88: i32 = MLDSA44Params::GAMMA2;
+/// See [`GAMMA2_Q_MINUS_1_OVER_88`].
+pub(crate) const GAMMA2_Q_MINUS_1_OVER_32: i32 = MLDSA65Params::GAMMA2;
+
+/// The weaker of two security strengths.
+///
+/// [`SecurityStrength`]'s discriminants are assigned in increasing order of strength, so comparing
+/// them as integers orders them. A `const fn` because the strength of a HashML-DSA pairing is a
+/// defaulted associated const.
+const fn weaker_of(a: SecurityStrength, b: SecurityStrength) -> SecurityStrength {
+    if (a as u8) <= (b as u8) { a } else { b }
+}
+
+/// A crate-private (aka "sealed") trait that prevents a new HashML-DSA pairing from being defined
+/// outside this crate.
+trait HashMLDSAParamsInternalTrait {}
+
+/// One HashML-DSA algorithm: an ML-DSA parameter set paired with a pre-hash function.
+///
+/// FIPS 204, Algorithm 4 (HashML-DSA.Sign) leaves the choice of PH open, so an instantiation is a
+/// pairing rather than a single parameter set. Everything that varies across the pairings lives
+/// here, so [`crate::hash_mldsa::HashMLDSA`] takes one type rather than a parameter set plus a
+/// hash function plus a digest length.
+///
+/// Sealed via a private supertrait, so the six types below are the only implementations.
+pub trait HashMLDSAParams: HashMLDSAParamsInternalTrait {
+    /// The ML-DSA parameter set underneath.
+    type MLDSA: MLDSAParams;
+    /// PH, the pre-hash function.
+    type PreHash: Hash + HashAlgParams + AlgorithmOID + Default;
+
+    /// The algorithm name, as reported by `Algorithm::ALG_NAME`.
+    ///
+    /// Written out per pairing rather than derived: it is the two component names spliced
+    /// together, and `&'static str` cannot be concatenated in a const context.
+    const ALG_NAME: &'static str;
+
+    /* Derived. Never written out per pairing. */
+
+    /// The length of the pre-hash `ph`, which is just PH's output length.
+    const PH_LEN: usize = <Self::PreHash as HashAlgParams>::OUTPUT_LEN;
+
+    /// The strength claimed for the pairing, as reported by `Algorithm::MAX_SECURITY_STRENGTH`.
+    ///
+    /// A HashML-DSA signature is no stronger than either of its two components, so this is the
+    /// weaker of the two. That is what caps, for example, HashML-DSA-87_with_SHA256 at 128 bits.
+    const MAX_SECURITY_STRENGTH: SecurityStrength = weaker_of(
+        <Self::MLDSA as MLDSAParams>::MAX_SECURITY_STRENGTH,
+        <Self::PreHash as Algorithm>::MAX_SECURITY_STRENGTH,
+    );
+}
+
+/// The HashML-DSA-44_with_SHA256 pairing.
+#[allow(non_camel_case_types)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct HashMLDSA44_with_SHA256Params;
+/// The HashML-DSA-65_with_SHA256 pairing.
+#[allow(non_camel_case_types)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct HashMLDSA65_with_SHA256Params;
+/// The HashML-DSA-87_with_SHA256 pairing.
+#[allow(non_camel_case_types)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct HashMLDSA87_with_SHA256Params;
+/// The HashML-DSA-44_with_SHA512 pairing.
+#[allow(non_camel_case_types)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct HashMLDSA44_with_SHA512Params;
+/// The HashML-DSA-65_with_SHA512 pairing.
+#[allow(non_camel_case_types)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct HashMLDSA65_with_SHA512Params;
+/// The HashML-DSA-87_with_SHA512 pairing.
+#[allow(non_camel_case_types)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct HashMLDSA87_with_SHA512Params;
+
+impl HashMLDSAParamsInternalTrait for HashMLDSA44_with_SHA256Params {}
+impl HashMLDSAParamsInternalTrait for HashMLDSA65_with_SHA256Params {}
+impl HashMLDSAParamsInternalTrait for HashMLDSA87_with_SHA256Params {}
+impl HashMLDSAParamsInternalTrait for HashMLDSA44_with_SHA512Params {}
+impl HashMLDSAParamsInternalTrait for HashMLDSA65_with_SHA512Params {}
+impl HashMLDSAParamsInternalTrait for HashMLDSA87_with_SHA512Params {}
+
+impl HashMLDSAParams for HashMLDSA44_with_SHA256Params {
+    type MLDSA = MLDSA44Params;
+    type PreHash = SHA256;
+    const ALG_NAME: &'static str = HASH_ML_DSA_44_with_SHA256_NAME;
+}
+impl HashMLDSAParams for HashMLDSA65_with_SHA256Params {
+    type MLDSA = MLDSA65Params;
+    type PreHash = SHA256;
+    const ALG_NAME: &'static str = HASH_ML_DSA_65_WITH_SHA256_NAME;
+}
+impl HashMLDSAParams for HashMLDSA87_with_SHA256Params {
+    type MLDSA = MLDSA87Params;
+    type PreHash = SHA256;
+    const ALG_NAME: &'static str = HASH_ML_DSA_87_with_SHA256_NAME;
+}
+impl HashMLDSAParams for HashMLDSA44_with_SHA512Params {
+    type MLDSA = MLDSA44Params;
+    type PreHash = SHA512;
+    const ALG_NAME: &'static str = HASH_ML_DSA_44_with_SHA512_NAME;
+}
+impl HashMLDSAParams for HashMLDSA65_with_SHA512Params {
+    type MLDSA = MLDSA65Params;
+    type PreHash = SHA512;
+    const ALG_NAME: &'static str = HASH_ML_DSA_65_WITH_SHA512_NAME;
+}
+impl HashMLDSAParams for HashMLDSA87_with_SHA512Params {
+    type MLDSA = MLDSA87Params;
+    type PreHash = SHA512;
+    const ALG_NAME: &'static str = HASH_ML_DSA_87_WITH_SHA512_NAME;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::mldsa::d;
+
+    /// FIPS 204, Table 1, transcribed column by column: the eight values each parameter set
+    /// assigns. `(tau, lambda, gamma1, gamma2, k, l, eta, omega)`.
+    const TABLE_1: [(i32, i32, i32, i32, usize, usize, usize, i32); 3] = [
+        (39, 128, 131072, (q - 1) / 88, 4, 4, 2, 80),
+        (49, 192, 524288, (q - 1) / 32, 6, 5, 4, 55),
+        (60, 256, 524288, (q - 1) / 32, 8, 7, 2, 75),
+    ];
+
+    /// FIPS 204, Table 2, transcribed row by row: `(private key, public key, signature)` in bytes.
+    /// The private key column is the full FIPS encoding, which this crate calls `FULL_SK_LEN`.
+    const TABLE_2: [(usize, usize, usize); 3] =
+        [(2560, 1312, 2420), (4032, 1952, 3309), (4896, 2592, 4627)];
+
+    /// FIPS 204, Table 1 also tabulates 𝛽, which it labels "𝛽 = 𝜏 ⋅ 𝜂".
+    const TABLE_1_BETA: [i32; 3] = [78, 196, 120];
+
+    fn check_table_1<P: MLDSAParams>(i: usize) {
+        let (tau, lambda, gamma1, gamma2, k, l, eta, omega) = TABLE_1[i];
+        assert_eq!(P::TAU, tau, "{}: 𝜏", P::ALG_NAME);
+        assert_eq!(P::LAMBDA, lambda, "{}: 𝜆", P::ALG_NAME);
+        assert_eq!(P::GAMMA1, gamma1, "{}: 𝛾1", P::ALG_NAME);
+        assert_eq!(P::GAMMA2, gamma2, "{}: 𝛾2", P::ALG_NAME);
+        assert_eq!(P::k, k, "{}: 𝑘", P::ALG_NAME);
+        assert_eq!(P::l, l, "{}: ℓ", P::ALG_NAME);
+        assert_eq!(P::ETA, eta, "{}: 𝜂", P::ALG_NAME);
+        assert_eq!(P::OMEGA, omega, "{}: 𝜔", P::ALG_NAME);
+        assert_eq!(P::BETA, TABLE_1_BETA[i], "{}: 𝛽 = 𝜏 ⋅ 𝜂", P::ALG_NAME);
+    }
+
+    fn check_table_2<P: MLDSAParams>(i: usize) {
+        let (full_sk_len, pk_len, sig_len) = TABLE_2[i];
+        assert_eq!(P::FULL_SK_LEN, full_sk_len, "{}: private key size", P::ALG_NAME);
+        assert_eq!(P::PK_LEN, pk_len, "{}: public key size", P::ALG_NAME);
+        assert_eq!(P::SIG_LEN, sig_len, "{}: signature size", P::ALG_NAME);
+        // This crate stores the seed, not the expanded key, for every parameter set.
+        assert_eq!(P::SK_LEN, 32, "{}: stored private key size", P::ALG_NAME);
+    }
+
+    /// Each of the three sizes of Table 2 also has a formula in FIPS 204, and the two must agree.
+    /// Table 2 is what is written down above; this is what re-derives it.
+    fn check_table_2_formulas<P: MLDSAParams>() {
+        // Algorithm 22 (pkEncode): 𝑝𝑘 ∈ 𝔹^(32+32𝑘(bitlen (𝑞−1)−𝑑)).
+        let pk_len = 32 + 32 * P::k * (bitlen((q - 1) as u32) - d as usize);
+        assert_eq!(P::PK_LEN, pk_len, "{}: Algorithm 22 output size", P::ALG_NAME);
+
+        // Algorithm 24 (skEncode): 𝑠𝑘 ∈ 𝔹^(32+32+64+32⋅((𝑘+ℓ)⋅bitlen (2𝜂)+𝑑𝑘)).
+        let full_sk_len =
+            32 + 32 + 64 + 32 * ((P::k + P::l) * bitlen(2 * P::ETA as u32) + d as usize * P::k);
+        assert_eq!(P::FULL_SK_LEN, full_sk_len, "{}: Algorithm 24 output size", P::ALG_NAME);
+
+        // Algorithm 26 (sigEncode): 𝜎 ∈ 𝔹^(𝜆/4+ℓ⋅32⋅(1+bitlen (𝛾1−1))+𝜔+𝑘).
+        let sig_len = P::LAMBDA as usize / 4
+            + P::l * 32 * (1 + bitlen(P::GAMMA1 as u32 - 1))
+            + P::OMEGA as usize
+            + P::k;
+        assert_eq!(P::SIG_LEN, sig_len, "{}: Algorithm 26 output size", P::ALG_NAME);
+    }
+
+    /// The associated types must be exactly as long as the consts that describe them; they are
+    /// written out by hand per parameter set, so this guards against a typo in one of them.
+    fn check_associated_type_sizes<P: MLDSAParams>() {
+        for (got, want, what) in [
+            (size_of::<P::SigCTilde>(), P::C_TILDE_LEN, "SigCTilde"),
+            (size_of::<P::PolyZPacked>(), P::POLY_Z_PACKED_LEN, "PolyZPacked"),
+            (size_of::<P::PolyW1Packed>(), P::POLY_W1_PACKED_LEN, "PolyW1Packed"),
+            (size_of::<P::S1Packed>(), P::S1_PACKED_LEN, "S1Packed"),
+            (size_of::<P::S2Packed>(), P::S2_PACKED_LEN, "S2Packed"),
+            (size_of::<P::T1Packed>(), P::T1_PACKED_LEN, "T1Packed"),
+        ] {
+            assert_eq!(got, want, "{}: {} vs its length const", P::ALG_NAME, what);
+        }
+    }
+
+    #[test]
+    fn test_parameter_sets_match_fips204_table_1() {
+        check_table_1::<MLDSA44Params>(0);
+        check_table_1::<MLDSA65Params>(1);
+        check_table_1::<MLDSA87Params>(2);
+    }
+
+    #[test]
+    fn test_sizes_match_fips204_table_2() {
+        check_table_2::<MLDSA44Params>(0);
+        check_table_2::<MLDSA65Params>(1);
+        check_table_2::<MLDSA87Params>(2);
+    }
+
+    #[test]
+    fn test_table_2_sizes_agree_with_the_encoding_formulas() {
+        check_table_2_formulas::<MLDSA44Params>();
+        check_table_2_formulas::<MLDSA65Params>();
+        check_table_2_formulas::<MLDSA87Params>();
+    }
+
+    #[test]
+    fn test_associated_types_are_the_length_their_consts_claim() {
+        check_associated_type_sizes::<MLDSA44Params>();
+        check_associated_type_sizes::<MLDSA65Params>();
+        check_associated_type_sizes::<MLDSA87Params>();
+    }
+
+    #[test]
+    fn test_derived_lengths_match_the_values_they_replaced() {
+        // These were hand-written per parameter set before the derivations above existed. They are
+        // pinned here so that a change to a formula cannot silently move them.
+        assert_eq!(
+            [MLDSA44Params::C_TILDE_LEN, MLDSA65Params::C_TILDE_LEN, MLDSA87Params::C_TILDE_LEN],
+            [32, 48, 64]
+        );
+        assert_eq!(
+            [
+                MLDSA44Params::POLY_Z_PACKED_LEN,
+                MLDSA65Params::POLY_Z_PACKED_LEN,
+                MLDSA87Params::POLY_Z_PACKED_LEN
+            ],
+            [576, 640, 640]
+        );
+        assert_eq!(
+            [
+                MLDSA44Params::POLY_W1_PACKED_LEN,
+                MLDSA65Params::POLY_W1_PACKED_LEN,
+                MLDSA87Params::POLY_W1_PACKED_LEN
+            ],
+            [192, 128, 128]
+        );
+        // The three whole-vector packed lengths, from the comments on the constants they replaced.
+        assert_eq!(
+            [
+                MLDSA44Params::S1_PACKED_LEN,
+                MLDSA65Params::S1_PACKED_LEN,
+                MLDSA87Params::S1_PACKED_LEN
+            ],
+            [384, 640, 672]
+        );
+        assert_eq!(
+            [
+                MLDSA44Params::S2_PACKED_LEN,
+                MLDSA65Params::S2_PACKED_LEN,
+                MLDSA87Params::S2_PACKED_LEN
+            ],
+            [384, 768, 768]
+        );
+        assert_eq!(
+            [
+                MLDSA44Params::T1_PACKED_LEN,
+                MLDSA65Params::T1_PACKED_LEN,
+                MLDSA87Params::T1_PACKED_LEN
+            ],
+            [1280, 1920, 2560]
+        );
+        assert_eq!(
+            [
+                MLDSA44Params::GAMMA1_MINUS_BETA,
+                MLDSA65Params::GAMMA1_MINUS_BETA,
+                MLDSA87Params::GAMMA1_MINUS_BETA
+            ],
+            [131072 - 78, 524288 - 196, 524288 - 120]
+        );
+        assert_eq!(
+            [
+                MLDSA44Params::GAMMA2_MINUS_BETA,
+                MLDSA65Params::GAMMA2_MINUS_BETA,
+                MLDSA87Params::GAMMA2_MINUS_BETA
+            ],
+            [(q - 1) / 88 - 78, (q - 1) / 32 - 196, (q - 1) / 32 - 120]
+        );
+    }
+
+    #[test]
+    fn test_bitlen_matches_its_definition() {
+        // FIPS 204 Section 2.3 defines bitlen 𝑥 as the length of the binary expansion of 𝑥.
+        assert_eq!(bitlen(0), 0);
+        assert_eq!(bitlen(1), 1);
+        assert_eq!(bitlen(2), 2);
+        assert_eq!(bitlen(3), 2);
+        assert_eq!(bitlen(4), 3);
+        // The two arguments the derivations above actually use, plus bitlen(𝑞 − 1) = 23.
+        assert_eq!(bitlen((1 << 17) - 1), 17);
+        assert_eq!(bitlen((1 << 19) - 1), 19);
+        assert_eq!(bitlen((q - 1) as u32), 23);
+    }
+
+    #[test]
+    fn test_gamma_dispatch_constants_cover_every_parameter_set() {
+        // The packing routines dispatch on these; a parameter set whose 𝛾 is neither value would
+        // fall through to a panic at runtime rather than fail to compile, so pin them here.
+        for gamma1 in [MLDSA44Params::GAMMA1, MLDSA65Params::GAMMA1, MLDSA87Params::GAMMA1] {
+            assert!(gamma1 == GAMMA1_2_POW_17 || gamma1 == GAMMA1_2_POW_19);
+        }
+        for gamma2 in [MLDSA44Params::GAMMA2, MLDSA65Params::GAMMA2, MLDSA87Params::GAMMA2] {
+            assert!(gamma2 == GAMMA2_Q_MINUS_1_OVER_88 || gamma2 == GAMMA2_Q_MINUS_1_OVER_32);
+        }
+        assert_ne!(GAMMA1_2_POW_17, GAMMA1_2_POW_19);
+        assert_ne!(GAMMA2_Q_MINUS_1_OVER_88, GAMMA2_Q_MINUS_1_OVER_32);
+    }
+}

--- a/crypto/mldsa-lowmemory/src/polynomial.rs
+++ b/crypto/mldsa-lowmemory/src/polynomial.rs
@@ -149,7 +149,7 @@ impl Polynomial {
     ///
     /// The coefficient width is bitlen ((𝑞 − 1)/(2𝛾2) − 1), which is 6 bits for 𝛾2 = (𝑞 − 1)/88 and
     /// 4 bits for 𝛾2 = (𝑞 − 1)/32, so there is one packing layout per distinct 𝛾2 rather than one
-    /// per parameter set. `P::GAMMA2` is a constant after monomorphization, so only the matching
+    /// per parameter set. `P::gamma2` is a constant after monomorphization, so only the matching
     /// arm survives.
     pub(crate) fn w1_encode<P: MLDSAParams>(&self) -> P::PolyW1Packed {
         // It might seem counter-intuitive for a low-memory implementation to create a tmp buffer
@@ -164,7 +164,7 @@ impl Polynomial {
         let mut out = <P::PolyW1Packed as ZeroizablePrimitive>::ZEROED;
         let r = out.as_mut();
 
-        match P::GAMMA2 {
+        match P::gamma2 {
             // ML-DSA-44: (𝑞 − 1)/(2𝛾2) − 1 = 43, so four 6-bit coefficients pack into three bytes.
             GAMMA2_Q_MINUS_1_OVER_88 => {
                 for i in 0..N / 4 {

--- a/crypto/mldsa-lowmemory/src/polynomial.rs
+++ b/crypto/mldsa-lowmemory/src/polynomial.rs
@@ -1,7 +1,9 @@
 //! Represents a polynomial over the ML-DSA ring.
 
 use crate::aux_functions::{high_bits, low_bits, make_hint, use_hint};
-use crate::mldsa::{MLDSA44_POLY_W1_PACKED_LEN, MLDSA65_POLY_W1_PACKED_LEN, N, q, q_inv};
+use crate::mldsa::{N, d, q, q_inv};
+use crate::params::{GAMMA2_Q_MINUS_1_OVER_32, GAMMA2_Q_MINUS_1_OVER_88, MLDSAParams};
+use bouncycastle_utils::secret::ZeroizablePrimitive;
 use core::ops::{Index, IndexMut};
 
 /// A polynomial over the ML-DSA ring.
@@ -75,19 +77,25 @@ impl Polynomial {
         }
     }
 
-    pub(crate) fn high_bits<const GAMMA2: i32>(&mut self) {
+    pub(crate) fn high_bits<P: MLDSAParams>(&mut self) {
         for i in 0..N {
-            self[i] = high_bits::<GAMMA2>(self[i]);
+            self[i] = high_bits::<P>(self[i]);
         }
     }
 
-    pub(crate) fn low_bits<const GAMMA2: i32>(&mut self) {
+    pub(crate) fn low_bits<P: MLDSAParams>(&mut self) {
         for i in 0..N {
-            self[i] = low_bits::<GAMMA2>(self[i]);
+            self[i] = low_bits::<P>(self[i]);
         }
     }
 
-    pub(crate) fn check_norm<const BOUND: i32>(&self) -> bool {
+    /// Tests whether any coefficient has absolute value at least `bound`.
+    ///
+    /// `bound` is a runtime argument rather than a const generic because every call site passes a
+    /// value derived from the parameter set (𝛾1 − 𝛽, 𝛾2 − 𝛽, or 𝛾2), and an associated const of a
+    /// type parameter cannot be used as a const generic argument. It is still a constant after
+    /// monomorphization, so this costs nothing.
+    pub(crate) fn check_norm(&self, bound: i32) -> bool {
         // Fine that this is not constant-time (returns true early) because it is used in a rejection loop.
         // IE the early quit here leads to rejection and continuing to the top of the rejection loop, or failing
         // the signature validation.
@@ -97,33 +105,38 @@ impl Polynomial {
         //  if bound > (q - 1) / 8 {
         //     return true;
         //  }
-        // but since BOUND is a constant here, a debug_assert is done to ensure the value is what is expected.
-        debug_assert!(BOUND <= (q - 1) / 8);
+        // but since every caller passes a parameter-set constant, a debug_assert is done instead
+        // to ensure the value is what is expected.
+        debug_assert!(bound <= (q - 1) / 8);
 
         let mut t: i32;
         for x in self.coeffs.iter() {
             t = *x >> 31;
             t = *x - (t & (2 * *x));
 
-            if t >= BOUND {
+            if t >= bound {
                 return true;
             }
         }
         false
     }
 
-    pub(crate) fn shift_left<const d: i32>(&mut self) {
+    /// Multiplies every coefficient by 2^𝑑.
+    ///
+    /// 𝑑 is 13 for all three parameter sets (FIPS 204, Table 1), so it is read from the global
+    /// constant rather than being passed in.
+    pub(crate) fn shift_left_d(&mut self) {
         for x in self.coeffs.iter_mut() {
             *x <<= d;
         }
     }
 
     /// Creates the hint vector, and also returns its hamming weight (ie the number of 1's).
-    pub(crate) fn make_hint_row<const GAMMA2: i32>(&self, r: &Self) -> (Self, i32) {
+    pub(crate) fn make_hint_row<P: MLDSAParams>(&self, r: &Self) -> (Self, i32) {
         let mut out = Polynomial::new();
         let mut count = 0i32;
         for i in 0..N {
-            let x = make_hint::<GAMMA2>(self[i], r[i]);
+            let x = make_hint::<P>(self[i], r[i]);
             out[i] = x;
             count += x;
         }
@@ -131,7 +144,14 @@ impl Polynomial {
         (out, count)
     }
 
-    pub(crate) fn w1_encode<const POLY_W1_PACKED_LEN: usize>(&self) -> [u8; POLY_W1_PACKED_LEN] {
+    /// SimpleBitPack(𝐰1[𝑖], (𝑞 − 1)/(2𝛾2) − 1), the per-coordinate body of
+    /// FIPS 204, Algorithm 28 (w1Encode), line 3.
+    ///
+    /// The coefficient width is bitlen ((𝑞 − 1)/(2𝛾2) − 1), which is 6 bits for 𝛾2 = (𝑞 − 1)/88 and
+    /// 4 bits for 𝛾2 = (𝑞 − 1)/32, so there is one packing layout per distinct 𝛾2 rather than one
+    /// per parameter set. `P::GAMMA2` is a constant after monomorphization, so only the matching
+    /// arm survives.
+    pub(crate) fn w1_encode<P: MLDSAParams>(&self) -> P::PolyW1Packed {
         // It might seem counter-intuitive for a low-memory implementation to create a tmp buffer
         // rather than work in the provided buffer, but experimentation shows that
         // rust is roughly an order of magnitude faster working in a scope-local array than
@@ -141,18 +161,21 @@ impl Polynomial {
         // several hundred physical memory writes.
         // So while it looks odd to use a scope variable in a low-memory implementation, it's way faster
         // while seemingly maintaining the same physical memory footprint.
-        let mut r = [0u8; POLY_W1_PACKED_LEN];
+        let mut out = <P::PolyW1Packed as ZeroizablePrimitive>::ZEROED;
+        let r = out.as_mut();
 
-        match POLY_W1_PACKED_LEN {
-            MLDSA44_POLY_W1_PACKED_LEN => {
+        match P::GAMMA2 {
+            // ML-DSA-44: (𝑞 − 1)/(2𝛾2) − 1 = 43, so four 6-bit coefficients pack into three bytes.
+            GAMMA2_Q_MINUS_1_OVER_88 => {
                 for i in 0..N / 4 {
                     r[3 * i] = ((self[4 * i]) as u8) | ((self[4 * i + 1] << 6) as u8);
                     r[3 * i + 1] = ((self[4 * i + 1] >> 2) as u8) | ((self[4 * i + 2] << 4) as u8);
                     r[3 * i + 2] = ((self[4 * i + 2] >> 4) as u8) | ((self[4 * i + 3] << 2) as u8);
                 }
             }
-            // ML-DSA65 and 87 share a POLY_W1_PACKED_LEN value
-            MLDSA65_POLY_W1_PACKED_LEN => {
+            // ML-DSA-65 and ML-DSA-87 share this 𝛾2: (𝑞 − 1)/(2𝛾2) − 1 = 15, so two 4-bit
+            // coefficients pack into one byte.
+            GAMMA2_Q_MINUS_1_OVER_32 => {
                 for i in 0..N / 2 {
                     r[i] = ((self[2 * i]) | (self[2 * i + 1] << 4)) as u8;
                 }
@@ -162,7 +185,7 @@ impl Polynomial {
             }
         }
 
-        r
+        out
     }
 
     /// Algorithm 41 NTT(𝑤)
@@ -244,9 +267,9 @@ impl Polynomial {
         }
     }
 
-    pub(crate) fn use_hint<const GAMMA2: i32>(&mut self, h: &Polynomial) {
+    pub(crate) fn use_hint<P: MLDSAParams>(&mut self, h: &Polynomial) {
         for i in 0..N {
-            self[i] = use_hint::<GAMMA2>(self[i], h[i]);
+            self[i] = use_hint::<P>(self[i], h[i]);
         }
     }
 }

--- a/crypto/mldsa-lowmemory/tests/hash_mldsa_tests.rs
+++ b/crypto/mldsa-lowmemory/tests/hash_mldsa_tests.rs
@@ -6,7 +6,7 @@ mod hash_mldsa_tests {
     use super::*;
     use bouncycastle_core::errors::SignatureError;
     use bouncycastle_core::key_material::{KeyMaterial256, KeyType};
-    use bouncycastle_core::traits::{Hash, PHSignatureVerifier};
+    use bouncycastle_core::traits::{Hash, PHSignatureVerifier, PHSigner};
     use bouncycastle_core_test_framework::signature::TestFrameworkSignature;
     use bouncycastle_mldsa_lowmemory::{
         HashMLDSA44_with_SHA256, HashMLDSA44_with_SHA512, HashMLDSA65_with_SHA256,
@@ -233,5 +233,54 @@ mod hash_mldsa_tests {
             Err(SignatureError::LengthError(_)) => { /* good */ }
             _ => panic!("Expected error"),
         }
+    }
+
+    #[test]
+    fn algorithm_names_strengths_and_oids() {
+        use bouncycastle_core::traits::{Algorithm, AlgorithmOID, SecurityStrength};
+
+        // `Algorithm` is implemented once, generically over the pairing, so nothing else states
+        // these per algorithm.
+        assert_eq!(HashMLDSA44_with_SHA256::ALG_NAME, "HashML-DSA-44_with_SHA256");
+        assert_eq!(HashMLDSA65_with_SHA256::ALG_NAME, "HashML-DSA-65_with_SHA256");
+        assert_eq!(HashMLDSA87_with_SHA256::ALG_NAME, "HashML-DSA-87_with_SHA256");
+        assert_eq!(HashMLDSA44_with_SHA512::ALG_NAME, "HashML-DSA-44_with_SHA512");
+        assert_eq!(HashMLDSA65_with_SHA512::ALG_NAME, "HashML-DSA-65_with_SHA512");
+        assert_eq!(HashMLDSA87_with_SHA512::ALG_NAME, "HashML-DSA-87_with_SHA512");
+
+        // Derived as the weaker of the two components: SHA-256 caps every pairing it appears in at
+        // 128 bits; with SHA-512 the ML-DSA parameter set is what binds.
+        assert_eq!(HashMLDSA44_with_SHA256::MAX_SECURITY_STRENGTH, SecurityStrength::_128bit);
+        assert_eq!(HashMLDSA65_with_SHA256::MAX_SECURITY_STRENGTH, SecurityStrength::_128bit);
+        assert_eq!(HashMLDSA87_with_SHA256::MAX_SECURITY_STRENGTH, SecurityStrength::_128bit);
+        assert_eq!(HashMLDSA44_with_SHA512::MAX_SECURITY_STRENGTH, SecurityStrength::_128bit);
+        assert_eq!(HashMLDSA65_with_SHA512::MAX_SECURITY_STRENGTH, SecurityStrength::_192bit);
+        assert_eq!(HashMLDSA87_with_SHA512::MAX_SECURITY_STRENGTH, SecurityStrength::_256bit);
+
+        // NIST's Computer Security Objects Register: id-hash-ml-dsa-44-with-sha512 { sigAlgs 32 },
+        // -65- { sigAlgs 33 }, -87- { sigAlgs 34 }. The three SHA-256 pairings carry no OID in
+        // this implementation, which is why `AlgorithmOID` is still written out per alias rather
+        // than derived from the pairing like the name and strength above.
+        assert_eq!(HashMLDSA44_with_SHA512::OID, &[2, 16, 840, 1, 101, 3, 4, 3, 32]);
+        assert_eq!(HashMLDSA65_with_SHA512::OID, &[2, 16, 840, 1, 101, 3, 4, 3, 33]);
+        assert_eq!(HashMLDSA87_with_SHA512::OID, &[2, 16, 840, 1, 101, 3, 4, 3, 34]);
+    }
+
+    #[test]
+    fn prehash_lengths_match_the_hash_functions() {
+        // `PH_LEN` is still a const generic on `HashMLDSA` -- `PHSigner` takes it as one -- but it
+        // is derived on the pairing from the pre-hash's own `OUTPUT_LEN`, and the two are checked
+        // against each other at build time. This confirms both agree with the actual digest.
+        let msg = b"The quick brown fox";
+        let ph256: [u8; 32] = SHA256::default().hash(msg).try_into().unwrap();
+        let ph512: [u8; 64] = SHA512::default().hash(msg).try_into().unwrap();
+
+        let (pk, sk) = HashMLDSA65_with_SHA256::keygen().unwrap();
+        let sig = HashMLDSA65_with_SHA256::sign_ph(&sk, &ph256, None).unwrap();
+        HashMLDSA65_with_SHA256::verify_ph(&pk, &ph256, None, &sig).unwrap();
+
+        let (pk, sk) = HashMLDSA65_with_SHA512::keygen().unwrap();
+        let sig = HashMLDSA65_with_SHA512::sign_ph(&sk, &ph512, None).unwrap();
+        HashMLDSA65_with_SHA512::verify_ph(&pk, &ph512, None, &sig).unwrap();
     }
 }

--- a/crypto/mldsa-lowmemory/tests/hash_mldsa_tests.rs
+++ b/crypto/mldsa-lowmemory/tests/hash_mldsa_tests.rs
@@ -268,9 +268,11 @@ mod hash_mldsa_tests {
 
     #[test]
     fn prehash_lengths_match_the_hash_functions() {
-        // `PH_LEN` is still a const generic on `HashMLDSA` -- `PHSigner` takes it as one -- but it
-        // is derived on the pairing from the pre-hash's own `OUTPUT_LEN`, and the two are checked
-        // against each other at build time. This confirms both agree with the actual digest.
+        // `PH_LEN` is still a const generic on `HashMLDSA` -- `PHSigner` takes it as one -- but
+        // no alias hard-codes it: each passes `{ ...Params::PH_LEN }`, which is the pre-hash's own
+        // `HashAlgParams::OUTPUT_LEN`. So there is only one value, and nothing in the chain can
+        // disagree with itself. What is left to check is whether that value matches the digest
+        // the hash actually produces, which is what this test does.
         let msg = b"The quick brown fox";
         let ph256: [u8; 32] = SHA256::default().hash(msg).try_into().unwrap();
         let ph512: [u8; 64] = SHA512::default().hash(msg).try_into().unwrap();

--- a/crypto/mldsa-lowmemory/tests/hash_mldsa_tests.rs
+++ b/crypto/mldsa-lowmemory/tests/hash_mldsa_tests.rs
@@ -264,6 +264,19 @@ mod hash_mldsa_tests {
         assert_eq!(HashMLDSA44_with_SHA512::OID, &[2, 16, 840, 1, 101, 3, 4, 3, 32]);
         assert_eq!(HashMLDSA65_with_SHA512::OID, &[2, 16, 840, 1, 101, 3, 4, 3, 33]);
         assert_eq!(HashMLDSA87_with_SHA512::OID, &[2, 16, 840, 1, 101, 3, 4, 3, 34]);
+
+        for (oid, der) in [
+            (HashMLDSA44_with_SHA512::OID, HashMLDSA44_with_SHA512::OID_DER),
+            (HashMLDSA65_with_SHA512::OID, HashMLDSA65_with_SHA512::OID_DER),
+            (HashMLDSA87_with_SHA512::OID, HashMLDSA87_with_SHA512::OID_DER),
+        ] {
+            assert_eq!(der[0], 0x06, "DER tag must be OBJECT IDENTIFIER");
+            assert_eq!(der[1] as usize, der.len() - 2, "DER length must match the content");
+            assert_eq!(
+                &der[2..],
+                &[0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x03, *oid.last().unwrap() as u8]
+            );
+        }
     }
 
     #[test]

--- a/crypto/mldsa-lowmemory/tests/mldsa_tests.rs
+++ b/crypto/mldsa-lowmemory/tests/mldsa_tests.rs
@@ -907,6 +907,62 @@ mod mldsa_tests {
         MLDSA44::sign_mu_deterministic_out(&sk, &mu, [1u8; 32], &mut sig_buf).unwrap();
         MLDSA44::verify(&pk, msg, None, &sig_buf).unwrap();
     }
+
+    #[test]
+    fn algorithm_names_and_oids() {
+        use bouncycastle_core::traits::{Algorithm, AlgorithmOID};
+
+        // `Algorithm` and `AlgorithmOID` are implemented once, generically over the parameter set,
+        // so nothing else states these per algorithm. Pinned here so that a wrong wiring of the
+        // blanket impls, or a typo in a parameter set, is a test failure rather than a silently
+        // mislabelled algorithm or an unparseable OID.
+        assert_eq!(MLDSA44::ALG_NAME, "ML-DSA-44");
+        assert_eq!(MLDSA65::ALG_NAME, "ML-DSA-65");
+        assert_eq!(MLDSA87::ALG_NAME, "ML-DSA-87");
+
+        assert_eq!(MLDSA44::MAX_SECURITY_STRENGTH, SecurityStrength::_128bit);
+        assert_eq!(MLDSA65::MAX_SECURITY_STRENGTH, SecurityStrength::_192bit);
+        assert_eq!(MLDSA87::MAX_SECURITY_STRENGTH, SecurityStrength::_256bit);
+
+        // NIST's Computer Security Objects Register: id-ml-dsa-44 { sigAlgs 17 },
+        // id-ml-dsa-65 { sigAlgs 18 }, id-ml-dsa-87 { sigAlgs 19 }.
+        assert_eq!(MLDSA44::OID, &[2, 16, 840, 1, 101, 3, 4, 3, 17]);
+        assert_eq!(MLDSA65::OID, &[2, 16, 840, 1, 101, 3, 4, 3, 18]);
+        assert_eq!(MLDSA87::OID, &[2, 16, 840, 1, 101, 3, 4, 3, 19]);
+
+        for (oid, der) in [
+            (MLDSA44::OID, MLDSA44::OID_DER),
+            (MLDSA65::OID, MLDSA65::OID_DER),
+            (MLDSA87::OID, MLDSA87::OID_DER),
+        ] {
+            assert_eq!(der[0], 0x06, "DER tag must be OBJECT IDENTIFIER");
+            assert_eq!(der[1] as usize, der.len() - 2, "DER length must match the content");
+            assert_eq!(
+                &der[2..],
+                &[0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x03, *oid.last().unwrap() as u8]
+            );
+        }
+    }
+
+    #[test]
+    fn stored_private_key_is_the_seed_but_the_full_encoding_is_the_fips_one() {
+        // This crate is the seed-holding implementation, so `SK_LEN` is 32 for every parameter
+        // set while the parameter set's `FULL_SK_LEN` is FIPS 204, Table 2's private key column.
+        // The two are separate consts; this pins that they have not been conflated.
+        assert_eq!([MLDSA44_SK_LEN, MLDSA65_SK_LEN, MLDSA87_SK_LEN], [32, 32, 32]);
+        assert_eq!([MLDSA44_PK_LEN, MLDSA65_PK_LEN, MLDSA87_PK_LEN], [1312, 1952, 2592]);
+        assert_eq!([MLDSA44_SIG_LEN, MLDSA65_SIG_LEN, MLDSA87_SIG_LEN], [2420, 3309, 4627]);
+
+        // `FULL_SK_LEN` is not a public constant, so it is checked through the encoding it sizes.
+        let seed = KeyMaterial256::from_bytes_as_type(&[7u8; 32], KeyType::Seed).unwrap();
+        let (_, sk44) = MLDSA44::keygen_from_seed(&seed).unwrap();
+        let (_, sk65) = MLDSA65::keygen_from_seed(&seed).unwrap();
+        let (_, sk87) = MLDSA87::keygen_from_seed(&seed).unwrap();
+        assert_eq!(sk44.encode().len(), 32, "the stored private key is the seed");
+        assert_eq!(sk44.encode_full_sk().len(), 2560);
+        assert_eq!(sk65.encode_full_sk().len(), 4032);
+        assert_eq!(sk87.encode_full_sk().len(), 4896);
+    }
 }
 
 struct Kat {

--- a/crypto/mldsa/src/aux_functions.rs
+++ b/crypto/mldsa/src/aux_functions.rs
@@ -35,7 +35,7 @@ pub(crate) fn coeff_from_three_bytes(b: &[u8; 3]) -> Result<i32, ()> {
 /// Output: An integer between −𝜂 and 𝜂, or ⊥.
 #[inline(always)]
 pub(crate) fn coeff_from_half_byte<P: MLDSAParams>(b: u8) -> Result<i32, ()> {
-    if P::ETA == 2 && b < 15 {
+    if P::eta == 2 && b < 15 {
         // Original code is bad because '%' is not constant-time.
         // Ok(2 - (b % 5) as i32)
         // I'm still not convinced this is constant-time, but maybe it's closer? And I can't come up with anything better.
@@ -46,7 +46,7 @@ pub(crate) fn coeff_from_half_byte<P: MLDSAParams>(b: u8) -> Result<i32, ()> {
         };
         Ok(2 - b as i32)
     } else {
-        if P::ETA == 4 && b < 9 { Ok(4 - b as i32) } else { Err(()) }
+        if P::eta == 4 && b < 9 { Ok(4 - b as i32) } else { Err(()) }
     }
 }
 
@@ -66,16 +66,6 @@ pub(crate) fn simple_bit_pack_t1(w: &Polynomial) -> [u8; POLY_T1PACKED_LEN] {
     output
 }
 
-/// As defined in Algorithm 17, this gives the length of a packed bitstring representing a polynomial
-/// whose coefficients have been rounded to \[-eta, eta], which is 32*bitlen(2*eta).
-pub const fn bitlen_eta(eta: usize) -> usize {
-    match eta {
-        2 => 32 * 3,
-        4 => 32 * 4,
-        _ => panic!("Invalid eta value"),
-    }
-}
-
 /// A variant of Algorithm 17 BitPack specific to a=eta, b=eta
 /// Encodes a polynomial 𝑤 into a byte string.
 /// Input: 𝑎, 𝑏 ∈ ℕ and 𝑤 ∈ 𝑅 such that the coefficients of 𝑤 are all in \[−eta, eta].
@@ -85,12 +75,16 @@ pub const fn bitlen_eta(eta: usize) -> usize {
 // and optimize away the branching.
 #[inline(always)]
 pub(crate) fn bit_pack_eta<P: MLDSAParams>(w: &Polynomial, r: &mut [u8]) {
-    debug_assert!(r.len() >= bitlen_eta(P::ETA));
+    // `>=` rather than `==`: skEncode reuses one buffer sized for the largest 𝜂 across all three
+    // parameter sets and copies out only the first `POLY_ETA_PACKED_LEN` bytes, so for 𝜂 = 2 the
+    // buffer is deliberately longer than what gets written. Exactly that many bytes are written out
+    // either way, so this still catches an undersized buffer.
+    debug_assert!(r.len() >= P::POLY_ETA_PACKED_LEN);
 
     // temp swap space
     let mut t: [u8; 8] = [0; 8];
 
-    match P::ETA {
+    match P::eta {
         // MLDSA44 and MLDSA87
         2 => {
             let eta: i32 = 2;
@@ -171,16 +165,16 @@ pub(crate) fn bitpack_gamma1<P: MLDSAParams>(z: &Polynomial) -> P::PolyZPacked {
     let r = out.as_mut();
 
     let mut t: [u32; 4] = [0; 4];
-    // One layout per distinct 𝛾1 rather than one per parameter set; `P::GAMMA1` is a constant
+    // One layout per distinct 𝛾1 rather than one per parameter set; `P::gamma1` is a constant
     // after monomorphization, so only the matching arm survives.
-    match P::GAMMA1 {
+    match P::gamma1 {
         // MLDSA-44
         GAMMA1_2_POW_17 => {
             for i in 0..N / 4 {
-                t[0] = (P::GAMMA1 - z[4 * i]) as u32;
-                t[1] = (P::GAMMA1 - z[4 * i + 1]) as u32;
-                t[2] = (P::GAMMA1 - z[4 * i + 2]) as u32;
-                t[3] = (P::GAMMA1 - z[4 * i + 3]) as u32;
+                t[0] = (P::gamma1 - z[4 * i]) as u32;
+                t[1] = (P::gamma1 - z[4 * i + 1]) as u32;
+                t[2] = (P::gamma1 - z[4 * i + 2]) as u32;
+                t[3] = (P::gamma1 - z[4 * i + 3]) as u32;
 
                 r[9 * i] = t[0] as u8;
                 r[9 * i + 1] = (t[0] >> 8) as u8;
@@ -196,8 +190,8 @@ pub(crate) fn bitpack_gamma1<P: MLDSAParams>(z: &Polynomial) -> P::PolyZPacked {
         // MLDSA-65 and -87 have the same GAMMA1 value
         GAMMA1_2_POW_19 => {
             for i in 0..N / 2 {
-                t[0] = (P::GAMMA1 - z[2 * i]) as u32;
-                t[1] = (P::GAMMA1 - z[2 * i + 1]) as u32;
+                t[0] = (P::gamma1 - z[2 * i]) as u32;
+                t[1] = (P::gamma1 - z[2 * i + 1]) as u32;
 
                 r[5 * i] = t[0] as u8;
                 r[5 * i + 1] = (t[0] >> 8) as u8;
@@ -244,11 +238,11 @@ pub(crate) fn simple_bit_unpack_t1(v: &[u8; POLY_T1PACKED_LEN]) -> Polynomial {
 // and optimize away the branching.
 #[inline(always)]
 pub(crate) fn bit_unpack_eta<P: MLDSAParams>(v: &[u8]) -> Polynomial {
-    debug_assert_eq!(v.len(), bitlen_eta(P::ETA));
+    debug_assert_eq!(v.len(), P::POLY_ETA_PACKED_LEN);
 
     let mut w = Polynomial::new();
 
-    match P::ETA {
+    match P::eta {
         // MLDSA44 and MLDSA87
         2 => {
             let eta: i32 = 2;
@@ -336,7 +330,7 @@ pub(crate) fn bit_unpack_t0(a: &[u8; POLY_T0PACKED_LEN]) -> Polynomial {
 pub(crate) fn bit_unpack_gamma1<P: MLDSAParams>(v: &[u8]) -> Polynomial {
     let mut w = Polynomial::new();
 
-    match P::GAMMA1 {
+    match P::gamma1 {
         // MLDSA-44
         GAMMA1_2_POW_17 => {
             for i in 0..N / 4 {
@@ -353,10 +347,10 @@ pub(crate) fn bit_unpack_gamma1<P: MLDSAParams>(v: &[u8]) -> Polynomial {
                     | ((v[9 * i + 8] as i32) << 10))
                     & 0x3FFFF;
 
-                w[4 * i] = P::GAMMA1 - w[4 * i];
-                w[4 * i + 1] = P::GAMMA1 - w[4 * i + 1];
-                w[4 * i + 2] = P::GAMMA1 - w[4 * i + 2];
-                w[4 * i + 3] = P::GAMMA1 - w[4 * i + 3];
+                w[4 * i] = P::gamma1 - w[4 * i];
+                w[4 * i + 1] = P::gamma1 - w[4 * i + 1];
+                w[4 * i + 2] = P::gamma1 - w[4 * i + 2];
+                w[4 * i + 3] = P::gamma1 - w[4 * i + 3];
             }
         }
         // MLDSA-65 and -87 have the same GAMMA1 value
@@ -369,8 +363,8 @@ pub(crate) fn bit_unpack_gamma1<P: MLDSAParams>(v: &[u8]) -> Polynomial {
                     | ((v[5 * i + 4] as i32) << 12))
                     & 0xFFFFF;
 
-                w[2 * i] = P::GAMMA1 - w[2 * i];
-                w[2 * i + 1] = P::GAMMA1 - w[2 * i + 1];
+                w[2 * i] = P::gamma1 - w[2 * i];
+                w[2 * i + 1] = P::gamma1 - w[2 * i + 1];
             }
         }
         _ => {
@@ -416,7 +410,7 @@ pub(crate) fn sig_encode<P: MLDSAParams, const SIG_LEN: usize>(
                 output[pos + m] = j as u8;
                 m += 1;
             }
-            output[pos + P::OMEGA as usize + i] = m as u8;
+            output[pos + P::omega as usize + i] = m as u8;
         }
     }
 
@@ -458,8 +452,8 @@ pub(crate) fn sig_decode<P: MLDSAParams, const SIG_LEN: usize>(
         // 4: if 𝑦[𝜔 + 𝑖] < Index or 𝑦[𝜔 + 𝑖] > 𝜔 then return ⊥
         // todo: this needs a specific test for malformed signature values. Maybe crucible coveres this case?
         //  ... could hide an assert here and see if it triggers.
-        if sig[pos + (P::OMEGA as usize) + i] < (idx as u8)
-            || sig[pos + (P::OMEGA as usize) + i] > P::OMEGA as u8
+        if sig[pos + (P::omega as usize) + i] < (idx as u8)
+            || sig[pos + (P::omega as usize) + i] > P::omega as u8
         {
             return Err(());
         }
@@ -467,7 +461,7 @@ pub(crate) fn sig_decode<P: MLDSAParams, const SIG_LEN: usize>(
         // 6: First ← Index
         // 7: while Index < 𝑦[𝜔 + 𝑖] do
         //   ▷ 𝑦[𝜔 + 𝑖] says how far one can advance Index
-        for j in idx..sig[pos + P::OMEGA as usize + i] as usize {
+        for j in idx..sig[pos + P::omega as usize + i] as usize {
             // 8: if Index > First then
             // 9:   if 𝑦[Index − 1] ≥ 𝑦[Index] then return ⊥
             //       ▷ malformed input
@@ -481,11 +475,11 @@ pub(crate) fn sig_decode<P: MLDSAParams, const SIG_LEN: usize>(
             //  > done by for loop
         }
 
-        idx = sig[pos + P::OMEGA as usize + i] as usize;
+        idx = sig[pos + P::omega as usize + i] as usize;
     }
 
     // ▷ read any leftover bytes in the first 𝜔 bytes of 𝑦 for malformed (nonzero) bytes
-    for j in idx..P::OMEGA as usize {
+    for j in idx..P::omega as usize {
         if sig[pos + j] != 0 {
             return Err(());
         }
@@ -522,7 +516,7 @@ pub(crate) fn sample_in_ball<P: MLDSAParams>(rho: &P::SigCTilde) -> Polynomial {
     // let mut pos = 8;
     // let mut b;
     let mut j = [0u8];
-    for i in (N - P::TAU as usize)..N {
+    for i in (N - P::tau as usize)..N {
         // 7: (ctx, 𝑗) ← H.Squeeze(ctx, 1)
         // Note: Even though it may appear that pre-squeezing a buffer outside the loop would be faster,
         //       testing it both ways doesn't make a noticeable difference, so this has been left as is
@@ -786,7 +780,7 @@ pub(crate) fn decompose<P: MLDSAParams>(r: i32) -> (i32, i32) {
     let mut r1: i32;
     let mut r0 = (r + 127) >> 7;
 
-    match P::GAMMA2 {
+    match P::gamma2 {
         // MLDSA-44
         GAMMA2_Q_MINUS_1_OVER_88 => {
             // (q - 1) / 88
@@ -805,7 +799,7 @@ pub(crate) fn decompose<P: MLDSAParams>(r: i32) -> (i32, i32) {
         }
     }
 
-    r1 = r - r0 * 2 * P::GAMMA2;
+    r1 = r - r0 * 2 * P::gamma2;
 
     // mutants note: the choice of (q - 1) is a bit arbitrary in that after doing the bit-shifting,
     //  this seems to work out mathematically equivalent if doing q/2, or (q+3)/2, but here it is left as (q-1)/2
@@ -853,7 +847,7 @@ pub(crate) fn make_hint<P: MLDSAParams>(z: i32, r: i32) -> i32 {
 
     // By the powers of someone much more clever than me, this is equivalent.
     // mutants note: we do not have KATs that exercise all branches of this if
-    if z <= P::GAMMA2 || z > q - P::GAMMA2 || (z == q - P::GAMMA2 && r == 0) { 0 } else { 1 }
+    if z <= P::gamma2 || z > q - P::gamma2 || (z == q - P::gamma2 && r == 0) { 0 } else { 1 }
 }
 
 /// Creates the hint vector from two Vector<k>'s, and also returns its hamming weight (ie the number of 1's).
@@ -885,7 +879,7 @@ pub(super) fn use_hint<P: MLDSAParams>(a: i32, hint: i32) -> i32 {
 
     debug_assert!(hint == 1);
 
-    match P::GAMMA2 {
+    match P::gamma2 {
         GAMMA2_Q_MINUS_1_OVER_88 => {
             // mutants note: this passes unit tests if it's a1 >= 0
             //      it is left like this because it matches the spec

--- a/crypto/mldsa/src/aux_functions.rs
+++ b/crypto/mldsa/src/aux_functions.rs
@@ -914,9 +914,7 @@ pub(crate) fn use_hint_polys<P: MLDSAParams>(
 pub(crate) fn use_hint_vecs<P: MLDSAParams>(h: &P::VecK, wp_approx: &P::VecK) -> P::VecK {
     let mut out = P::VecK::new();
     for i in 0..P::k {
-        let hint = h.elems()[i];
-        let approx = wp_approx.elems()[i];
-        use_hint_polys::<P>(&approx, &hint, &mut out.elems_mut()[i]);
+        use_hint_polys::<P>(&wp_approx.elems()[i], &h.elems()[i], &mut out.elems_mut()[i]);
     }
 
     out

--- a/crypto/mldsa/src/aux_functions.rs
+++ b/crypto/mldsa/src/aux_functions.rs
@@ -1,14 +1,14 @@
 //! Implements auxiliary functions for ML-DSA as defined in Section 7 of FIPS 204.
 
-use crate::matrix::{Matrix, Vector};
-use crate::mldsa::{G, H, q_inv};
-use crate::mldsa::{
-    MLDSA44_GAMMA1, MLDSA44_GAMMA2, MLDSA65_GAMMA1, MLDSA65_GAMMA2, N, POLY_T0PACKED_LEN,
-    POLY_T1PACKED_LEN, d, q,
+use crate::matrix::{MatrixTrait, VectorTrait};
+use crate::mldsa::{G, H, N, POLY_T0PACKED_LEN, POLY_T1PACKED_LEN, d, q, q_inv};
+use crate::params::{
+    GAMMA1_2_POW_17, GAMMA1_2_POW_19, GAMMA2_Q_MINUS_1_OVER_32, GAMMA2_Q_MINUS_1_OVER_88,
+    MLDSAParams,
 };
 use crate::polynomial::Polynomial;
 use bouncycastle_core::traits::XOF;
-use bouncycastle_utils::secret::Secret;
+use bouncycastle_utils::secret::{Secret, ZeroizablePrimitive};
 
 /// Algorithm 14 CoeffFromThreeBytes(𝑏0, 𝑏1, 𝑏2)
 /// Output: An integer modulo 𝑞 or ⊥.
@@ -34,8 +34,8 @@ pub(crate) fn coeff_from_three_bytes(b: &[u8; 3]) -> Result<i32, ()> {
 /// Input: Integer 𝑏 ∈ {0, 1, … , 15}.
 /// Output: An integer between −𝜂 and 𝜂, or ⊥.
 #[inline(always)]
-pub(crate) fn coeff_from_half_byte<const ETA: usize>(b: u8) -> Result<i32, ()> {
-    if ETA == 2 && b < 15 {
+pub(crate) fn coeff_from_half_byte<P: MLDSAParams>(b: u8) -> Result<i32, ()> {
+    if P::ETA == 2 && b < 15 {
         // Original code is bad because '%' is not constant-time.
         // Ok(2 - (b % 5) as i32)
         // I'm still not convinced this is constant-time, but maybe it's closer? And I can't come up with anything better.
@@ -46,7 +46,7 @@ pub(crate) fn coeff_from_half_byte<const ETA: usize>(b: u8) -> Result<i32, ()> {
         };
         Ok(2 - b as i32)
     } else {
-        if ETA == 4 && b < 9 { Ok(4 - b as i32) } else { Err(()) }
+        if P::ETA == 4 && b < 9 { Ok(4 - b as i32) } else { Err(()) }
     }
 }
 
@@ -84,13 +84,13 @@ pub const fn bitlen_eta(eta: usize) -> usize {
 // the hope here is that the compiler will aggressively inline this function,
 // and optimize away the branching.
 #[inline(always)]
-pub(crate) fn bit_pack_eta<const ETA: usize>(w: &Polynomial, r: &mut [u8]) {
-    debug_assert!(r.len() >= bitlen_eta(ETA));
+pub(crate) fn bit_pack_eta<P: MLDSAParams>(w: &Polynomial, r: &mut [u8]) {
+    debug_assert!(r.len() >= bitlen_eta(P::ETA));
 
     // temp swap space
     let mut t: [u8; 8] = [0; 8];
 
-    match ETA {
+    match P::ETA {
         // MLDSA44 and MLDSA87
         2 => {
             let eta: i32 = 2;
@@ -166,19 +166,21 @@ pub(crate) fn bit_pack_t0(t0: &Polynomial) -> [u8; POLY_T0PACKED_LEN] {
 }
 
 /// A variant of Algorithm 17 specific to packing z in the signature value in \[−𝛾1 + 1, 𝛾1].
-pub(crate) fn bitpack_gamma1<const POLY_Z_PACKED_LEN: usize, const GAMMA1: i32>(
-    z: &Polynomial,
-) -> [u8; POLY_Z_PACKED_LEN] {
-    let mut r = [0u8; POLY_Z_PACKED_LEN];
+pub(crate) fn bitpack_gamma1<P: MLDSAParams>(z: &Polynomial) -> P::PolyZPacked {
+    let mut out = <P::PolyZPacked as ZeroizablePrimitive>::ZEROED;
+    let r = out.as_mut();
 
     let mut t: [u32; 4] = [0; 4];
-    match GAMMA1 {
-        MLDSA44_GAMMA1 => {
+    // One layout per distinct 𝛾1 rather than one per parameter set; `P::GAMMA1` is a constant
+    // after monomorphization, so only the matching arm survives.
+    match P::GAMMA1 {
+        // MLDSA-44
+        GAMMA1_2_POW_17 => {
             for i in 0..N / 4 {
-                t[0] = (GAMMA1 - z[4 * i]) as u32;
-                t[1] = (GAMMA1 - z[4 * i + 1]) as u32;
-                t[2] = (GAMMA1 - z[4 * i + 2]) as u32;
-                t[3] = (GAMMA1 - z[4 * i + 3]) as u32;
+                t[0] = (P::GAMMA1 - z[4 * i]) as u32;
+                t[1] = (P::GAMMA1 - z[4 * i + 1]) as u32;
+                t[2] = (P::GAMMA1 - z[4 * i + 2]) as u32;
+                t[3] = (P::GAMMA1 - z[4 * i + 3]) as u32;
 
                 r[9 * i] = t[0] as u8;
                 r[9 * i + 1] = (t[0] >> 8) as u8;
@@ -191,11 +193,11 @@ pub(crate) fn bitpack_gamma1<const POLY_Z_PACKED_LEN: usize, const GAMMA1: i32>(
                 r[9 * i + 8] = (t[3] >> 10) as u8;
             }
         }
-        // MLDSA-65 and 87 have the same GAMMA1 value
-        MLDSA65_GAMMA1 => {
+        // MLDSA-65 and -87 have the same GAMMA1 value
+        GAMMA1_2_POW_19 => {
             for i in 0..N / 2 {
-                t[0] = (GAMMA1 - z[2 * i]) as u32;
-                t[1] = (GAMMA1 - z[2 * i + 1]) as u32;
+                t[0] = (P::GAMMA1 - z[2 * i]) as u32;
+                t[1] = (P::GAMMA1 - z[2 * i + 1]) as u32;
 
                 r[5 * i] = t[0] as u8;
                 r[5 * i + 1] = (t[0] >> 8) as u8;
@@ -209,7 +211,7 @@ pub(crate) fn bitpack_gamma1<const POLY_Z_PACKED_LEN: usize, const GAMMA1: i32>(
         }
     }
 
-    r
+    out
 }
 
 /// A specific instantiation of Algorithm 18 SimpleBitUnpack(v, 𝑏) with the constants set for unpacking the t1 vector
@@ -241,12 +243,12 @@ pub(crate) fn simple_bit_unpack_t1(v: &[u8; POLY_T1PACKED_LEN]) -> Polynomial {
 // the hope here is that the compiler will aggressively inline this function,
 // and optimize away the branching.
 #[inline(always)]
-pub(crate) fn bit_unpack_eta<const ETA: usize>(v: &[u8]) -> Polynomial {
-    debug_assert_eq!(v.len(), bitlen_eta(ETA));
+pub(crate) fn bit_unpack_eta<P: MLDSAParams>(v: &[u8]) -> Polynomial {
+    debug_assert_eq!(v.len(), bitlen_eta(P::ETA));
 
     let mut w = Polynomial::new();
 
-    match ETA {
+    match P::ETA {
         // MLDSA44 and MLDSA87
         2 => {
             let eta: i32 = 2;
@@ -331,11 +333,12 @@ pub(crate) fn bit_unpack_t0(a: &[u8; POLY_T0PACKED_LEN]) -> Polynomial {
 /// When 𝑎 + 𝑏 + 1 is a power of 2, the coefficients are in [−𝑎, 𝑏].
 ///
 /// Note: caller is responsible for ensuring correct input array size
-pub(crate) fn bit_unpack_gamma1<const GAMMA1: i32>(v: &[u8]) -> Polynomial {
+pub(crate) fn bit_unpack_gamma1<P: MLDSAParams>(v: &[u8]) -> Polynomial {
     let mut w = Polynomial::new();
 
-    match GAMMA1 {
-        MLDSA44_GAMMA1 => {
+    match P::GAMMA1 {
+        // MLDSA-44
+        GAMMA1_2_POW_17 => {
             for i in 0..N / 4 {
                 w[4 * i] = (((v[9 * i] as i32) | ((v[9 * i + 1] as i32) << 8))
                     | ((v[9 * i + 2] as i32) << 16))
@@ -350,14 +353,14 @@ pub(crate) fn bit_unpack_gamma1<const GAMMA1: i32>(v: &[u8]) -> Polynomial {
                     | ((v[9 * i + 8] as i32) << 10))
                     & 0x3FFFF;
 
-                w[4 * i] = GAMMA1 - w[4 * i];
-                w[4 * i + 1] = GAMMA1 - w[4 * i + 1];
-                w[4 * i + 2] = GAMMA1 - w[4 * i + 2];
-                w[4 * i + 3] = GAMMA1 - w[4 * i + 3];
+                w[4 * i] = P::GAMMA1 - w[4 * i];
+                w[4 * i + 1] = P::GAMMA1 - w[4 * i + 1];
+                w[4 * i + 2] = P::GAMMA1 - w[4 * i + 2];
+                w[4 * i + 3] = P::GAMMA1 - w[4 * i + 3];
             }
         }
-        // MLDSA-65 and 87 have the same GAMMA1 value
-        MLDSA65_GAMMA1 => {
+        // MLDSA-65 and -87 have the same GAMMA1 value
+        GAMMA1_2_POW_19 => {
             for i in 0..N / 2 {
                 w[2 * i] = (((v[5 * i] as i32) | ((v[5 * i + 1] as i32) << 8))
                     | ((v[5 * i + 2] as i32) << 16))
@@ -366,8 +369,8 @@ pub(crate) fn bit_unpack_gamma1<const GAMMA1: i32>(v: &[u8]) -> Polynomial {
                     | ((v[5 * i + 4] as i32) << 12))
                     & 0xFFFFF;
 
-                w[2 * i] = GAMMA1 - w[2 * i];
-                w[2 * i + 1] = GAMMA1 - w[2 * i + 1];
+                w[2 * i] = P::GAMMA1 - w[2 * i];
+                w[2 * i + 1] = P::GAMMA1 - w[2 * i + 1];
             }
         }
         _ => {
@@ -384,43 +387,36 @@ pub(crate) fn bit_unpack_gamma1<const GAMMA1: i32>(v: &[u8]) -> Polynomial {
 /// Output: Signature 𝜎 ∈ 𝔹𝜆/4+ℓ⋅32⋅(1+bitlen (𝛾1−1))+𝜔+𝑘.
 ///
 /// Returns the number of bytes written to the output buffer.
-pub(crate) fn sig_encode<
-    const GAMMA1: i32,
-    const k: usize,
-    const l: usize,
-    const LAMBDA_over_4: usize,
-    const OMEGA: i32,
-    const POLY_Z_PACKED_LEN: usize,
-    const SIG_LEN: usize,
->(
-    c_tilde: &[u8; LAMBDA_over_4],
-    z: &Vector<l>,
-    h: &Vector<k>,
+pub(crate) fn sig_encode<P: MLDSAParams, const SIG_LEN: usize>(
+    c_tilde: &P::SigCTilde,
+    z: &P::VecL,
+    h: &P::VecK,
     output: &mut [u8; SIG_LEN],
 ) -> usize {
+    debug_assert_eq!(SIG_LEN, P::SIG_LEN);
     output.fill(0);
 
     let mut pos = 0;
 
-    output[..LAMBDA_over_4].copy_from_slice(c_tilde);
-    pos += LAMBDA_over_4;
+    output[..P::C_TILDE_LEN].copy_from_slice(c_tilde.as_ref());
+    pos += P::C_TILDE_LEN;
 
-    for i in 0..l {
-        output[pos..pos + POLY_Z_PACKED_LEN]
-            .copy_from_slice(&bitpack_gamma1::<POLY_Z_PACKED_LEN, GAMMA1>(&z.elems[i]));
-        pos += POLY_Z_PACKED_LEN;
+    for i in 0..P::l {
+        output[pos..pos + P::POLY_Z_PACKED_LEN]
+            .copy_from_slice(bitpack_gamma1::<P>(&z.elems()[i]).as_ref());
+        pos += P::POLY_Z_PACKED_LEN;
     }
 
     // This inlines Algorithm 20 HintBitPack(𝐡)
 
     let mut m: usize = 0;
-    for i in 0..k {
+    for i in 0..P::k {
         for j in 0..N {
-            if h.elems[i][j] != 0 {
+            if h.elems()[i][j] != 0 {
                 output[pos + m] = j as u8;
                 m += 1;
             }
-            output[pos + OMEGA as usize + i] = m as u8;
+            output[pos + P::OMEGA as usize + i] = m as u8;
         }
     }
 
@@ -432,29 +428,22 @@ pub(crate) fn sig_encode<
 /// Input: Signature 𝜎 ∈ 𝔹𝜆/4+ℓ⋅32⋅(1+bitlen (𝛾1−1))+𝜔+𝑘.
 /// Output: 𝑐 ∈ 𝔹𝜆/4, 𝐳 ∈ 𝑅ℓ with coefficients in \[−𝛾1 + 1, 𝛾1], 𝐡 ∈ 𝑅𝑘, or ⊥.
 ///   Output: (c_tilde, z, h)
-pub(crate) fn sig_decode<
-    const GAMMA1: i32,
-    const k: usize,
-    const l: usize,
-    const LAMBDA_over_4: usize,
-    const OMEGA: i32,
-    const POLY_Z_PACKED_LEN: usize,
-    const SIG_LEN: usize,
->(
+pub(crate) fn sig_decode<P: MLDSAParams, const SIG_LEN: usize>(
     sig: &[u8; SIG_LEN],
-) -> Result<([u8; LAMBDA_over_4], Vector<l>, Vector<k>), ()> {
-    let mut c_tilde = [0u8; LAMBDA_over_4];
-    let mut z: Vector<l> = Vector::<l>::new();
-    let mut h: Vector<k> = Vector::<k>::new();
+) -> Result<(P::SigCTilde, P::VecL, P::VecK), ()> {
+    debug_assert_eq!(SIG_LEN, P::SIG_LEN);
+    let mut c_tilde = <P::SigCTilde as ZeroizablePrimitive>::ZEROED;
+    let mut z = P::VecL::new();
+    let mut h = P::VecK::new();
 
     let mut pos: usize = 0;
 
-    c_tilde.copy_from_slice(&sig[..LAMBDA_over_4]);
-    pos += LAMBDA_over_4;
+    c_tilde.as_mut().copy_from_slice(&sig[..P::C_TILDE_LEN]);
+    pos += P::C_TILDE_LEN;
 
-    for i in 0..l {
-        z.elems[i] = bit_unpack_gamma1::<GAMMA1>(&sig[pos..pos + POLY_Z_PACKED_LEN]);
-        pos += POLY_Z_PACKED_LEN;
+    for i in 0..P::l {
+        z.elems_mut()[i] = bit_unpack_gamma1::<P>(&sig[pos..pos + P::POLY_Z_PACKED_LEN]);
+        pos += P::POLY_Z_PACKED_LEN;
     }
 
     // This inlines Algorithm 21 HintBitUnpack(𝑦)
@@ -465,12 +454,12 @@ pub(crate) fn sig_decode<
 
     // 3: for 𝑖 from 0 to 𝑘 − 1 do
     //  ▷ reconstruct 𝐡[𝑖]
-    for i in 0..k {
+    for i in 0..P::k {
         // 4: if 𝑦[𝜔 + 𝑖] < Index or 𝑦[𝜔 + 𝑖] > 𝜔 then return ⊥
         // todo: this needs a specific test for malformed signature values. Maybe crucible coveres this case?
         //  ... could hide an assert here and see if it triggers.
-        if sig[pos + (OMEGA as usize) + i] < (idx as u8)
-            || sig[pos + (OMEGA as usize) + i] > OMEGA as u8
+        if sig[pos + (P::OMEGA as usize) + i] < (idx as u8)
+            || sig[pos + (P::OMEGA as usize) + i] > P::OMEGA as u8
         {
             return Err(());
         }
@@ -478,7 +467,7 @@ pub(crate) fn sig_decode<
         // 6: First ← Index
         // 7: while Index < 𝑦[𝜔 + 𝑖] do
         //   ▷ 𝑦[𝜔 + 𝑖] says how far one can advance Index
-        for j in idx..sig[pos + OMEGA as usize + i] as usize {
+        for j in idx..sig[pos + P::OMEGA as usize + i] as usize {
             // 8: if Index > First then
             // 9:   if 𝑦[Index − 1] ≥ 𝑦[Index] then return ⊥
             //       ▷ malformed input
@@ -486,17 +475,17 @@ pub(crate) fn sig_decode<
                 return Err(());
             }
             // 12: 𝐡[𝑖]_𝑦[Index] ← 1
-            h.elems[i][sig[pos + j] as usize] = 1;
+            h.elems_mut()[i][sig[pos + j] as usize] = 1;
 
             // 13: Index ← Index + 1
             //  > done by for loop
         }
 
-        idx = sig[pos + OMEGA as usize + i] as usize;
+        idx = sig[pos + P::OMEGA as usize + i] as usize;
     }
 
     // ▷ read any leftover bytes in the first 𝜔 bytes of 𝑦 for malformed (nonzero) bytes
-    for j in idx..OMEGA as usize {
+    for j in idx..P::OMEGA as usize {
         if sig[pos + j] != 0 {
             return Err(());
         }
@@ -509,9 +498,7 @@ pub(crate) fn sig_decode<
 /// Samples a polynomial 𝑐 ∈ 𝑅 with coefficients from {−1, 0, 1} and Hamming weight 𝜏 ≤ 64.
 /// Input: A seed 𝜌 ∈ 𝔹𝜆/4
 /// Output: A polynomial 𝑐 in 𝑅.
-pub(crate) fn sample_in_ball<const LAMBDA_over_4: usize, const TAU: i32>(
-    rho: &[u8; LAMBDA_over_4],
-) -> Polynomial {
+pub(crate) fn sample_in_ball<P: MLDSAParams>(rho: &P::SigCTilde) -> Polynomial {
     // 1: 𝑐 ← 0
     let mut c = Polynomial::new();
 
@@ -519,7 +506,7 @@ pub(crate) fn sample_in_ball<const LAMBDA_over_4: usize, const TAU: i32>(
     // 3: ctx ← H.Absorb(ctx, 𝜌)
     // 4: (ctx, 𝑠) ← H.Squeeze(ctx, 8)
     let mut h = H::new();
-    h.absorb(rho).expect("absorb before squeeze is infallible");
+    h.absorb(rho.as_ref()).expect("absorb before squeeze is infallible");
     let mut s = [0u8; 8];
     h.squeeze_out(&mut s);
 
@@ -535,7 +522,7 @@ pub(crate) fn sample_in_ball<const LAMBDA_over_4: usize, const TAU: i32>(
     // let mut pos = 8;
     // let mut b;
     let mut j = [0u8];
-    for i in (N - TAU as usize)..N {
+    for i in (N - P::TAU as usize)..N {
         // 7: (ctx, 𝑗) ← H.Squeeze(ctx, 1)
         // Note: Even though it may appear that pre-squeezing a buffer outside the loop would be faster,
         //       testing it both ways doesn't make a noticeable difference, so this has been left as is
@@ -624,7 +611,7 @@ pub(crate) fn rej_ntt_poly(rho: &[u8; 32], nonce: &[u8; 2]) -> Polynomial {
 /// This is supposed to take a rho: [u8; 66], which is: 𝜌||IntegerToBytes(𝑠, 1)||IntegerToBytes(𝑟, 1)
 /// but to avoid needing to copy bytes and allocate more memory,
 /// that is split into a [u8;64] and a [u8;2]
-pub(crate) fn rej_bounded_poly<const ETA: usize>(rho: &[u8; 64], nonce: &[u8; 2]) -> Polynomial {
+pub(crate) fn rej_bounded_poly<P: MLDSAParams>(rho: &[u8; 64], nonce: &[u8; 2]) -> Polynomial {
     let mut a = Polynomial::new();
     let mut j: usize = 0;
     let mut h = H::new();
@@ -640,8 +627,8 @@ pub(crate) fn rej_bounded_poly<const ETA: usize>(rho: &[u8; 64], nonce: &[u8; 2]
     let mut idx: usize = 0;
 
     while j < N {
-        let z0 = coeff_from_half_byte::<ETA>(z_arr[idx] & 0x0F); // equiv to % 16 (but faster, and more importantly, constant-time)
-        let z1 = coeff_from_half_byte::<ETA>(z_arr[idx] >> 4); // equiv to div_floor(16) (but faster, and more importantly, constant-time)
+        let z0 = coeff_from_half_byte::<P>(z_arr[idx] & 0x0F); // equiv to % 16 (but faster, and more importantly, constant-time)
+        let z1 = coeff_from_half_byte::<P>(z_arr[idx] >> 4); // equiv to div_floor(16) (but faster, and more importantly, constant-time)
 
         if z0.is_ok() {
             a[j] = z0.unwrap();
@@ -667,12 +654,12 @@ pub(crate) fn rej_bounded_poly<const ETA: usize>(rho: &[u8; 64], nonce: &[u8; 2]
 /// in other words: derives the public matrix from the public seed.
 /// Input: A seed 𝜌 ∈ 𝔹32 .̂
 /// Output: Matrix Â ∈ (𝑇𝑞)𝑘×ℓ .
-pub(crate) fn expandA<const k: usize, const l: usize>(rho: &[u8; 32]) -> Matrix<k, l> {
-    let mut A_hat = Matrix::<k, l>::new();
+pub(crate) fn expandA<P: MLDSAParams>(rho: &[u8; 32]) -> P::MatrixA {
+    let mut A_hat = P::MatrixA::new();
 
-    for r in 0..k {
-        for s in 0..l {
-            A_hat.elems[r][s] = rej_ntt_poly(rho, &[s as u8, r as u8]);
+    for r in 0..P::k {
+        for s in 0..P::l {
+            A_hat.set_elem(r, s, rej_ntt_poly(rho, &[s as u8, r as u8]));
         }
     }
 
@@ -685,18 +672,16 @@ pub(crate) fn expandA<const k: usize, const l: usize>(rho: &[u8; 32]) -> Matrix<
 /// Input: A seed 𝜌 ∈ 𝔹64 .
 /// Output: Vectors 𝐬1, 𝐬2 of secret polynomials in 𝑅
 /// Note that this returns Secret<Vector<k>> because s1, s2 are always part of a private key.
-pub(crate) fn expandS<const k: usize, const l: usize, const ETA: usize>(
-    rho: &[u8; 64],
-) -> (Secret<Vector<l>>, Secret<Vector<k>>) {
-    let mut s1: Secret<Vector<l>> = Secret::new();
-    let mut s2: Secret<Vector<k>> = Secret::new();
+pub(crate) fn expandS<P: MLDSAParams>(rho: &[u8; 64]) -> (Secret<P::VecL>, Secret<P::VecK>) {
+    let mut s1: Secret<P::VecL> = Secret::new();
+    let mut s2: Secret<P::VecK> = Secret::new();
 
-    for r in 0..l {
-        s1.elems[r] = rej_bounded_poly::<ETA>(rho, &(r as u16).to_le_bytes());
+    for r in 0..P::l {
+        s1.elems_mut()[r] = rej_bounded_poly::<P>(rho, &(r as u16).to_le_bytes());
     }
 
-    for r in 0..k {
-        s2.elems[r] = rej_bounded_poly::<ETA>(rho, &(r as u16 + l as u16).to_le_bytes());
+    for r in 0..P::k {
+        s2.elems_mut()[r] = rej_bounded_poly::<P>(rho, &(r as u16 + P::l as u16).to_le_bytes());
     }
 
     (s1, s2)
@@ -704,13 +689,13 @@ pub(crate) fn expandS<const k: usize, const l: usize, const ETA: usize>(
 
 /// Implements the meta-function described in FIPS 204 section 7.4 for applying power_2_round to a vector.
 /// ((𝐫1\[𝑖])𝑗, (𝐫0\[𝑖])𝑗) = Power2Round((𝐫\[𝑖])𝑗).
-pub(crate) fn power_2_round_vec<const LEN: usize>(v: &Vector<LEN>) -> (Vector<LEN>, Vector<LEN>) {
-    let mut r1 = Vector::<LEN>::new();
-    let mut r0 = Vector::<LEN>::new();
+pub(crate) fn power_2_round_vec<V: VectorTrait>(v: &V) -> (V, V) {
+    let mut r1 = V::new();
+    let mut r0 = V::new();
 
-    for i in 0..LEN {
+    for i in 0..V::LEN {
         for j in 0..N {
-            (r1.elems[i][j], r0.elems[i][j]) = power_2_round(v.elems[i][j]);
+            (r1.elems_mut()[i][j], r0.elems_mut()[i][j]) = power_2_round(v.elems()[i][j]);
         }
     }
 
@@ -721,17 +706,15 @@ pub(crate) fn power_2_round_vec<const LEN: usize>(v: &Vector<LEN>) -> (Vector<LE
 /// Samples a vector 𝐲 ∈ 𝑅ℓ such that each polynomial 𝐲[𝑟] has coefficients between −𝛾1 + 1 and 𝛾1.
 /// Input: A seed 𝜌 ∈ 𝔹64 and a nonnegative integer 𝜇.
 /// Output: Vector 𝐲 ∈ 𝑅ℓ .
-pub(crate) fn expand_mask<const l: usize, const GAMMA1: i32, const GAMMA1_MASK_LEN: usize>(
-    rho: &[u8; 64],
-    mu: u16,
-) -> Vector<l> {
-    let mut y = Vector::<l>::new();
+pub(crate) fn expand_mask<P: MLDSAParams>(rho: &[u8; 64], mu: u16) -> P::VecL {
+    let mut y = P::VecL::new();
 
     // 1: 𝑐 ← 1 + bitlen (𝛾1 − 1)
     //  ▷ 𝛾1 is always a power of 2
-    // 32c = GAMMA1_MASK_LEN;
+    // The 32𝑐 bytes squeezed on line 4 are exactly `P::POLY_Z_PACKED_LEN`, so the buffer for them
+    // is `P::PolyZPacked`; see the docs on [`MLDSAParams::POLY_Z_PACKED_LEN`].
 
-    for r in 0..l {
+    for r in 0..P::l {
         // 3: 𝜌′ ← 𝜌||IntegerToBytes(𝜇 + 𝑟, 2)
         // 4: 𝑣 ← H(𝜌′, 32𝑐)
         let v = {
@@ -739,13 +722,13 @@ pub(crate) fn expand_mask<const l: usize, const GAMMA1: i32, const GAMMA1_MASK_L
             h.absorb(rho).expect("absorb before squeeze is infallible");
             h.absorb(&(mu + (r as u16)).to_le_bytes())
                 .expect("absorb before squeeze is infallible");
-            let mut v = [0u8; GAMMA1_MASK_LEN];
-            h.squeeze_out(&mut v);
+            let mut v = <P::PolyZPacked as ZeroizablePrimitive>::ZEROED;
+            h.squeeze_out(v.as_mut());
             v
         };
 
         // 5: 𝐲[𝑟] ← BitUnpack(𝑣, 𝛾1 − 1, 𝛾1)
-        y.elems[r] = bit_unpack_gamma1::<GAMMA1>(&v);
+        y.elems_mut()[r] = bit_unpack_gamma1::<P>(v.as_ref());
     }
 
     y
@@ -788,7 +771,7 @@ fn test_power_2_round() {
 /// Decomposes 𝑟 into (𝑟1, 𝑟0) such that 𝑟 ≡ 𝑟1(2𝛾2) + 𝑟0 mod 𝑞.
 /// Input: 𝑟 ∈ ℤ𝑞.
 /// Output: Integers (𝑟1, 𝑟0).
-pub(crate) fn decompose<const GAMMA2: i32>(r: i32) -> (i32, i32) {
+pub(crate) fn decompose<P: MLDSAParams>(r: i32) -> (i32, i32) {
     // 1: 𝑟+ ← 𝑟 mod 𝑞
     // 2: 𝑟0 ← 𝑟+ mod±(2𝛾2)
     // 3: if 𝑟+ − 𝑟0 = 𝑞 − 1 then
@@ -803,14 +786,15 @@ pub(crate) fn decompose<const GAMMA2: i32>(r: i32) -> (i32, i32) {
     let mut r1: i32;
     let mut r0 = (r + 127) >> 7;
 
-    match GAMMA2 {
-        MLDSA44_GAMMA2 => {
+    match P::GAMMA2 {
+        // MLDSA-44
+        GAMMA2_Q_MINUS_1_OVER_88 => {
             // (q - 1) / 88
             r0 = (r0 * 11275 + (1 << 23)) >> 24;
             r0 ^= ((43 - r0) >> 31) & r0;
         }
-        // ML-DSA65 and 87 have the same GAMMA2
-        MLDSA65_GAMMA2 => {
+        // ML-DSA-65 and -87 have the same GAMMA2
+        GAMMA2_Q_MINUS_1_OVER_32 => {
             // (q - 1) / 32;
             r0 = (r0 * 1025 + (1 << 21)) >> 22;
             r0 &= 15;
@@ -821,7 +805,7 @@ pub(crate) fn decompose<const GAMMA2: i32>(r: i32) -> (i32, i32) {
         }
     }
 
-    r1 = r - r0 * 2 * GAMMA2;
+    r1 = r - r0 * 2 * P::GAMMA2;
 
     // mutants note: the choice of (q - 1) is a bit arbitrary in that after doing the bit-shifting,
     //  this seems to work out mathematically equivalent if doing q/2, or (q+3)/2, but here it is left as (q-1)/2
@@ -835,10 +819,10 @@ pub(crate) fn decompose<const GAMMA2: i32>(r: i32) -> (i32, i32) {
 /// Returns 𝑟1 from the output of Decompose (𝑟).
 /// Input: 𝑟 ∈ ℤ𝑞.
 /// Output: Integer 𝑟1.
-pub(crate) fn high_bits<const GAMMA2: i32>(r: i32) -> i32 {
+pub(crate) fn high_bits<P: MLDSAParams>(r: i32) -> i32 {
     // 1: (𝑟1, 𝑟0) ← Decompose(𝑟)
     // 2: return 𝑟1
-    let (r1, _) = decompose::<GAMMA2>(r);
+    let (r1, _) = decompose::<P>(r);
     r1
 }
 
@@ -846,10 +830,10 @@ pub(crate) fn high_bits<const GAMMA2: i32>(r: i32) -> i32 {
 /// Returns 𝑟0 from the output of Decompose (𝑟).
 /// Input: 𝑟 ∈ ℤ𝑞.
 /// Output: Integer 𝑟0.
-pub(crate) fn low_bits<const GAMMA2: i32>(r: i32) -> i32 {
+pub(crate) fn low_bits<P: MLDSAParams>(r: i32) -> i32 {
     // 1: (𝑟1, 𝑟0) ← Decompose(𝑟)
     // 2: return 𝑟0
-    let (_, r0) = decompose::<GAMMA2>(r);
+    let (_, r0) = decompose::<P>(r);
     r0
 }
 
@@ -857,32 +841,29 @@ pub(crate) fn low_bits<const GAMMA2: i32>(r: i32) -> i32 {
 /// Computes hint bit indicating whether adding 𝑧 to 𝑟 alters the high bits of 𝑟.
 /// Input: 𝑧, 𝑟 ∈ ℤ𝑞.
 /// Output: Boolean.
-pub(crate) fn make_hint<const GAMMA2: i32>(z: i32, r: i32) -> i32 {
+pub(crate) fn make_hint<P: MLDSAParams>(z: i32, r: i32) -> i32 {
     // // 1: 𝑟1 ← HighBits(𝑟)
-    // let r1 = high_bits::<GAMMA2>(r);
+    // let r1 = high_bits::<P>(r);
     //
     // // 2: 𝑣1 ← HighBits(𝑟 + 𝑧)
-    // let v1 = high_bits::<GAMMA2>(r + z);
+    // let v1 = high_bits::<P>(r + z);
     //
     // // 3: return [[𝑟1 ≠ 𝑣1]]
     // if r1 != v1 { 1 } else { 0 }
 
     // By the powers of someone much more clever than me, this is equivalent.
     // mutants note: we do not have KATs that exercise all branches of this if
-    if z <= GAMMA2 || z > q - GAMMA2 || (z == q - GAMMA2 && r == 0) { 0 } else { 1 }
+    if z <= P::GAMMA2 || z > q - P::GAMMA2 || (z == q - P::GAMMA2 && r == 0) { 0 } else { 1 }
 }
 
 /// Creates the hint vector from two Vector<k>'s, and also returns its hamming weight (ie the number of 1's).
-pub(crate) fn make_hint_vecs<const k: usize, const GAMMA2: i32>(
-    r: &Vector<k>,
-    s: &Vector<k>,
-) -> (Vector<k>, i32) {
-    let mut out = Vector::<k>::new();
+pub(crate) fn make_hint_vecs<P: MLDSAParams>(r: &P::VecK, s: &P::VecK) -> (P::VecK, i32) {
+    let mut out = P::VecK::new();
     let mut count = 0i32;
 
-    for i in 0..k {
-        let (w, c) = r.elems[i].make_hint::<GAMMA2>(&s.elems[i]);
-        out.elems[i] = w;
+    for i in 0..P::k {
+        let (w, c) = r.elems()[i].make_hint::<P>(&s.elems()[i]);
+        out.elems_mut()[i] = w;
 
         // mutants note: this chains up to hint_hamming_weight > OMEGA and there is no test KAT that triggers this branch
         count += c;
@@ -895,8 +876,8 @@ pub(crate) fn make_hint_vecs<const k: usize, const GAMMA2: i32>(
 /// Returns the high bits of 𝑟 adjusted according to hint ℎ.
 /// Input: Boolean ℎ, 𝑟 ∈ ℤ𝑞.
 /// Output: 𝑟1 ∈ ℤ with 0 ≤ 𝑟1 ≤ (𝑞−1) / 2*gamma2).
-pub(super) fn use_hint<const GAMMA2: i32>(a: i32, hint: i32) -> i32 {
-    let (a0, a1) = decompose::<GAMMA2>(a);
+pub(super) fn use_hint<P: MLDSAParams>(a: i32, hint: i32) -> i32 {
+    let (a0, a1) = decompose::<P>(a);
 
     if hint == 0 {
         return a0;
@@ -904,8 +885,8 @@ pub(super) fn use_hint<const GAMMA2: i32>(a: i32, hint: i32) -> i32 {
 
     debug_assert!(hint == 1);
 
-    match GAMMA2 {
-        MLDSA44_GAMMA2 => {
+    match P::GAMMA2 {
+        GAMMA2_Q_MINUS_1_OVER_88 => {
             // mutants note: this passes unit tests if it's a1 >= 0
             //      it is left like this because it matches the spec
             if a1 > 0 {
@@ -915,7 +896,7 @@ pub(super) fn use_hint<const GAMMA2: i32>(a: i32, hint: i32) -> i32 {
             }
         }
         // ML-DSA65 and 87 have the same GAMMA2
-        MLDSA65_GAMMA2 => {
+        GAMMA2_Q_MINUS_1_OVER_32 => {
             // mutants note: this passes unit tests if it's a1 >= 0
             //      it is left like this because it matches the spec
             if a1 > 0 { (a0 + 1) & 15 } else { (a0 - 1) & 15 }
@@ -926,23 +907,22 @@ pub(super) fn use_hint<const GAMMA2: i32>(a: i32, hint: i32) -> i32 {
     }
 }
 
-pub(crate) fn use_hint_polys<const GAMMA2: i32>(
+pub(crate) fn use_hint_polys<P: MLDSAParams>(
     wp_approx: &Polynomial,
     h: &Polynomial,
     out: &mut Polynomial,
 ) {
     for i in 0..N {
-        out[i] = use_hint::<GAMMA2>(wp_approx[i], h[i]);
+        out[i] = use_hint::<P>(wp_approx[i], h[i]);
     }
 }
 
-pub(crate) fn use_hint_vecs<const k: usize, const GAMMA2: i32>(
-    h: &Vector<k>,
-    wp_approx: &Vector<k>,
-) -> Vector<k> {
-    let mut out = Vector::<k>::new();
-    for i in 0..k {
-        use_hint_polys::<GAMMA2>(&wp_approx.elems[i], &h.elems[i], &mut out.elems[i]);
+pub(crate) fn use_hint_vecs<P: MLDSAParams>(h: &P::VecK, wp_approx: &P::VecK) -> P::VecK {
+    let mut out = P::VecK::new();
+    for i in 0..P::k {
+        let hint = h.elems()[i];
+        let approx = wp_approx.elems()[i];
+        use_hint_polys::<P>(&approx, &hint, &mut out.elems_mut()[i]);
     }
 
     out

--- a/crypto/mldsa/src/hash_mldsa.rs
+++ b/crypto/mldsa/src/hash_mldsa.rs
@@ -66,29 +66,19 @@
 //! But a simple [`HashMLDSA::keygen`] is provided.
 
 use crate::mldsa::{H, MLDSA_MU_LEN, MLDSA_RND_LEN, MLDSATrait};
-use crate::mldsa::{
-    MLDSA44_BETA, MLDSA44_C_TILDE, MLDSA44_ETA, MLDSA44_GAMMA1, MLDSA44_GAMMA1_MASK_LEN,
-    MLDSA44_GAMMA1_MINUS_BETA, MLDSA44_GAMMA2, MLDSA44_GAMMA2_MINUS_BETA, MLDSA44_LAMBDA,
-    MLDSA44_LAMBDA_over_4, MLDSA44_OMEGA, MLDSA44_PK_LEN, MLDSA44_POLY_W1_PACKED_LEN,
-    MLDSA44_POLY_Z_PACKED_LEN, MLDSA44_SIG_LEN, MLDSA44_SK_LEN, MLDSA44_TAU, MLDSA44_k, MLDSA44_l,
-};
-use crate::mldsa::{
-    MLDSA65_BETA, MLDSA65_C_TILDE, MLDSA65_ETA, MLDSA65_GAMMA1, MLDSA65_GAMMA1_MASK_LEN,
-    MLDSA65_GAMMA1_MINUS_BETA, MLDSA65_GAMMA2, MLDSA65_GAMMA2_MINUS_BETA, MLDSA65_LAMBDA,
-    MLDSA65_LAMBDA_over_4, MLDSA65_OMEGA, MLDSA65_PK_LEN, MLDSA65_POLY_W1_PACKED_LEN,
-    MLDSA65_POLY_Z_PACKED_LEN, MLDSA65_SIG_LEN, MLDSA65_SK_LEN, MLDSA65_TAU, MLDSA65_k, MLDSA65_l,
-};
-use crate::mldsa::{
-    MLDSA87_BETA, MLDSA87_C_TILDE, MLDSA87_ETA, MLDSA87_GAMMA1, MLDSA87_GAMMA1_MASK_LEN,
-    MLDSA87_GAMMA1_MINUS_BETA, MLDSA87_GAMMA2, MLDSA87_GAMMA2_MINUS_BETA, MLDSA87_LAMBDA,
-    MLDSA87_LAMBDA_over_4, MLDSA87_OMEGA, MLDSA87_PK_LEN, MLDSA87_POLY_W1_PACKED_LEN,
-    MLDSA87_POLY_Z_PACKED_LEN, MLDSA87_SIG_LEN, MLDSA87_SK_LEN, MLDSA87_TAU, MLDSA87_k, MLDSA87_l,
-};
+use crate::mldsa::{MLDSA44_PK_LEN, MLDSA44_SIG_LEN, MLDSA44_SK_LEN};
+use crate::mldsa::{MLDSA65_PK_LEN, MLDSA65_SIG_LEN, MLDSA65_SK_LEN};
+use crate::mldsa::{MLDSA87_PK_LEN, MLDSA87_SIG_LEN, MLDSA87_SK_LEN};
 use crate::mldsa_keys::{MLDSAPrivateKeyInternalTrait, MLDSAPublicKeyInternalTrait};
+use crate::params::{
+    HashMLDSA44_with_SHA256Params, HashMLDSA44_with_SHA512Params, HashMLDSA65_with_SHA256Params,
+    HashMLDSA65_with_SHA512Params, HashMLDSA87_with_SHA256Params, HashMLDSA87_with_SHA512Params,
+    HashMLDSAParams, MLDSAParams,
+};
 use crate::{
     MLDSA, MLDSA44PrivateKey, MLDSA44PublicKey, MLDSA65PrivateKey, MLDSA65PublicKey,
     MLDSA87PrivateKey, MLDSA87PublicKey, MLDSAPrivateKeyExpanded, MLDSAPrivateKeyTrait,
-    MLDSAPublicKeyExpanded, MLDSAPublicKeyTrait, Matrix,
+    MLDSAPublicKeyExpanded, MLDSAPublicKeyTrait,
 };
 use bouncycastle_core::errors::SignatureError;
 use bouncycastle_core::key_material::KeyMaterial;
@@ -97,7 +87,6 @@ use bouncycastle_core::traits::{
     SignatureVerifier, Signer, XOF,
 };
 use bouncycastle_rng::HashDRBG_SHA512;
-use bouncycastle_sha2::{SHA256, SHA512};
 use core::marker::PhantomData;
 
 // Imports needed only for docs
@@ -124,134 +113,50 @@ pub const HASH_ML_DSA_87_WITH_SHA512_NAME: &str = "HashML-DSA-87_with_SHA512";
 /// The HashML-DSA-44_with_SHA512 signature algorithm.
 #[allow(non_camel_case_types)]
 pub type HashMLDSA44_with_SHA256 = HashMLDSA<
-    SHA256,
+    HashMLDSA44_with_SHA256Params,
+    MLDSA44PublicKey,
+    MLDSA44PrivateKey,
     32,
     MLDSA44_PK_LEN,
     MLDSA44_SK_LEN,
     MLDSA44_SIG_LEN,
-    MLDSA44PublicKey,
-    MLDSA44PrivateKey,
-    MLDSA44_TAU,
-    MLDSA44_LAMBDA,
-    MLDSA44_GAMMA1,
-    MLDSA44_GAMMA2,
-    MLDSA44_k,
-    MLDSA44_l,
-    MLDSA44_ETA,
-    MLDSA44_BETA,
-    MLDSA44_OMEGA,
-    MLDSA44_C_TILDE,
-    MLDSA44_POLY_Z_PACKED_LEN,
-    MLDSA44_POLY_W1_PACKED_LEN,
-    MLDSA44_LAMBDA_over_4,
-    MLDSA44_GAMMA1_MINUS_BETA,
-    MLDSA44_GAMMA2_MINUS_BETA,
-    MLDSA44_GAMMA1_MASK_LEN,
 >;
-
-impl Algorithm for HashMLDSA44_with_SHA256 {
-    const ALG_NAME: &'static str = HASH_ML_DSA_44_with_SHA256_NAME;
-    const MAX_SECURITY_STRENGTH: SecurityStrength = SecurityStrength::_128bit;
-}
 
 /// The HashML-DSA-65_with_SHA256 signature algorithm.
 #[allow(non_camel_case_types)]
 pub type HashMLDSA65_with_SHA256 = HashMLDSA<
-    SHA256,
+    HashMLDSA65_with_SHA256Params,
+    MLDSA65PublicKey,
+    MLDSA65PrivateKey,
     32,
     MLDSA65_PK_LEN,
     MLDSA65_SK_LEN,
     MLDSA65_SIG_LEN,
-    MLDSA65PublicKey,
-    MLDSA65PrivateKey,
-    MLDSA65_TAU,
-    MLDSA65_LAMBDA,
-    MLDSA65_GAMMA1,
-    MLDSA65_GAMMA2,
-    MLDSA65_k,
-    MLDSA65_l,
-    MLDSA65_ETA,
-    MLDSA65_BETA,
-    MLDSA65_OMEGA,
-    MLDSA65_C_TILDE,
-    MLDSA65_POLY_Z_PACKED_LEN,
-    MLDSA65_POLY_W1_PACKED_LEN,
-    MLDSA65_LAMBDA_over_4,
-    MLDSA65_GAMMA1_MINUS_BETA,
-    MLDSA65_GAMMA2_MINUS_BETA,
-    MLDSA65_GAMMA1_MASK_LEN,
 >;
-
-impl Algorithm for HashMLDSA65_with_SHA256 {
-    const ALG_NAME: &'static str = HASH_ML_DSA_65_WITH_SHA256_NAME;
-    const MAX_SECURITY_STRENGTH: SecurityStrength = SecurityStrength::_128bit;
-}
 
 /// The HashML-DSA-87_with_SHA256 signature algorithm.
 #[allow(non_camel_case_types)]
 pub type HashMLDSA87_with_SHA256 = HashMLDSA<
-    SHA256,
+    HashMLDSA87_with_SHA256Params,
+    MLDSA87PublicKey,
+    MLDSA87PrivateKey,
     32,
     MLDSA87_PK_LEN,
     MLDSA87_SK_LEN,
     MLDSA87_SIG_LEN,
-    MLDSA87PublicKey,
-    MLDSA87PrivateKey,
-    MLDSA87_TAU,
-    MLDSA87_LAMBDA,
-    MLDSA87_GAMMA1,
-    MLDSA87_GAMMA2,
-    MLDSA87_k,
-    MLDSA87_l,
-    MLDSA87_ETA,
-    MLDSA87_BETA,
-    MLDSA87_OMEGA,
-    MLDSA87_C_TILDE,
-    MLDSA87_POLY_Z_PACKED_LEN,
-    MLDSA87_POLY_W1_PACKED_LEN,
-    MLDSA87_LAMBDA_over_4,
-    MLDSA87_GAMMA1_MINUS_BETA,
-    MLDSA87_GAMMA2_MINUS_BETA,
-    MLDSA87_GAMMA1_MASK_LEN,
 >;
-
-impl Algorithm for HashMLDSA87_with_SHA256 {
-    const ALG_NAME: &'static str = HASH_ML_DSA_87_with_SHA256_NAME;
-    const MAX_SECURITY_STRENGTH: SecurityStrength = SecurityStrength::_128bit;
-}
 
 /// The HashML-DSA-44_with_SHA512 signature algorithm.
 #[allow(non_camel_case_types)]
 pub type HashMLDSA44_with_SHA512 = HashMLDSA<
-    SHA512,
+    HashMLDSA44_with_SHA512Params,
+    MLDSA44PublicKey,
+    MLDSA44PrivateKey,
     64,
     MLDSA44_PK_LEN,
     MLDSA44_SK_LEN,
     MLDSA44_SIG_LEN,
-    MLDSA44PublicKey,
-    MLDSA44PrivateKey,
-    MLDSA44_TAU,
-    MLDSA44_LAMBDA,
-    MLDSA44_GAMMA1,
-    MLDSA44_GAMMA2,
-    MLDSA44_k,
-    MLDSA44_l,
-    MLDSA44_ETA,
-    MLDSA44_BETA,
-    MLDSA44_OMEGA,
-    MLDSA44_C_TILDE,
-    MLDSA44_POLY_Z_PACKED_LEN,
-    MLDSA44_POLY_W1_PACKED_LEN,
-    MLDSA44_LAMBDA_over_4,
-    MLDSA44_GAMMA1_MINUS_BETA,
-    MLDSA44_GAMMA2_MINUS_BETA,
-    MLDSA44_GAMMA1_MASK_LEN,
 >;
-
-impl Algorithm for HashMLDSA44_with_SHA512 {
-    const ALG_NAME: &'static str = HASH_ML_DSA_44_with_SHA512_NAME;
-    const MAX_SECURITY_STRENGTH: SecurityStrength = SecurityStrength::_128bit;
-}
 /// Assigned by NIST in the Computer Security Objects Register: id-hash-ml-dsa-44-with-sha512 { sigAlgs 32 }
 impl AlgorithmOID for HashMLDSA44_with_SHA512 {
     const OID: &'static [u32] = &[2, 16, 840, 1, 101, 3, 4, 3, 32];
@@ -262,35 +167,14 @@ impl AlgorithmOID for HashMLDSA44_with_SHA512 {
 /// The HashML-DSA-65_with_SHA512 signature algorithm.
 #[allow(non_camel_case_types)]
 pub type HashMLDSA65_with_SHA512 = HashMLDSA<
-    SHA512,
+    HashMLDSA65_with_SHA512Params,
+    MLDSA65PublicKey,
+    MLDSA65PrivateKey,
     64,
     MLDSA65_PK_LEN,
     MLDSA65_SK_LEN,
     MLDSA65_SIG_LEN,
-    MLDSA65PublicKey,
-    MLDSA65PrivateKey,
-    MLDSA65_TAU,
-    MLDSA65_LAMBDA,
-    MLDSA65_GAMMA1,
-    MLDSA65_GAMMA2,
-    MLDSA65_k,
-    MLDSA65_l,
-    MLDSA65_ETA,
-    MLDSA65_BETA,
-    MLDSA65_OMEGA,
-    MLDSA65_C_TILDE,
-    MLDSA65_POLY_Z_PACKED_LEN,
-    MLDSA65_POLY_W1_PACKED_LEN,
-    MLDSA65_LAMBDA_over_4,
-    MLDSA65_GAMMA1_MINUS_BETA,
-    MLDSA65_GAMMA2_MINUS_BETA,
-    MLDSA65_GAMMA1_MASK_LEN,
 >;
-
-impl Algorithm for HashMLDSA65_with_SHA512 {
-    const ALG_NAME: &'static str = HASH_ML_DSA_65_WITH_SHA512_NAME;
-    const MAX_SECURITY_STRENGTH: SecurityStrength = SecurityStrength::_192bit;
-}
 /// Assigned by NIST in the Computer Security Objects Register: id-hash-ml-dsa-65-with-sha512 { sigAlgs 33 }
 impl AlgorithmOID for HashMLDSA65_with_SHA512 {
     const OID: &'static [u32] = &[2, 16, 840, 1, 101, 3, 4, 3, 33];
@@ -301,40 +185,34 @@ impl AlgorithmOID for HashMLDSA65_with_SHA512 {
 /// The HashML-DSA-87_with_SHA512 signature algorithm.
 #[allow(non_camel_case_types)]
 pub type HashMLDSA87_with_SHA512 = HashMLDSA<
-    SHA512,
+    HashMLDSA87_with_SHA512Params,
+    MLDSA87PublicKey,
+    MLDSA87PrivateKey,
     64,
     MLDSA87_PK_LEN,
     MLDSA87_SK_LEN,
     MLDSA87_SIG_LEN,
-    MLDSA87PublicKey,
-    MLDSA87PrivateKey,
-    MLDSA87_TAU,
-    MLDSA87_LAMBDA,
-    MLDSA87_GAMMA1,
-    MLDSA87_GAMMA2,
-    MLDSA87_k,
-    MLDSA87_l,
-    MLDSA87_ETA,
-    MLDSA87_BETA,
-    MLDSA87_OMEGA,
-    MLDSA87_C_TILDE,
-    MLDSA87_POLY_Z_PACKED_LEN,
-    MLDSA87_POLY_W1_PACKED_LEN,
-    MLDSA87_LAMBDA_over_4,
-    MLDSA87_GAMMA1_MINUS_BETA,
-    MLDSA87_GAMMA2_MINUS_BETA,
-    MLDSA87_GAMMA1_MASK_LEN,
 >;
-
-impl Algorithm for HashMLDSA87_with_SHA512 {
-    const ALG_NAME: &'static str = HASH_ML_DSA_87_WITH_SHA512_NAME;
-    const MAX_SECURITY_STRENGTH: SecurityStrength = SecurityStrength::_256bit;
-}
 /// Assigned by NIST in the Computer Security Objects Register: id-hash-ml-dsa-87-with-sha512 { sigAlgs 34 }
 impl AlgorithmOID for HashMLDSA87_with_SHA512 {
     const OID: &'static [u32] = &[2, 16, 840, 1, 101, 3, 4, 3, 34];
     const OID_DER: &'static [u8] =
         &[0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x03, 0x22];
+}
+
+impl<
+    HP: HashMLDSAParams,
+    PK: MLDSAPublicKeyTrait<HP::MLDSA, PK_LEN> + MLDSAPublicKeyInternalTrait<HP::MLDSA, PK_LEN>,
+    SK: MLDSAPrivateKeyTrait<HP::MLDSA, SK_LEN, PK_LEN>
+        + MLDSAPrivateKeyInternalTrait<HP::MLDSA, SK_LEN, PK_LEN>,
+    const PH_LEN: usize,
+    const PK_LEN: usize,
+    const SK_LEN: usize,
+    const SIG_LEN: usize,
+> Algorithm for HashMLDSA<HP, PK, SK, PH_LEN, PK_LEN, SK_LEN, SIG_LEN>
+{
+    const ALG_NAME: &'static str = HP::ALG_NAME;
+    const MAX_SECURITY_STRENGTH: SecurityStrength = HP::MAX_SECURITY_STRENGTH;
 }
 
 /// An instance of the HashML-DSA algorithm.
@@ -344,32 +222,16 @@ impl AlgorithmOID for HashMLDSA87_with_SHA512 {
 /// by specifying the hash function to use (in the verifier), and specifying the bytes of the OID to
 /// to use as its domain separator in constructing the message representative M'.
 pub struct HashMLDSA<
-    HASH: Hash + AlgorithmOID + Default,
-    const HASH_LEN: usize,
+    HP: HashMLDSAParams,
+    PK: MLDSAPublicKeyTrait<HP::MLDSA, PK_LEN> + MLDSAPublicKeyInternalTrait<HP::MLDSA, PK_LEN>,
+    SK: MLDSAPrivateKeyTrait<HP::MLDSA, SK_LEN, PK_LEN>
+        + MLDSAPrivateKeyInternalTrait<HP::MLDSA, SK_LEN, PK_LEN>,
+    const PH_LEN: usize,
     const PK_LEN: usize,
     const SK_LEN: usize,
     const SIG_LEN: usize,
-    PK: MLDSAPublicKeyTrait<k, l, PK_LEN> + MLDSAPublicKeyInternalTrait<k, PK_LEN>,
-    SK: MLDSAPrivateKeyTrait<k, l, ETA, SK_LEN, PK_LEN>
-        + MLDSAPrivateKeyInternalTrait<k, l, ETA, SK_LEN, PK_LEN>,
-    const TAU: i32,
-    const LAMBDA: i32,
-    const GAMMA1: i32,
-    const GAMMA2: i32,
-    const k: usize,
-    const l: usize,
-    const ETA: usize,
-    const BETA: i32,
-    const OMEGA: i32,
-    const C_TILDE: usize,
-    const POLY_Z_PACKED_LEN: usize,
-    const POLY_W1_PACKED_LEN: usize,
-    const LAMBDA_over_4: usize,
-    const GAMMA1_MINUS_BETA: i32,
-    const GAMMA2_MINUS_BETA: i32,
-    const GAMMA1_MASK_LEN: usize,
 > {
-    _phantom: PhantomData<(PK, SK)>,
+    _phantom: PhantomData<(HP, PK, SK)>,
 
     signer_rnd: Option<[u8; MLDSA_RND_LEN]>,
 
@@ -383,7 +245,7 @@ pub struct HashMLDSA<
     pk: Option<PK>,
 
     /// Hash function instance for streaming message hashing
-    hash: HASH,
+    hash: HP::PreHash,
 
     /// Since HashML-DSA does message buffering in the external pre-hash, not in mu,
     /// this needs to be saved for later
@@ -392,56 +254,15 @@ pub struct HashMLDSA<
 }
 
 impl<
-    HASH: Hash + AlgorithmOID + Default,
+    HP: HashMLDSAParams,
+    PK: MLDSAPublicKeyTrait<HP::MLDSA, PK_LEN> + MLDSAPublicKeyInternalTrait<HP::MLDSA, PK_LEN>,
+    SK: MLDSAPrivateKeyTrait<HP::MLDSA, SK_LEN, PK_LEN>
+        + MLDSAPrivateKeyInternalTrait<HP::MLDSA, SK_LEN, PK_LEN>,
     const PH_LEN: usize,
     const PK_LEN: usize,
     const SK_LEN: usize,
     const SIG_LEN: usize,
-    PK: MLDSAPublicKeyTrait<k, l, PK_LEN> + MLDSAPublicKeyInternalTrait<k, PK_LEN>,
-    SK: MLDSAPrivateKeyTrait<k, l, ETA, SK_LEN, PK_LEN>
-        + MLDSAPrivateKeyInternalTrait<k, l, ETA, SK_LEN, PK_LEN>,
-    const TAU: i32,
-    const LAMBDA: i32,
-    const GAMMA1: i32,
-    const GAMMA2: i32,
-    const k: usize,
-    const l: usize,
-    const ETA: usize,
-    const BETA: i32,
-    const OMEGA: i32,
-    const C_TILDE: usize,
-    const POLY_Z_PACKED_LEN: usize,
-    const POLY_W1_PACKED_LEN: usize,
-    const LAMBDA_over_4: usize,
-    const GAMMA1_MASK_LEN: usize,
-    const GAMMA1_MINUS_BETA: i32,
-    const GAMMA2_MINUS_BETA: i32,
->
-    HashMLDSA<
-        HASH,
-        PH_LEN,
-        PK_LEN,
-        SK_LEN,
-        SIG_LEN,
-        PK,
-        SK,
-        TAU,
-        LAMBDA,
-        GAMMA1,
-        GAMMA2,
-        k,
-        l,
-        ETA,
-        BETA,
-        OMEGA,
-        C_TILDE,
-        POLY_Z_PACKED_LEN,
-        POLY_W1_PACKED_LEN,
-        LAMBDA_over_4,
-        GAMMA1_MINUS_BETA,
-        GAMMA2_MINUS_BETA,
-        GAMMA1_MASK_LEN,
-    >
+> HashMLDSA<HP, PK, SK, PH_LEN, PK_LEN, SK_LEN, SIG_LEN>
 {
     /// Generate a keypair, sourcing randomness from bouncycastle's default os-backed RNG.
     ///
@@ -450,60 +271,16 @@ impl<
     /// Keygen, and keys in general, are interchangeable between MLDSA and HashMLDSA.
     /// Error condition: basically only on RNG failures.
     pub fn keygen() -> Result<(PK, SK), SignatureError> {
-        MLDSA::<
-            PK_LEN,
-            SK_LEN,
-            SIG_LEN,
-            PK,
-            SK,
-            TAU,
-            LAMBDA,
-            GAMMA1,
-            GAMMA2,
-            k,
-            l,
-            ETA,
-            BETA,
-            OMEGA,
-            C_TILDE,
-            POLY_Z_PACKED_LEN,
-            POLY_W1_PACKED_LEN,
-            LAMBDA_over_4,
-            GAMMA1_MINUS_BETA,
-            GAMMA2_MINUS_BETA,
-            GAMMA1_MASK_LEN,
-        >::keygen()
+        MLDSA::<HP::MLDSA, PK, SK, PK_LEN, SK_LEN, SIG_LEN>::keygen()
     }
 
     /// Imports a secret key from a seed.
     pub fn keygen_from_seed(seed: &KeyMaterial<32>) -> Result<(PK, SK), SignatureError> {
-        MLDSA::<
-            PK_LEN,
-            SK_LEN,
-            SIG_LEN,
-            PK,
-            SK,
-            TAU,
-            LAMBDA,
-            GAMMA1,
-            GAMMA2,
-            k,
-            l,
-            ETA,
-            BETA,
-            OMEGA,
-            C_TILDE,
-            POLY_Z_PACKED_LEN,
-            POLY_W1_PACKED_LEN,
-            LAMBDA_over_4,
-            GAMMA1_MINUS_BETA,
-            GAMMA2_MINUS_BETA,
-            GAMMA1_MASK_LEN,
-        >::keygen_internal(seed)
+        MLDSA::<HP::MLDSA, PK, SK, PK_LEN, SK_LEN, SIG_LEN>::keygen_internal(seed)
     }
     /// Same as [`Signer::sign`], but signs from an [`MLDSAPrivateKeyExpanded`].
     pub fn sign_with_expanded_key(
-        sk: &MLDSAPrivateKeyExpanded<k, l, ETA, PK, SK, SK_LEN, PK_LEN>,
+        sk: &MLDSAPrivateKeyExpanded<HP::MLDSA, PK, SK, SK_LEN, PK_LEN>,
         msg: &[u8],
         ctx: Option<&[u8]>,
     ) -> Result<[u8; SIG_LEN], SignatureError> {
@@ -514,7 +291,7 @@ impl<
     }
     /// Same as [`Signer::sign_out`], but signs from an [`MLDSAPrivateKeyExpanded`].
     pub fn sign_with_expanded_key_out(
-        sk: &MLDSAPrivateKeyExpanded<k, l, ETA, PK, SK, SK_LEN, PK_LEN>,
+        sk: &MLDSAPrivateKeyExpanded<HP::MLDSA, PK, SK, SK_LEN, PK_LEN>,
         msg: &[u8],
         ctx: Option<&[u8]>,
         output: &mut [u8; SIG_LEN],
@@ -522,12 +299,12 @@ impl<
         output.fill(0);
 
         let mut ph_m = [0u8; PH_LEN];
-        _ = HASH::default().hash_out(msg, &mut ph_m);
+        _ = <HP::PreHash as Default>::default().hash_out(msg, &mut ph_m);
         Self::sign_ph_with_expanded_key_out(sk, &ph_m, ctx, output)
     }
     /// Same as [`PHSigner::sign_ph`], but signs from an [`MLDSAPrivateKeyExpanded`].
     pub fn sign_ph_with_expanded_key(
-        sk: &MLDSAPrivateKeyExpanded<k, l, ETA, PK, SK, SK_LEN, PK_LEN>,
+        sk: &MLDSAPrivateKeyExpanded<HP::MLDSA, PK, SK, SK_LEN, PK_LEN>,
         ph: &[u8; PH_LEN],
         ctx: Option<&[u8]>,
     ) -> Result<[u8; SIG_LEN], SignatureError> {
@@ -538,7 +315,7 @@ impl<
     }
     /// Same as [`PHSigner::sign_ph_out`], but signs from an [`MLDSAPrivateKeyExpanded`].
     pub fn sign_ph_with_expanded_key_out(
-        sk: &MLDSAPrivateKeyExpanded<k, l, ETA, PK, SK, SK_LEN, PK_LEN>,
+        sk: &MLDSAPrivateKeyExpanded<HP::MLDSA, PK, SK, SK_LEN, PK_LEN>,
         ph: &[u8; PH_LEN],
         ctx: Option<&[u8]>,
         output: &mut [u8; SIG_LEN],
@@ -564,7 +341,7 @@ impl<
     /// prevent accidental nonce reuse, this function moves `rnd`.
     pub fn sign_ph_deterministic(
         sk: &SK,
-        A_hat: Option<&Matrix<k, l>>,
+        A_hat: Option<&<HP::MLDSA as MLDSAParams>::MatrixA>,
         ctx: Option<&[u8]>,
         ph: &[u8; PH_LEN],
         rnd: [u8; 32],
@@ -587,7 +364,7 @@ impl<
     /// Returns the number of bytes written to the output buffer. Can be called with an oversized buffer.
     pub fn sign_ph_deterministic_out(
         sk: &SK,
-        A_hat: Option<&Matrix<k, l>>,
+        A_hat: Option<&<HP::MLDSA as MLDSAParams>::MatrixA>,
         ctx: Option<&[u8]>,
         ph: &[u8; PH_LEN],
         rnd: [u8; 32],
@@ -615,7 +392,8 @@ impl<
             h.absorb(&[1u8]).expect("absorb before squeeze is infallible");
             h.absorb(&[ctx.len() as u8]).expect("absorb before squeeze is infallible");
             h.absorb(ctx).expect("absorb before squeeze is infallible");
-            h.absorb(HASH::OID_DER).expect("absorb before squeeze is infallible");
+            h.absorb(<HP::PreHash as AlgorithmOID>::OID_DER)
+                .expect("absorb before squeeze is infallible");
             h.absorb(ph).expect("absorb before squeeze is infallible");
             let mut mu = [0u8; MLDSA_MU_LEN];
             let bytes_written = h.squeeze_out(&mut mu);
@@ -625,29 +403,10 @@ impl<
         };
 
         // 24: 𝜎 ← ML-DSA.Sign_internal(𝑠𝑘, 𝑀', 𝑟𝑛𝑑)
-        let bytes_written = MLDSA::<
-            PK_LEN,
-            SK_LEN,
-            SIG_LEN,
-            PK,
-            SK,
-            TAU,
-            LAMBDA,
-            GAMMA1,
-            GAMMA2,
-            k,
-            l,
-            ETA,
-            BETA,
-            OMEGA,
-            C_TILDE,
-            POLY_Z_PACKED_LEN,
-            POLY_W1_PACKED_LEN,
-            LAMBDA_over_4,
-            GAMMA1_MINUS_BETA,
-            GAMMA2_MINUS_BETA,
-            GAMMA1_MASK_LEN,
-        >::sign_mu_deterministic_out(sk, A_hat, &mu, rnd, output)?;
+        let bytes_written =
+            MLDSA::<HP::MLDSA, PK, SK, PK_LEN, SK_LEN, SIG_LEN>::sign_mu_deterministic_out(
+                sk, A_hat, &mu, rnd, output,
+            )?;
 
         Ok(bytes_written)
     }
@@ -688,27 +447,27 @@ impl<
             sk: None,
             seed: Some(seed.clone()),
             pk: None,
-            hash: HASH::default(),
+            hash: <HP::PreHash as Default>::default(),
             ctx,
             ctx_len,
         })
     }
     /// Same as [`SignatureVerifier::verify`], but verifies from an [`MLDSAPublicKeyExpanded`].
     pub fn verify_with_expanded_key(
-        pk: &MLDSAPublicKeyExpanded<k, l, PK, PK_LEN>,
+        pk: &MLDSAPublicKeyExpanded<HP::MLDSA, PK, PK_LEN>,
         msg: &[u8],
         ctx: Option<&[u8]>,
         sig: &[u8],
     ) -> Result<(), SignatureError> {
         let mut ph_m = [0u8; PH_LEN];
-        _ = HASH::default().hash_out(msg, &mut ph_m);
+        _ = <HP::PreHash as Default>::default().hash_out(msg, &mut ph_m);
 
         Self::verify_ph_internal(&pk.pk, Some(&pk.A_hat()), &ph_m, ctx, sig)
     }
 
     fn verify_ph_internal(
         pk: &PK,
-        A_hat: Option<&Matrix<k, l>>,
+        A_hat: Option<&<HP::MLDSA as MLDSAParams>::MatrixA>,
         ph: &[u8; PH_LEN],
         ctx: Option<&[u8]>,
         sig: &[u8],
@@ -738,7 +497,8 @@ impl<
             h.absorb(&[1u8]).expect("absorb before squeeze is infallible");
             h.absorb(&[ctx.len() as u8]).expect("absorb before squeeze is infallible");
             h.absorb(ctx).expect("absorb before squeeze is infallible");
-            h.absorb(HASH::OID_DER).expect("absorb before squeeze is infallible");
+            h.absorb(<HP::PreHash as AlgorithmOID>::OID_DER)
+                .expect("absorb before squeeze is infallible");
             h.absorb(ph).expect("absorb before squeeze is infallible");
             let mut mu = [0u8; MLDSA_MU_LEN];
             _ = h.squeeze_out(&mut mu);
@@ -747,107 +507,32 @@ impl<
         };
 
         match A_hat {
-            Some(A_hat) => MLDSA::<
-                PK_LEN,
-                SK_LEN,
-                SIG_LEN,
-                PK,
-                SK,
-                TAU,
-                LAMBDA,
-                GAMMA1,
-                GAMMA2,
-                k,
-                l,
-                ETA,
-                BETA,
-                OMEGA,
-                C_TILDE,
-                POLY_Z_PACKED_LEN,
-                POLY_W1_PACKED_LEN,
-                LAMBDA_over_4,
-                GAMMA1_MINUS_BETA,
-                GAMMA2_MINUS_BETA,
-                GAMMA1_MASK_LEN,
-            >::verify_mu(pk, Some(A_hat), &mu, sig_sized),
-            None => MLDSA::<
-                PK_LEN,
-                SK_LEN,
-                SIG_LEN,
-                PK,
-                SK,
-                TAU,
-                LAMBDA,
-                GAMMA1,
-                GAMMA2,
-                k,
-                l,
-                ETA,
-                BETA,
-                OMEGA,
-                C_TILDE,
-                POLY_Z_PACKED_LEN,
-                POLY_W1_PACKED_LEN,
-                LAMBDA_over_4,
-                GAMMA1_MINUS_BETA,
-                GAMMA2_MINUS_BETA,
-                GAMMA1_MASK_LEN,
-            >::verify_mu(pk, Some(&pk.A_hat()), &mu, sig_sized),
+            Some(A_hat) => MLDSA::<HP::MLDSA, PK, SK, PK_LEN, SK_LEN, SIG_LEN>::verify_mu(
+                pk,
+                Some(A_hat),
+                &mu,
+                sig_sized,
+            ),
+            None => MLDSA::<HP::MLDSA, PK, SK, PK_LEN, SK_LEN, SIG_LEN>::verify_mu(
+                pk,
+                Some(&pk.A_hat()),
+                &mu,
+                sig_sized,
+            ),
         }
     }
 }
 
 impl<
-    HASH: Hash + AlgorithmOID + Default,
-    PK: MLDSAPublicKeyTrait<k, l, PK_LEN> + MLDSAPublicKeyInternalTrait<k, PK_LEN>,
-    SK: MLDSAPrivateKeyTrait<k, l, ETA, SK_LEN, PK_LEN>
-        + MLDSAPrivateKeyInternalTrait<k, l, ETA, SK_LEN, PK_LEN>,
+    HP: HashMLDSAParams,
+    PK: MLDSAPublicKeyTrait<HP::MLDSA, PK_LEN> + MLDSAPublicKeyInternalTrait<HP::MLDSA, PK_LEN>,
+    SK: MLDSAPrivateKeyTrait<HP::MLDSA, SK_LEN, PK_LEN>
+        + MLDSAPrivateKeyInternalTrait<HP::MLDSA, SK_LEN, PK_LEN>,
     const PH_LEN: usize,
     const PK_LEN: usize,
     const SK_LEN: usize,
     const SIG_LEN: usize,
-    const TAU: i32,
-    const LAMBDA: i32,
-    const GAMMA1: i32,
-    const GAMMA2: i32,
-    const k: usize,
-    const l: usize,
-    const ETA: usize,
-    const BETA: i32,
-    const OMEGA: i32,
-    const C_TILDE: usize,
-    const POLY_Z_PACKED_LEN: usize,
-    const POLY_W1_PACKED_LEN: usize,
-    const LAMBDA_over_4: usize,
-    const GAMMA1_MINUS_BETA: i32,
-    const GAMMA2_MINUS_BETA: i32,
-    const GAMMA1_MASK_LEN: usize,
-> Signer<SK, SK_LEN, SIG_LEN>
-    for HashMLDSA<
-        HASH,
-        PH_LEN,
-        PK_LEN,
-        SK_LEN,
-        SIG_LEN,
-        PK,
-        SK,
-        TAU,
-        LAMBDA,
-        GAMMA1,
-        GAMMA2,
-        k,
-        l,
-        ETA,
-        BETA,
-        OMEGA,
-        C_TILDE,
-        POLY_Z_PACKED_LEN,
-        POLY_W1_PACKED_LEN,
-        LAMBDA_over_4,
-        GAMMA1_MINUS_BETA,
-        GAMMA2_MINUS_BETA,
-        GAMMA1_MASK_LEN,
-    >
+> Signer<SK, SK_LEN, SIG_LEN> for HashMLDSA<HP, PK, SK, PH_LEN, PK_LEN, SK_LEN, SIG_LEN>
 {
     /// Algorithm 4 HashML-DSA.Sign(𝑠𝑘, 𝑀 , 𝑐𝑡𝑥, PH)
     /// Generate a “pre-hash” ML-DSA signature.
@@ -867,7 +552,7 @@ impl<
         output.fill(0);
 
         let mut ph_m = [0u8; PH_LEN];
-        _ = HASH::default().hash_out(msg, &mut ph_m);
+        _ = <HP::PreHash as Default>::default().hash_out(msg, &mut ph_m);
         Self::sign_ph_out(sk, &ph_m, ctx, output)
     }
 
@@ -879,7 +564,7 @@ impl<
             sk: Some(sk.clone()),
             seed: None,
             pk: None,
-            hash: HASH::default(),
+            hash: <HP::PreHash as Default>::default(),
             ctx,
             ctx_len,
         })
@@ -946,60 +631,20 @@ impl<
 }
 
 impl<
-    HASH: Hash + AlgorithmOID + Default,
-    PK: MLDSAPublicKeyTrait<k, l, PK_LEN> + MLDSAPublicKeyInternalTrait<k, PK_LEN>,
-    SK: MLDSAPrivateKeyTrait<k, l, ETA, SK_LEN, PK_LEN>
-        + MLDSAPrivateKeyInternalTrait<k, l, ETA, SK_LEN, PK_LEN>,
+    HP: HashMLDSAParams,
+    PK: MLDSAPublicKeyTrait<HP::MLDSA, PK_LEN> + MLDSAPublicKeyInternalTrait<HP::MLDSA, PK_LEN>,
+    SK: MLDSAPrivateKeyTrait<HP::MLDSA, SK_LEN, PK_LEN>
+        + MLDSAPrivateKeyInternalTrait<HP::MLDSA, SK_LEN, PK_LEN>,
     const PH_LEN: usize,
     const PK_LEN: usize,
     const SK_LEN: usize,
     const SIG_LEN: usize,
-    const TAU: i32,
-    const LAMBDA: i32,
-    const GAMMA1: i32,
-    const GAMMA2: i32,
-    const k: usize,
-    const l: usize,
-    const ETA: usize,
-    const BETA: i32,
-    const OMEGA: i32,
-    const C_TILDE: usize,
-    const POLY_Z_PACKED_LEN: usize,
-    const POLY_W1_PACKED_LEN: usize,
-    const LAMBDA_over_4: usize,
-    const GAMMA1_MINUS_BETA: i32,
-    const GAMMA2_MINUS_BETA: i32,
-    const GAMMA1_MASK_LEN: usize,
 > SignatureVerifier<PK, PK_LEN, SIG_LEN>
-    for HashMLDSA<
-        HASH,
-        PH_LEN,
-        PK_LEN,
-        SK_LEN,
-        SIG_LEN,
-        PK,
-        SK,
-        TAU,
-        LAMBDA,
-        GAMMA1,
-        GAMMA2,
-        k,
-        l,
-        ETA,
-        BETA,
-        OMEGA,
-        C_TILDE,
-        POLY_Z_PACKED_LEN,
-        POLY_W1_PACKED_LEN,
-        LAMBDA_over_4,
-        GAMMA1_MINUS_BETA,
-        GAMMA2_MINUS_BETA,
-        GAMMA1_MASK_LEN,
-    >
+    for HashMLDSA<HP, PK, SK, PH_LEN, PK_LEN, SK_LEN, SIG_LEN>
 {
     fn verify(pk: &PK, msg: &[u8], ctx: Option<&[u8]>, sig: &[u8]) -> Result<(), SignatureError> {
         let mut ph_m = [0u8; PH_LEN];
-        _ = HASH::default().hash_out(msg, &mut ph_m);
+        _ = <HP::PreHash as Default>::default().hash_out(msg, &mut ph_m);
 
         Self::verify_ph(pk, &ph_m, ctx, sig)
     }
@@ -1012,7 +657,7 @@ impl<
             sk: None,
             seed: None,
             pk: Some(pk.clone()),
-            hash: HASH::default(),
+            hash: <HP::PreHash as Default>::default(),
             ctx,
             ctx_len,
         })
@@ -1033,56 +678,16 @@ impl<
 }
 
 impl<
-    HASH: Hash + AlgorithmOID + Default,
+    HP: HashMLDSAParams,
+    PK: MLDSAPublicKeyTrait<HP::MLDSA, PK_LEN> + MLDSAPublicKeyInternalTrait<HP::MLDSA, PK_LEN>,
+    SK: MLDSAPrivateKeyTrait<HP::MLDSA, SK_LEN, PK_LEN>
+        + MLDSAPrivateKeyInternalTrait<HP::MLDSA, SK_LEN, PK_LEN>,
     const PH_LEN: usize,
     const PK_LEN: usize,
     const SK_LEN: usize,
     const SIG_LEN: usize,
-    PK: MLDSAPublicKeyTrait<k, l, PK_LEN> + MLDSAPublicKeyInternalTrait<k, PK_LEN>,
-    SK: MLDSAPrivateKeyTrait<k, l, ETA, SK_LEN, PK_LEN>
-        + MLDSAPrivateKeyInternalTrait<k, l, ETA, SK_LEN, PK_LEN>,
-    const TAU: i32,
-    const LAMBDA: i32,
-    const GAMMA1: i32,
-    const GAMMA2: i32,
-    const k: usize,
-    const l: usize,
-    const ETA: usize,
-    const BETA: i32,
-    const OMEGA: i32,
-    const C_TILDE: usize,
-    const POLY_Z_PACKED_LEN: usize,
-    const POLY_W1_PACKED_LEN: usize,
-    const LAMBDA_over_4: usize,
-    const GAMMA1_MASK_LEN: usize,
-    const GAMMA1_MINUS_BETA: i32,
-    const GAMMA2_MINUS_BETA: i32,
 > PHSigner<PK, SK, PK_LEN, SK_LEN, SIG_LEN, PH_LEN>
-    for HashMLDSA<
-        HASH,
-        PH_LEN,
-        PK_LEN,
-        SK_LEN,
-        SIG_LEN,
-        PK,
-        SK,
-        TAU,
-        LAMBDA,
-        GAMMA1,
-        GAMMA2,
-        k,
-        l,
-        ETA,
-        BETA,
-        OMEGA,
-        C_TILDE,
-        POLY_Z_PACKED_LEN,
-        POLY_W1_PACKED_LEN,
-        LAMBDA_over_4,
-        GAMMA1_MINUS_BETA,
-        GAMMA2_MINUS_BETA,
-        GAMMA1_MASK_LEN,
-    >
+    for HashMLDSA<HP, PK, SK, PH_LEN, PK_LEN, SK_LEN, SIG_LEN>
 {
     fn sign_ph(
         sk: &SK,
@@ -1114,56 +719,16 @@ impl<
 }
 
 impl<
-    HASH: Hash + AlgorithmOID + Default,
+    HP: HashMLDSAParams,
+    PK: MLDSAPublicKeyTrait<HP::MLDSA, PK_LEN> + MLDSAPublicKeyInternalTrait<HP::MLDSA, PK_LEN>,
+    SK: MLDSAPrivateKeyTrait<HP::MLDSA, SK_LEN, PK_LEN>
+        + MLDSAPrivateKeyInternalTrait<HP::MLDSA, SK_LEN, PK_LEN>,
     const PH_LEN: usize,
     const PK_LEN: usize,
     const SK_LEN: usize,
     const SIG_LEN: usize,
-    PK: MLDSAPublicKeyTrait<k, l, PK_LEN> + MLDSAPublicKeyInternalTrait<k, PK_LEN>,
-    SK: MLDSAPrivateKeyTrait<k, l, ETA, SK_LEN, PK_LEN>
-        + MLDSAPrivateKeyInternalTrait<k, l, ETA, SK_LEN, PK_LEN>,
-    const TAU: i32,
-    const LAMBDA: i32,
-    const GAMMA1: i32,
-    const GAMMA2: i32,
-    const k: usize,
-    const l: usize,
-    const ETA: usize,
-    const BETA: i32,
-    const OMEGA: i32,
-    const C_TILDE: usize,
-    const POLY_Z_PACKED_LEN: usize,
-    const POLY_W1_PACKED_LEN: usize,
-    const LAMBDA_over_4: usize,
-    const GAMMA1_MASK_LEN: usize,
-    const GAMMA1_MINUS_BETA: i32,
-    const GAMMA2_MINUS_BETA: i32,
 > PHSignatureVerifier<PK, PK_LEN, SIG_LEN, PH_LEN>
-    for HashMLDSA<
-        HASH,
-        PH_LEN,
-        PK_LEN,
-        SK_LEN,
-        SIG_LEN,
-        PK,
-        SK,
-        TAU,
-        LAMBDA,
-        GAMMA1,
-        GAMMA2,
-        k,
-        l,
-        ETA,
-        BETA,
-        OMEGA,
-        C_TILDE,
-        POLY_Z_PACKED_LEN,
-        POLY_W1_PACKED_LEN,
-        LAMBDA_over_4,
-        GAMMA1_MINUS_BETA,
-        GAMMA2_MINUS_BETA,
-        GAMMA1_MASK_LEN,
-    >
+    for HashMLDSA<HP, PK, SK, PH_LEN, PK_LEN, SK_LEN, SIG_LEN>
 {
     fn verify_ph(
         pk: &PK,

--- a/crypto/mldsa/src/hash_mldsa.rs
+++ b/crypto/mldsa/src/hash_mldsa.rs
@@ -110,13 +110,13 @@ pub const HASH_ML_DSA_87_WITH_SHA512_NAME: &str = "HashML-DSA-87_with_SHA512";
 
 /*** Pub Types ***/
 
-/// The HashML-DSA-44_with_SHA512 signature algorithm.
+/// The HashML-DSA-44_with_SHA256 signature algorithm.
 #[allow(non_camel_case_types)]
 pub type HashMLDSA44_with_SHA256 = HashMLDSA<
     HashMLDSA44_with_SHA256Params,
     MLDSA44PublicKey,
     MLDSA44PrivateKey,
-    32,
+    { HashMLDSA44_with_SHA256Params::PH_LEN },
     MLDSA44_PK_LEN,
     MLDSA44_SK_LEN,
     MLDSA44_SIG_LEN,
@@ -128,7 +128,7 @@ pub type HashMLDSA65_with_SHA256 = HashMLDSA<
     HashMLDSA65_with_SHA256Params,
     MLDSA65PublicKey,
     MLDSA65PrivateKey,
-    32,
+    { HashMLDSA65_with_SHA256Params::PH_LEN },
     MLDSA65_PK_LEN,
     MLDSA65_SK_LEN,
     MLDSA65_SIG_LEN,
@@ -140,7 +140,7 @@ pub type HashMLDSA87_with_SHA256 = HashMLDSA<
     HashMLDSA87_with_SHA256Params,
     MLDSA87PublicKey,
     MLDSA87PrivateKey,
-    32,
+    { HashMLDSA87_with_SHA256Params::PH_LEN },
     MLDSA87_PK_LEN,
     MLDSA87_SK_LEN,
     MLDSA87_SIG_LEN,
@@ -152,7 +152,7 @@ pub type HashMLDSA44_with_SHA512 = HashMLDSA<
     HashMLDSA44_with_SHA512Params,
     MLDSA44PublicKey,
     MLDSA44PrivateKey,
-    64,
+    { HashMLDSA44_with_SHA512Params::PH_LEN },
     MLDSA44_PK_LEN,
     MLDSA44_SK_LEN,
     MLDSA44_SIG_LEN,
@@ -170,7 +170,7 @@ pub type HashMLDSA65_with_SHA512 = HashMLDSA<
     HashMLDSA65_with_SHA512Params,
     MLDSA65PublicKey,
     MLDSA65PrivateKey,
-    64,
+    { HashMLDSA65_with_SHA512Params::PH_LEN },
     MLDSA65_PK_LEN,
     MLDSA65_SK_LEN,
     MLDSA65_SIG_LEN,
@@ -188,7 +188,7 @@ pub type HashMLDSA87_with_SHA512 = HashMLDSA<
     HashMLDSA87_with_SHA512Params,
     MLDSA87PublicKey,
     MLDSA87PrivateKey,
-    64,
+    { HashMLDSA87_with_SHA512Params::PH_LEN },
     MLDSA87_PK_LEN,
     MLDSA87_SK_LEN,
     MLDSA87_SIG_LEN,
@@ -201,18 +201,18 @@ impl AlgorithmOID for HashMLDSA87_with_SHA512 {
 }
 
 impl<
-    HP: HashMLDSAParams,
-    PK: MLDSAPublicKeyTrait<HP::MLDSA, PK_LEN> + MLDSAPublicKeyInternalTrait<HP::MLDSA, PK_LEN>,
-    SK: MLDSAPrivateKeyTrait<HP::MLDSA, SK_LEN, PK_LEN>
-        + MLDSAPrivateKeyInternalTrait<HP::MLDSA, SK_LEN, PK_LEN>,
+    P: HashMLDSAParams,
+    PK: MLDSAPublicKeyTrait<P::MLDSA, PK_LEN> + MLDSAPublicKeyInternalTrait<P::MLDSA, PK_LEN>,
+    SK: MLDSAPrivateKeyTrait<P::MLDSA, SK_LEN, PK_LEN>
+        + MLDSAPrivateKeyInternalTrait<P::MLDSA, SK_LEN, PK_LEN>,
     const PH_LEN: usize,
     const PK_LEN: usize,
     const SK_LEN: usize,
     const SIG_LEN: usize,
-> Algorithm for HashMLDSA<HP, PK, SK, PH_LEN, PK_LEN, SK_LEN, SIG_LEN>
+> Algorithm for HashMLDSA<P, PK, SK, PH_LEN, PK_LEN, SK_LEN, SIG_LEN>
 {
-    const ALG_NAME: &'static str = HP::ALG_NAME;
-    const MAX_SECURITY_STRENGTH: SecurityStrength = HP::MAX_SECURITY_STRENGTH;
+    const ALG_NAME: &'static str = P::ALG_NAME;
+    const MAX_SECURITY_STRENGTH: SecurityStrength = P::MAX_SECURITY_STRENGTH;
 }
 
 /// An instance of the HashML-DSA algorithm.
@@ -222,16 +222,16 @@ impl<
 /// by specifying the hash function to use (in the verifier), and specifying the bytes of the OID to
 /// to use as its domain separator in constructing the message representative M'.
 pub struct HashMLDSA<
-    HP: HashMLDSAParams,
-    PK: MLDSAPublicKeyTrait<HP::MLDSA, PK_LEN> + MLDSAPublicKeyInternalTrait<HP::MLDSA, PK_LEN>,
-    SK: MLDSAPrivateKeyTrait<HP::MLDSA, SK_LEN, PK_LEN>
-        + MLDSAPrivateKeyInternalTrait<HP::MLDSA, SK_LEN, PK_LEN>,
+    P: HashMLDSAParams,
+    PK: MLDSAPublicKeyTrait<P::MLDSA, PK_LEN> + MLDSAPublicKeyInternalTrait<P::MLDSA, PK_LEN>,
+    SK: MLDSAPrivateKeyTrait<P::MLDSA, SK_LEN, PK_LEN>
+        + MLDSAPrivateKeyInternalTrait<P::MLDSA, SK_LEN, PK_LEN>,
     const PH_LEN: usize,
     const PK_LEN: usize,
     const SK_LEN: usize,
     const SIG_LEN: usize,
 > {
-    _phantom: PhantomData<(HP, PK, SK)>,
+    _phantom: PhantomData<(P, PK, SK)>,
 
     signer_rnd: Option<[u8; MLDSA_RND_LEN]>,
 
@@ -245,7 +245,7 @@ pub struct HashMLDSA<
     pk: Option<PK>,
 
     /// Hash function instance for streaming message hashing
-    hash: HP::PreHash,
+    hash: P::PreHash,
 
     /// Since HashML-DSA does message buffering in the external pre-hash, not in mu,
     /// this needs to be saved for later
@@ -254,15 +254,15 @@ pub struct HashMLDSA<
 }
 
 impl<
-    HP: HashMLDSAParams,
-    PK: MLDSAPublicKeyTrait<HP::MLDSA, PK_LEN> + MLDSAPublicKeyInternalTrait<HP::MLDSA, PK_LEN>,
-    SK: MLDSAPrivateKeyTrait<HP::MLDSA, SK_LEN, PK_LEN>
-        + MLDSAPrivateKeyInternalTrait<HP::MLDSA, SK_LEN, PK_LEN>,
+    P: HashMLDSAParams,
+    PK: MLDSAPublicKeyTrait<P::MLDSA, PK_LEN> + MLDSAPublicKeyInternalTrait<P::MLDSA, PK_LEN>,
+    SK: MLDSAPrivateKeyTrait<P::MLDSA, SK_LEN, PK_LEN>
+        + MLDSAPrivateKeyInternalTrait<P::MLDSA, SK_LEN, PK_LEN>,
     const PH_LEN: usize,
     const PK_LEN: usize,
     const SK_LEN: usize,
     const SIG_LEN: usize,
-> HashMLDSA<HP, PK, SK, PH_LEN, PK_LEN, SK_LEN, SIG_LEN>
+> HashMLDSA<P, PK, SK, PH_LEN, PK_LEN, SK_LEN, SIG_LEN>
 {
     /// Generate a keypair, sourcing randomness from bouncycastle's default os-backed RNG.
     ///
@@ -271,16 +271,16 @@ impl<
     /// Keygen, and keys in general, are interchangeable between MLDSA and HashMLDSA.
     /// Error condition: basically only on RNG failures.
     pub fn keygen() -> Result<(PK, SK), SignatureError> {
-        MLDSA::<HP::MLDSA, PK, SK, PK_LEN, SK_LEN, SIG_LEN>::keygen()
+        MLDSA::<P::MLDSA, PK, SK, PK_LEN, SK_LEN, SIG_LEN>::keygen()
     }
 
     /// Imports a secret key from a seed.
     pub fn keygen_from_seed(seed: &KeyMaterial<32>) -> Result<(PK, SK), SignatureError> {
-        MLDSA::<HP::MLDSA, PK, SK, PK_LEN, SK_LEN, SIG_LEN>::keygen_internal(seed)
+        MLDSA::<P::MLDSA, PK, SK, PK_LEN, SK_LEN, SIG_LEN>::keygen_internal(seed)
     }
     /// Same as [`Signer::sign`], but signs from an [`MLDSAPrivateKeyExpanded`].
     pub fn sign_with_expanded_key(
-        sk: &MLDSAPrivateKeyExpanded<HP::MLDSA, PK, SK, SK_LEN, PK_LEN>,
+        sk: &MLDSAPrivateKeyExpanded<P::MLDSA, PK, SK, SK_LEN, PK_LEN>,
         msg: &[u8],
         ctx: Option<&[u8]>,
     ) -> Result<[u8; SIG_LEN], SignatureError> {
@@ -291,7 +291,7 @@ impl<
     }
     /// Same as [`Signer::sign_out`], but signs from an [`MLDSAPrivateKeyExpanded`].
     pub fn sign_with_expanded_key_out(
-        sk: &MLDSAPrivateKeyExpanded<HP::MLDSA, PK, SK, SK_LEN, PK_LEN>,
+        sk: &MLDSAPrivateKeyExpanded<P::MLDSA, PK, SK, SK_LEN, PK_LEN>,
         msg: &[u8],
         ctx: Option<&[u8]>,
         output: &mut [u8; SIG_LEN],
@@ -299,12 +299,12 @@ impl<
         output.fill(0);
 
         let mut ph_m = [0u8; PH_LEN];
-        _ = <HP::PreHash as Default>::default().hash_out(msg, &mut ph_m);
+        _ = <P::PreHash as Default>::default().hash_out(msg, &mut ph_m);
         Self::sign_ph_with_expanded_key_out(sk, &ph_m, ctx, output)
     }
     /// Same as [`PHSigner::sign_ph`], but signs from an [`MLDSAPrivateKeyExpanded`].
     pub fn sign_ph_with_expanded_key(
-        sk: &MLDSAPrivateKeyExpanded<HP::MLDSA, PK, SK, SK_LEN, PK_LEN>,
+        sk: &MLDSAPrivateKeyExpanded<P::MLDSA, PK, SK, SK_LEN, PK_LEN>,
         ph: &[u8; PH_LEN],
         ctx: Option<&[u8]>,
     ) -> Result<[u8; SIG_LEN], SignatureError> {
@@ -315,7 +315,7 @@ impl<
     }
     /// Same as [`PHSigner::sign_ph_out`], but signs from an [`MLDSAPrivateKeyExpanded`].
     pub fn sign_ph_with_expanded_key_out(
-        sk: &MLDSAPrivateKeyExpanded<HP::MLDSA, PK, SK, SK_LEN, PK_LEN>,
+        sk: &MLDSAPrivateKeyExpanded<P::MLDSA, PK, SK, SK_LEN, PK_LEN>,
         ph: &[u8; PH_LEN],
         ctx: Option<&[u8]>,
         output: &mut [u8; SIG_LEN],
@@ -341,7 +341,7 @@ impl<
     /// prevent accidental nonce reuse, this function moves `rnd`.
     pub fn sign_ph_deterministic(
         sk: &SK,
-        A_hat: Option<&<HP::MLDSA as MLDSAParams>::MatrixA>,
+        A_hat: Option<&<P::MLDSA as MLDSAParams>::MatrixA>,
         ctx: Option<&[u8]>,
         ph: &[u8; PH_LEN],
         rnd: [u8; 32],
@@ -364,7 +364,7 @@ impl<
     /// Returns the number of bytes written to the output buffer. Can be called with an oversized buffer.
     pub fn sign_ph_deterministic_out(
         sk: &SK,
-        A_hat: Option<&<HP::MLDSA as MLDSAParams>::MatrixA>,
+        A_hat: Option<&<P::MLDSA as MLDSAParams>::MatrixA>,
         ctx: Option<&[u8]>,
         ph: &[u8; PH_LEN],
         rnd: [u8; 32],
@@ -392,7 +392,7 @@ impl<
             h.absorb(&[1u8]).expect("absorb before squeeze is infallible");
             h.absorb(&[ctx.len() as u8]).expect("absorb before squeeze is infallible");
             h.absorb(ctx).expect("absorb before squeeze is infallible");
-            h.absorb(<HP::PreHash as AlgorithmOID>::OID_DER)
+            h.absorb(<P::PreHash as AlgorithmOID>::OID_DER)
                 .expect("absorb before squeeze is infallible");
             h.absorb(ph).expect("absorb before squeeze is infallible");
             let mut mu = [0u8; MLDSA_MU_LEN];
@@ -404,7 +404,7 @@ impl<
 
         // 24: 𝜎 ← ML-DSA.Sign_internal(𝑠𝑘, 𝑀', 𝑟𝑛𝑑)
         let bytes_written =
-            MLDSA::<HP::MLDSA, PK, SK, PK_LEN, SK_LEN, SIG_LEN>::sign_mu_deterministic_out(
+            MLDSA::<P::MLDSA, PK, SK, PK_LEN, SK_LEN, SIG_LEN>::sign_mu_deterministic_out(
                 sk, A_hat, &mu, rnd, output,
             )?;
 
@@ -447,27 +447,27 @@ impl<
             sk: None,
             seed: Some(seed.clone()),
             pk: None,
-            hash: <HP::PreHash as Default>::default(),
+            hash: <P::PreHash as Default>::default(),
             ctx,
             ctx_len,
         })
     }
     /// Same as [`SignatureVerifier::verify`], but verifies from an [`MLDSAPublicKeyExpanded`].
     pub fn verify_with_expanded_key(
-        pk: &MLDSAPublicKeyExpanded<HP::MLDSA, PK, PK_LEN>,
+        pk: &MLDSAPublicKeyExpanded<P::MLDSA, PK, PK_LEN>,
         msg: &[u8],
         ctx: Option<&[u8]>,
         sig: &[u8],
     ) -> Result<(), SignatureError> {
         let mut ph_m = [0u8; PH_LEN];
-        _ = <HP::PreHash as Default>::default().hash_out(msg, &mut ph_m);
+        _ = <P::PreHash as Default>::default().hash_out(msg, &mut ph_m);
 
         Self::verify_ph_internal(&pk.pk, Some(&pk.A_hat()), &ph_m, ctx, sig)
     }
 
     fn verify_ph_internal(
         pk: &PK,
-        A_hat: Option<&<HP::MLDSA as MLDSAParams>::MatrixA>,
+        A_hat: Option<&<P::MLDSA as MLDSAParams>::MatrixA>,
         ph: &[u8; PH_LEN],
         ctx: Option<&[u8]>,
         sig: &[u8],
@@ -497,7 +497,7 @@ impl<
             h.absorb(&[1u8]).expect("absorb before squeeze is infallible");
             h.absorb(&[ctx.len() as u8]).expect("absorb before squeeze is infallible");
             h.absorb(ctx).expect("absorb before squeeze is infallible");
-            h.absorb(<HP::PreHash as AlgorithmOID>::OID_DER)
+            h.absorb(<P::PreHash as AlgorithmOID>::OID_DER)
                 .expect("absorb before squeeze is infallible");
             h.absorb(ph).expect("absorb before squeeze is infallible");
             let mut mu = [0u8; MLDSA_MU_LEN];
@@ -507,13 +507,13 @@ impl<
         };
 
         match A_hat {
-            Some(A_hat) => MLDSA::<HP::MLDSA, PK, SK, PK_LEN, SK_LEN, SIG_LEN>::verify_mu(
+            Some(A_hat) => MLDSA::<P::MLDSA, PK, SK, PK_LEN, SK_LEN, SIG_LEN>::verify_mu(
                 pk,
                 Some(A_hat),
                 &mu,
                 sig_sized,
             ),
-            None => MLDSA::<HP::MLDSA, PK, SK, PK_LEN, SK_LEN, SIG_LEN>::verify_mu(
+            None => MLDSA::<P::MLDSA, PK, SK, PK_LEN, SK_LEN, SIG_LEN>::verify_mu(
                 pk,
                 Some(&pk.A_hat()),
                 &mu,
@@ -524,15 +524,15 @@ impl<
 }
 
 impl<
-    HP: HashMLDSAParams,
-    PK: MLDSAPublicKeyTrait<HP::MLDSA, PK_LEN> + MLDSAPublicKeyInternalTrait<HP::MLDSA, PK_LEN>,
-    SK: MLDSAPrivateKeyTrait<HP::MLDSA, SK_LEN, PK_LEN>
-        + MLDSAPrivateKeyInternalTrait<HP::MLDSA, SK_LEN, PK_LEN>,
+    P: HashMLDSAParams,
+    PK: MLDSAPublicKeyTrait<P::MLDSA, PK_LEN> + MLDSAPublicKeyInternalTrait<P::MLDSA, PK_LEN>,
+    SK: MLDSAPrivateKeyTrait<P::MLDSA, SK_LEN, PK_LEN>
+        + MLDSAPrivateKeyInternalTrait<P::MLDSA, SK_LEN, PK_LEN>,
     const PH_LEN: usize,
     const PK_LEN: usize,
     const SK_LEN: usize,
     const SIG_LEN: usize,
-> Signer<SK, SK_LEN, SIG_LEN> for HashMLDSA<HP, PK, SK, PH_LEN, PK_LEN, SK_LEN, SIG_LEN>
+> Signer<SK, SK_LEN, SIG_LEN> for HashMLDSA<P, PK, SK, PH_LEN, PK_LEN, SK_LEN, SIG_LEN>
 {
     /// Algorithm 4 HashML-DSA.Sign(𝑠𝑘, 𝑀 , 𝑐𝑡𝑥, PH)
     /// Generate a “pre-hash” ML-DSA signature.
@@ -552,7 +552,7 @@ impl<
         output.fill(0);
 
         let mut ph_m = [0u8; PH_LEN];
-        _ = <HP::PreHash as Default>::default().hash_out(msg, &mut ph_m);
+        _ = <P::PreHash as Default>::default().hash_out(msg, &mut ph_m);
         Self::sign_ph_out(sk, &ph_m, ctx, output)
     }
 
@@ -564,7 +564,7 @@ impl<
             sk: Some(sk.clone()),
             seed: None,
             pk: None,
-            hash: <HP::PreHash as Default>::default(),
+            hash: <P::PreHash as Default>::default(),
             ctx,
             ctx_len,
         })
@@ -631,20 +631,19 @@ impl<
 }
 
 impl<
-    HP: HashMLDSAParams,
-    PK: MLDSAPublicKeyTrait<HP::MLDSA, PK_LEN> + MLDSAPublicKeyInternalTrait<HP::MLDSA, PK_LEN>,
-    SK: MLDSAPrivateKeyTrait<HP::MLDSA, SK_LEN, PK_LEN>
-        + MLDSAPrivateKeyInternalTrait<HP::MLDSA, SK_LEN, PK_LEN>,
+    P: HashMLDSAParams,
+    PK: MLDSAPublicKeyTrait<P::MLDSA, PK_LEN> + MLDSAPublicKeyInternalTrait<P::MLDSA, PK_LEN>,
+    SK: MLDSAPrivateKeyTrait<P::MLDSA, SK_LEN, PK_LEN>
+        + MLDSAPrivateKeyInternalTrait<P::MLDSA, SK_LEN, PK_LEN>,
     const PH_LEN: usize,
     const PK_LEN: usize,
     const SK_LEN: usize,
     const SIG_LEN: usize,
-> SignatureVerifier<PK, PK_LEN, SIG_LEN>
-    for HashMLDSA<HP, PK, SK, PH_LEN, PK_LEN, SK_LEN, SIG_LEN>
+> SignatureVerifier<PK, PK_LEN, SIG_LEN> for HashMLDSA<P, PK, SK, PH_LEN, PK_LEN, SK_LEN, SIG_LEN>
 {
     fn verify(pk: &PK, msg: &[u8], ctx: Option<&[u8]>, sig: &[u8]) -> Result<(), SignatureError> {
         let mut ph_m = [0u8; PH_LEN];
-        _ = <HP::PreHash as Default>::default().hash_out(msg, &mut ph_m);
+        _ = <P::PreHash as Default>::default().hash_out(msg, &mut ph_m);
 
         Self::verify_ph(pk, &ph_m, ctx, sig)
     }
@@ -657,7 +656,7 @@ impl<
             sk: None,
             seed: None,
             pk: Some(pk.clone()),
-            hash: <HP::PreHash as Default>::default(),
+            hash: <P::PreHash as Default>::default(),
             ctx,
             ctx_len,
         })
@@ -678,16 +677,16 @@ impl<
 }
 
 impl<
-    HP: HashMLDSAParams,
-    PK: MLDSAPublicKeyTrait<HP::MLDSA, PK_LEN> + MLDSAPublicKeyInternalTrait<HP::MLDSA, PK_LEN>,
-    SK: MLDSAPrivateKeyTrait<HP::MLDSA, SK_LEN, PK_LEN>
-        + MLDSAPrivateKeyInternalTrait<HP::MLDSA, SK_LEN, PK_LEN>,
+    P: HashMLDSAParams,
+    PK: MLDSAPublicKeyTrait<P::MLDSA, PK_LEN> + MLDSAPublicKeyInternalTrait<P::MLDSA, PK_LEN>,
+    SK: MLDSAPrivateKeyTrait<P::MLDSA, SK_LEN, PK_LEN>
+        + MLDSAPrivateKeyInternalTrait<P::MLDSA, SK_LEN, PK_LEN>,
     const PH_LEN: usize,
     const PK_LEN: usize,
     const SK_LEN: usize,
     const SIG_LEN: usize,
 > PHSigner<PK, SK, PK_LEN, SK_LEN, SIG_LEN, PH_LEN>
-    for HashMLDSA<HP, PK, SK, PH_LEN, PK_LEN, SK_LEN, SIG_LEN>
+    for HashMLDSA<P, PK, SK, PH_LEN, PK_LEN, SK_LEN, SIG_LEN>
 {
     fn sign_ph(
         sk: &SK,
@@ -719,16 +718,16 @@ impl<
 }
 
 impl<
-    HP: HashMLDSAParams,
-    PK: MLDSAPublicKeyTrait<HP::MLDSA, PK_LEN> + MLDSAPublicKeyInternalTrait<HP::MLDSA, PK_LEN>,
-    SK: MLDSAPrivateKeyTrait<HP::MLDSA, SK_LEN, PK_LEN>
-        + MLDSAPrivateKeyInternalTrait<HP::MLDSA, SK_LEN, PK_LEN>,
+    P: HashMLDSAParams,
+    PK: MLDSAPublicKeyTrait<P::MLDSA, PK_LEN> + MLDSAPublicKeyInternalTrait<P::MLDSA, PK_LEN>,
+    SK: MLDSAPrivateKeyTrait<P::MLDSA, SK_LEN, PK_LEN>
+        + MLDSAPrivateKeyInternalTrait<P::MLDSA, SK_LEN, PK_LEN>,
     const PH_LEN: usize,
     const PK_LEN: usize,
     const SK_LEN: usize,
     const SIG_LEN: usize,
 > PHSignatureVerifier<PK, PK_LEN, SIG_LEN, PH_LEN>
-    for HashMLDSA<HP, PK, SK, PH_LEN, PK_LEN, SK_LEN, SIG_LEN>
+    for HashMLDSA<P, PK, SK, PH_LEN, PK_LEN, SK_LEN, SIG_LEN>
 {
     fn verify_ph(
         pk: &PK,

--- a/crypto/mldsa/src/lib.rs
+++ b/crypto/mldsa/src/lib.rs
@@ -180,15 +180,9 @@ pub use mldsa::{MLDSA87_PK_LEN, MLDSA87_SIG_LEN, MLDSA87_SK_LEN};
 
 pub use mldsa::SUSPENDED_MU_BUILDER_STATE_LEN;
 
-pub use params::{MLDSA44Params, MLDSA65Params, MLDSA87Params};
-
 pub use hash_mldsa::HASH_ML_DSA_44_with_SHA256_NAME;
 pub use hash_mldsa::HASH_ML_DSA_65_WITH_SHA256_NAME;
 pub use hash_mldsa::HASH_ML_DSA_87_with_SHA256_NAME;
-pub use params::{
-    HashMLDSA44_with_SHA256Params, HashMLDSA44_with_SHA512Params, HashMLDSA65_with_SHA256Params,
-    HashMLDSA65_with_SHA512Params, HashMLDSA87_with_SHA256Params, HashMLDSA87_with_SHA512Params,
-};
 
 pub use hash_mldsa::HASH_ML_DSA_44_with_SHA512_NAME;
 pub use hash_mldsa::HASH_ML_DSA_65_WITH_SHA512_NAME;

--- a/crypto/mldsa/src/lib.rs
+++ b/crypto/mldsa/src/lib.rs
@@ -148,6 +148,7 @@ pub mod hash_mldsa;
 mod matrix;
 pub mod mldsa;
 mod mldsa_keys;
+mod params;
 mod polynomial;
 
 /*** Exported types ***/
@@ -172,14 +173,6 @@ pub use mldsa::ML_DSA_44_NAME;
 pub use mldsa::ML_DSA_65_NAME;
 pub use mldsa::ML_DSA_87_NAME;
 
-pub use hash_mldsa::HASH_ML_DSA_44_with_SHA256_NAME;
-pub use hash_mldsa::HASH_ML_DSA_65_WITH_SHA256_NAME;
-pub use hash_mldsa::HASH_ML_DSA_87_with_SHA256_NAME;
-
-pub use hash_mldsa::HASH_ML_DSA_44_with_SHA512_NAME;
-pub use hash_mldsa::HASH_ML_DSA_65_WITH_SHA512_NAME;
-pub use hash_mldsa::HASH_ML_DSA_87_WITH_SHA512_NAME;
-
 pub use mldsa::{MLDSA_MU_LEN, MLDSA_RND_LEN, MLDSA_SEED_LEN, MLDSA_TR_LEN};
 pub use mldsa::{MLDSA44_PK_LEN, MLDSA44_SIG_LEN, MLDSA44_SK_LEN};
 pub use mldsa::{MLDSA65_PK_LEN, MLDSA65_SIG_LEN, MLDSA65_SK_LEN};
@@ -187,4 +180,16 @@ pub use mldsa::{MLDSA87_PK_LEN, MLDSA87_SIG_LEN, MLDSA87_SK_LEN};
 
 pub use mldsa::SUSPENDED_MU_BUILDER_STATE_LEN;
 
-pub use matrix::Matrix;
+pub use params::{MLDSA44Params, MLDSA65Params, MLDSA87Params};
+
+pub use hash_mldsa::HASH_ML_DSA_44_with_SHA256_NAME;
+pub use hash_mldsa::HASH_ML_DSA_65_WITH_SHA256_NAME;
+pub use hash_mldsa::HASH_ML_DSA_87_with_SHA256_NAME;
+pub use params::{
+    HashMLDSA44_with_SHA256Params, HashMLDSA44_with_SHA512Params, HashMLDSA65_with_SHA256Params,
+    HashMLDSA65_with_SHA512Params, HashMLDSA87_with_SHA256Params, HashMLDSA87_with_SHA512Params,
+};
+
+pub use hash_mldsa::HASH_ML_DSA_44_with_SHA512_NAME;
+pub use hash_mldsa::HASH_ML_DSA_65_WITH_SHA512_NAME;
+pub use hash_mldsa::HASH_ML_DSA_87_WITH_SHA512_NAME;

--- a/crypto/mldsa/src/matrix.rs
+++ b/crypto/mldsa/src/matrix.rs
@@ -3,10 +3,31 @@
 
 use crate::aux_functions::multiply_ntt;
 use crate::mldsa::H;
+use crate::params::MLDSAParams;
 use crate::polynomial::Polynomial;
 use bouncycastle_core::traits::XOF;
 use bouncycastle_utils::secret::ZeroizablePrimitive;
 use core::ops::{Index, IndexMut};
+
+/// The operations this crate performs on the public matrix 𝐀̂.
+///
+/// [`Matrix`] is the only implementation; see the module docs for why the trait exists.
+pub(crate) trait MatrixTrait: Sized + Clone {
+    /// The vector this matrix can be applied to: an element of 𝑅^ℓ.
+    type VecL: VectorTrait;
+    /// The vector applying this matrix produces: an element of 𝑅^𝑘.
+    type VecK: VectorTrait;
+
+    /// A matrix with every coefficient set to zero.
+    fn new() -> Self;
+
+    /// Overwrites the polynomial at `elems[row][col]`.
+    fn set_elem(&mut self, row: usize, col: usize, p: Polynomial);
+
+    /// Algorithm 48 MatrixVectorNTT(𝐌, 𝐯)
+    /// Computes the product 𝐌 ∘̂ 𝐯_hat of a matrix 𝐌_hat and a vector 𝐯_hat over 𝑇𝑞.
+    fn matrix_vector_ntt(&self, v: &Self::VecL) -> Self::VecK;
+}
 
 /// A matrix over the ML-DSA ring.
 #[derive(Clone)]
@@ -47,8 +68,88 @@ impl<const k: usize, const l: usize> Matrix<k, l> {
     }
 }
 
+impl<const k: usize, const l: usize> MatrixTrait for Matrix<k, l> {
+    type VecL = Vector<l>;
+    type VecK = Vector<k>;
+
+    fn new() -> Self {
+        Matrix::new()
+    }
+
+    fn set_elem(&mut self, row: usize, col: usize, p: Polynomial) {
+        self.elems[row][col] = p;
+    }
+
+    fn matrix_vector_ntt(&self, v: &Vector<l>) -> Vector<k> {
+        Matrix::matrix_vector_ntt(self, v)
+    }
+}
+
+/// The operations this crate performs on a vector of polynomials, i.e. on an element of 𝑅^LEN.
+///
+/// [`Vector`] is the only implementation; the trait exists so that code generic over a parameter
+/// set can operate on [`MLDSAParams::VecK`] and [`MLDSAParams::VecL`] without knowing their length.
+pub trait VectorTrait:
+    Sized + Copy + ZeroizablePrimitive + Index<usize, Output = Polynomial> + IndexMut<usize>
+{
+    /// The number of polynomial coordinates, i.e. 𝑘 or ℓ.
+    const LEN: usize;
+
+    /// A vector with every coefficient set to zero.
+    fn new() -> Self;
+
+    /// The coordinates, for iteration and chunking.
+    fn elems(&self) -> &[Polynomial];
+    /// The coordinates, for iteration and chunking.
+    fn elems_mut(&mut self) -> &mut [Polynomial];
+
+    /// Algorithm 46 AddVectorNTT(𝐯, 𝐰)̂
+    /// Computes the sum 𝐯_hat + 𝐰_hat of two vectors 𝐯_hat, 𝐰_hat over 𝑇𝑞.
+    fn add_vector_ntt(&mut self, s: &Self);
+
+    /// Subtracts another vector from this one, coordinatewise.
+    fn sub_vector(&self, s: &Self) -> Self;
+
+    /// Algorithm 47 ScalarVectorNTT(𝑐,̂ 𝐯)̂
+    /// Computes the product 𝑐_hat * 𝐯_hat of a scalar 𝑐_hat and a vector 𝐯_hat over 𝑇𝑞.
+    fn scalar_vector_ntt(&self, w: &Polynomial) -> Self;
+
+    /// Adds 𝑞 to every negative coefficient.
+    fn conditional_add_q(&mut self);
+
+    /// Montgomery-reduces every coefficient.
+    fn reduce(&mut self);
+
+    /// Applies Algorithm 41 NTT(𝑤) to every coordinate.
+    fn ntt(&mut self);
+
+    /// Applies Algorithm 42 NTT−1(𝑤_hat) to every coordinate.
+    fn inv_ntt(&mut self);
+
+    /// Applies Algorithm 37 HighBits(𝑟) coefficientwise.
+    fn high_bits<P: MLDSAParams>(&self) -> Self;
+
+    /// Applies Algorithm 38 LowBits(𝑟) coefficientwise.
+    fn low_bits<P: MLDSAParams>(&self) -> Self;
+
+    /// Multiplies every coefficient by 2^𝑑.
+    fn shift_left_d(&self) -> Self;
+
+    /// Tests whether any coefficient of any coordinate has absolute value at least `bound`.
+    /// See `Polynomial::check_norm` for why `bound` is not a const generic.
+    fn check_norm(&self, bound: i32) -> bool;
+
+    /// Algorithm 28 w1Encode(𝐰1), fed straight into `h` rather than into a buffer.
+    fn w1_encode_and_hash<P: MLDSAParams>(&self, h: &mut H);
+}
+
+/// A vector of `LEN` polynomials, i.e. an element of 𝑅^LEN.
+///
+/// Public only because it is the value of [`MLDSAParams::VecK`] and [`MLDSAParams::VecL`]; its
+/// fields and operations are crate-private, so from outside it is an opaque handle. Reach it
+/// through [`VectorTrait`].
 #[derive(Clone, Copy)]
-pub(crate) struct Vector<const LEN: usize> {
+pub struct Vector<const LEN: usize> {
     pub(crate) elems: [Polynomial; LEN],
 }
 
@@ -75,21 +176,37 @@ impl<const LEN: usize> Vector<LEN> {
     pub(crate) const fn new() -> Self {
         Self { elems: [Polynomial::new(); LEN] }
     }
+}
+
+impl<const LEN: usize> VectorTrait for Vector<LEN> {
+    const LEN: usize = LEN;
+
+    fn new() -> Self {
+        Vector::new()
+    }
+
+    fn elems(&self) -> &[Polynomial] {
+        &self.elems
+    }
+
+    fn elems_mut(&mut self) -> &mut [Polynomial] {
+        &mut self.elems
+    }
 
     /// Algorithm 46 AddVectorNTT(𝐯, 𝐰)̂
     /// Computes the sum 𝐯_hat + 𝐰_hat of two vectors 𝐯_hat, 𝐰_hat over 𝑇𝑞.
     /// Input: ℓ ∈ ℕ, v_hat ∈ T^ℓ, w_hat ∈ 𝑇^ℓ
     /// Output: u_hat ∈ T^ℓ_𝑞.
     /// Add another vector to this vector
-    pub(crate) fn add_vector_ntt(&mut self, s: &Self) {
+    fn add_vector_ntt(&mut self, s: &Self) {
         for i in 0..LEN {
             // perform montgomery addition of each polynomial in the vector
             self[i].add_ntt(&s[i]);
         }
     }
 
-    pub(crate) fn sub_vector(&self, s: &Self) -> Self {
-        let mut out = self.clone();
+    fn sub_vector(&self, s: &Self) -> Self {
+        let mut out = *self;
         for i in 0..LEN {
             out[i].sub(&s[i]);
         }
@@ -100,8 +217,8 @@ impl<const LEN: usize> Vector<LEN> {
     /// Computes the product 𝑐_hat * 𝐯_hat of a scalar 𝑐_hat and a vector 𝐯_hat over 𝑇𝑞.
     /// Input: 𝑐_hat ∈ 𝑇𝑞, ℓ ∈ ℕ, 𝐯_hat ∈ 𝑇^ℓ
     /// Output: 𝑞 .
-    pub(crate) fn scalar_vector_ntt(&self, w: &Polynomial) -> Self {
-        let mut s_hat = Self::new();
+    fn scalar_vector_ntt(&self, w: &Polynomial) -> Self {
+        let mut s_hat = Vector::<LEN>::new();
         for i in 0..LEN {
             s_hat[i] = multiply_ntt(&self[i], &w);
         }
@@ -109,63 +226,63 @@ impl<const LEN: usize> Vector<LEN> {
         s_hat
     }
 
-    pub(crate) fn conditional_add_q(&mut self) {
+    fn conditional_add_q(&mut self) {
         for i in 0..LEN {
             self[i].conditional_add_q();
         }
     }
 
-    pub(crate) fn reduce(&mut self) {
+    fn reduce(&mut self) {
         for i in 0..LEN {
             self[i].reduce();
         }
     }
 
-    pub(crate) fn ntt(&mut self) {
+    fn ntt(&mut self) {
         for i in 0..LEN {
             self[i].ntt();
         }
     }
 
-    pub(crate) fn inv_ntt(&mut self) {
+    fn inv_ntt(&mut self) {
         for i in 0..LEN {
             self[i].inv_ntt();
         }
     }
 
-    pub(crate) fn high_bits<const GAMMA2: i32>(&self) -> Self {
-        let mut s = Self::new();
+    fn high_bits<P: MLDSAParams>(&self) -> Self {
+        let mut s = Vector::<LEN>::new();
 
         for i in 0..LEN {
-            s[i] = self[i].high_bits::<GAMMA2>();
+            s[i] = self[i].high_bits::<P>();
         }
 
         s
     }
 
-    pub(crate) fn low_bits<const GAMMA2: i32>(&self) -> Self {
-        let mut s = Self::new();
+    fn low_bits<P: MLDSAParams>(&self) -> Self {
+        let mut s = Vector::<LEN>::new();
 
         for i in 0..LEN {
-            s[i] = self[i].low_bits::<GAMMA2>();
+            s[i] = self[i].low_bits::<P>();
         }
 
         s
     }
 
-    pub(crate) fn shift_left<const d: i32>(&self) -> Self {
-        let mut out = self.clone();
+    fn shift_left_d(&self) -> Self {
+        let mut out = *self;
         for i in 0..LEN {
-            out[i].shift_left::<d>();
+            out[i].shift_left_d();
         }
 
         out
     }
 
-    pub(crate) fn check_norm<const BOUND: i32>(&self) -> bool {
+    fn check_norm(&self, bound: i32) -> bool {
         // Fine that this is not constant-time because it is used in a rejection loop -- the early quit leads to rejection.
         for x in self.elems.iter() {
-            if x.check_norm::<BOUND>() {
+            if x.check_norm(bound) {
                 return true;
             }
         }
@@ -177,7 +294,7 @@ impl<const LEN: usize> Vector<LEN> {
     /// Input: 𝐰1 ∈ 𝑅𝑘 whose polynomial coordinates have coefficients in \[0, (𝑞 − 1)/(2𝛾2) − 1].
     /// Output: A byte string representation 𝐰1_tilde ∈ 𝔹32𝑘⋅bitlen ((𝑞−1)/(2𝛾2)−1)
     /// Optimized from FIPS 204 to feed into the hash one row at a time to reduce overall memory footprint.
-    pub(crate) fn w1_encode_and_hash<const POLY_W1_PACKED_LEN: usize>(&self, h: &mut H) {
+    fn w1_encode_and_hash<P: MLDSAParams>(&self, h: &mut H) {
         // 1: 𝐰̃1 ← ()
         // Nothing needs to be allocated since it is being fed into the hash row-wise
 
@@ -185,8 +302,7 @@ impl<const LEN: usize> Vector<LEN> {
         // 3:   𝐰̃1 ← 𝐰̃1 || SimpleBitPack (𝐰1[𝑖], (𝑞 − 1)/(2𝛾2) − 1)
         // 4: end for
         for w in self.elems.iter() {
-            h.absorb(&w.w1_encode::<POLY_W1_PACKED_LEN>())
-                .expect("absorb before squeeze is infallible");
+            h.absorb(w.w1_encode::<P>().as_ref()).expect("absorb before squeeze is infallible");
         }
     }
 }

--- a/crypto/mldsa/src/mldsa.rs
+++ b/crypto/mldsa/src/mldsa.rs
@@ -479,9 +479,10 @@ use crate::aux_functions::{
     expand_mask, expandA, expandS, make_hint_vecs, power_2_round_vec, sample_in_ball, sig_decode,
     sig_encode, use_hint_vecs,
 };
-use crate::matrix::{Matrix, Vector};
+use crate::matrix::{MatrixTrait, VectorTrait};
 use crate::mldsa_keys::{MLDSAPrivateKeyInternalTrait, MLDSAPrivateKeyTrait};
 use crate::mldsa_keys::{MLDSAPublicKeyInternalTrait, MLDSAPublicKeyTrait};
+use crate::params::{MLDSA44Params, MLDSA65Params, MLDSA87Params, MLDSAParams};
 use crate::{
     MLDSA44PrivateKey, MLDSA44PublicKey, MLDSA65PrivateKey, MLDSA65PublicKey, MLDSA87PrivateKey,
     MLDSA87PublicKey, MLDSAPrivateKeyExpanded, MLDSAPublicKeyExpanded,
@@ -493,7 +494,7 @@ use bouncycastle_core::traits::{
 };
 use bouncycastle_rng::HashDRBG_SHA512;
 use bouncycastle_sha3::{SHAKE128, SHAKE256, SUSPENDED_SHA3_STATE_LEN};
-use bouncycastle_utils::secret::Secret;
+use bouncycastle_utils::secret::{Secret, ZeroizablePrimitive};
 use core::marker::PhantomData;
 
 // imports needed just for docs
@@ -529,95 +530,28 @@ pub const MLDSA_MU_LEN: usize = 64;
 pub(crate) const POLY_T0PACKED_LEN: usize = 416;
 pub(crate) const POLY_T1PACKED_LEN: usize = 320;
 
-/* ML-DSA-44 params */
+/*** Re-exporting length constants that a caller will need instead of the entire Params objects which contains a bunch of internal algorithm detail ***/
 
 /// Length of the \[u8] holding a ML-DSA-44 public key.
-pub const MLDSA44_PK_LEN: usize = 1312;
+pub const MLDSA44_PK_LEN: usize = MLDSA44Params::PK_LEN;
 /// Length of the \[u8] holding a ML-DSA-44 private key.
-pub const MLDSA44_SK_LEN: usize = 2560;
+pub const MLDSA44_SK_LEN: usize = MLDSA44Params::SK_LEN;
 /// Length of the \[u8] holding a ML-DSA-44 signature value.
-pub const MLDSA44_SIG_LEN: usize = 2420;
-pub(crate) const MLDSA44_TAU: i32 = 39;
-pub(crate) const MLDSA44_LAMBDA: i32 = 128;
-pub(crate) const MLDSA44_GAMMA1: i32 = 1 << 17;
-pub(crate) const MLDSA44_GAMMA2: i32 = (q - 1) / 88; // mutants note: because of the bitshifting, the "- 1" ends up not mattering
-pub(crate) const MLDSA44_k: usize = 4;
-pub(crate) const MLDSA44_l: usize = 4;
-pub(crate) const MLDSA44_ETA: usize = 2;
-pub(crate) const MLDSA44_BETA: i32 = 78;
-pub(crate) const MLDSA44_OMEGA: i32 = 80;
-
-// Useful derived values
-pub(crate) const MLDSA44_C_TILDE: usize = 32;
-pub(crate) const MLDSA44_POLY_Z_PACKED_LEN: usize = 576;
-pub(crate) const MLDSA44_POLY_W1_PACKED_LEN: usize = 192;
-pub(crate) const MLDSA44_LAMBDA_over_4: usize = 128 / 4;
-pub(crate) const MLDSA44_GAMMA1_MINUS_BETA: i32 = MLDSA44_GAMMA1 - MLDSA44_BETA;
-pub(crate) const MLDSA44_GAMMA2_MINUS_BETA: i32 = MLDSA44_GAMMA2 - MLDSA44_BETA;
-
-// Alg 32
-// 1: 𝑐 ← 1 + bitlen (𝛾1 − 1)
-pub(crate) const MLDSA44_GAMMA1_MASK_LEN: usize = 576; // 32*(1 + bitlen (𝛾1 − 1) )
-
-/* ML-DSA-65 params */
+pub const MLDSA44_SIG_LEN: usize = MLDSA44Params::SIG_LEN;
 
 /// Length of the \[u8] holding a ML-DSA-65 public key.
-pub const MLDSA65_PK_LEN: usize = 1952;
+pub const MLDSA65_PK_LEN: usize = MLDSA65Params::PK_LEN;
 /// Length of the \[u8] holding a ML-DSA-65 private key.
-pub const MLDSA65_SK_LEN: usize = 4032;
+pub const MLDSA65_SK_LEN: usize = MLDSA65Params::SK_LEN;
 /// Length of the \[u8] holding a ML-DSA-65 signature value.
-pub const MLDSA65_SIG_LEN: usize = 3309;
-pub(crate) const MLDSA65_TAU: i32 = 49;
-pub(crate) const MLDSA65_LAMBDA: i32 = 192;
-pub(crate) const MLDSA65_GAMMA1: i32 = 1 << 19;
-pub(crate) const MLDSA65_GAMMA2: i32 = (q - 1) / 32; // mutants note: because of the bitshifting, the "- 1" ends up not mattering
-pub(crate) const MLDSA65_k: usize = 6;
-pub(crate) const MLDSA65_l: usize = 5;
-pub(crate) const MLDSA65_ETA: usize = 4;
-pub(crate) const MLDSA65_BETA: i32 = 196;
-pub(crate) const MLDSA65_OMEGA: i32 = 55;
-
-// Useful derived values
-pub(crate) const MLDSA65_C_TILDE: usize = 48;
-pub(crate) const MLDSA65_POLY_Z_PACKED_LEN: usize = 640;
-pub(crate) const MLDSA65_POLY_W1_PACKED_LEN: usize = 128;
-pub(crate) const MLDSA65_LAMBDA_over_4: usize = 192 / 4;
-pub(crate) const MLDSA65_GAMMA1_MINUS_BETA: i32 = MLDSA65_GAMMA1 - MLDSA65_BETA;
-pub(crate) const MLDSA65_GAMMA2_MINUS_BETA: i32 = MLDSA65_GAMMA2 - MLDSA65_BETA;
-
-// Alg 32
-// 1: 𝑐 ← 1 + bitlen (𝛾1 − 1)
-pub(crate) const MLDSA65_GAMMA1_MASK_LEN: usize = 640;
-
-/* ML-DSA-87 params */
+pub const MLDSA65_SIG_LEN: usize = MLDSA65Params::SIG_LEN;
 
 /// Length of the \[u8] holding a ML-DSA-87 public key.
-pub const MLDSA87_PK_LEN: usize = 2592;
+pub const MLDSA87_PK_LEN: usize = MLDSA87Params::PK_LEN;
 /// Length of the \[u8] holding a ML-DSA-87 private key.
-pub const MLDSA87_SK_LEN: usize = 4896;
+pub const MLDSA87_SK_LEN: usize = MLDSA87Params::SK_LEN;
 /// Length of the \[u8] holding a ML-DSA-87 signature value.
-pub const MLDSA87_SIG_LEN: usize = 4627;
-pub(crate) const MLDSA87_TAU: i32 = 60;
-pub(crate) const MLDSA87_LAMBDA: i32 = 256;
-pub(crate) const MLDSA87_GAMMA1: i32 = 1 << 19;
-pub(crate) const MLDSA87_GAMMA2: i32 = (q - 1) / 32; // mutants note: because of the bitshifting, the "- 1" ends up not mattering
-pub(crate) const MLDSA87_k: usize = 8;
-pub(crate) const MLDSA87_l: usize = 7;
-pub(crate) const MLDSA87_ETA: usize = 2;
-pub(crate) const MLDSA87_BETA: i32 = 120;
-pub(crate) const MLDSA87_OMEGA: i32 = 75;
-
-// Useful derived values
-pub(crate) const MLDSA87_C_TILDE: usize = 64;
-pub(crate) const MLDSA87_POLY_Z_PACKED_LEN: usize = 640;
-pub(crate) const MLDSA87_POLY_W1_PACKED_LEN: usize = 128;
-pub(crate) const MLDSA87_LAMBDA_over_4: usize = 256 / 4;
-pub(crate) const MLDSA87_GAMMA1_MINUS_BETA: i32 = MLDSA87_GAMMA1 - MLDSA87_BETA;
-pub(crate) const MLDSA87_GAMMA2_MINUS_BETA: i32 = MLDSA87_GAMMA2 - MLDSA87_BETA;
-
-// Alg 32
-// 1: 𝑐 ← 1 + bitlen (𝛾1 − 1)
-pub(crate) const MLDSA87_GAMMA1_MASK_LEN: usize = 640;
+pub const MLDSA87_SIG_LEN: usize = MLDSA87Params::SIG_LEN;
 
 // Typedefs just to make the algorithms look more like the FIPS 204 sample code.
 pub(crate) type H = SHAKE256;
@@ -627,110 +561,63 @@ pub(crate) type G = SHAKE128;
 
 /// The ML-DSA-44 algorithm.
 pub type MLDSA44 = MLDSA<
+    MLDSA44Params,
+    MLDSA44PublicKey,
+    MLDSA44PrivateKey,
     MLDSA44_PK_LEN,
     MLDSA44_SK_LEN,
     MLDSA44_SIG_LEN,
-    MLDSA44PublicKey,
-    MLDSA44PrivateKey,
-    MLDSA44_TAU,
-    MLDSA44_LAMBDA,
-    MLDSA44_GAMMA1,
-    MLDSA44_GAMMA2,
-    MLDSA44_k,
-    MLDSA44_l,
-    MLDSA44_ETA,
-    MLDSA44_BETA,
-    MLDSA44_OMEGA,
-    MLDSA44_C_TILDE,
-    MLDSA44_POLY_Z_PACKED_LEN,
-    MLDSA44_POLY_W1_PACKED_LEN,
-    MLDSA44_LAMBDA_over_4,
-    MLDSA44_GAMMA1_MINUS_BETA,
-    MLDSA44_GAMMA2_MINUS_BETA,
-    MLDSA44_GAMMA1_MASK_LEN,
 >;
-
-impl Algorithm for MLDSA44 {
-    const ALG_NAME: &'static str = ML_DSA_44_NAME;
-    const MAX_SECURITY_STRENGTH: SecurityStrength = SecurityStrength::_128bit;
-}
-/// Assigned by NIST in the Computer Security Objects Register: id-ml-dsa-44 { sigAlgs 17 }
-impl AlgorithmOID for MLDSA44 {
-    const OID: &'static [u32] = &[2, 16, 840, 1, 101, 3, 4, 3, 17];
-    const OID_DER: &'static [u8] =
-        &[0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x03, 0x11];
-}
 
 /// The ML-DSA-65 algorithm.
 pub type MLDSA65 = MLDSA<
+    MLDSA65Params,
+    MLDSA65PublicKey,
+    MLDSA65PrivateKey,
     MLDSA65_PK_LEN,
     MLDSA65_SK_LEN,
     MLDSA65_SIG_LEN,
-    MLDSA65PublicKey,
-    MLDSA65PrivateKey,
-    MLDSA65_TAU,
-    MLDSA65_LAMBDA,
-    MLDSA65_GAMMA1,
-    MLDSA65_GAMMA2,
-    MLDSA65_k,
-    MLDSA65_l,
-    MLDSA65_ETA,
-    MLDSA65_BETA,
-    MLDSA65_OMEGA,
-    MLDSA65_C_TILDE,
-    MLDSA65_POLY_Z_PACKED_LEN,
-    MLDSA65_POLY_W1_PACKED_LEN,
-    MLDSA65_LAMBDA_over_4,
-    MLDSA65_GAMMA1_MINUS_BETA,
-    MLDSA65_GAMMA2_MINUS_BETA,
-    MLDSA65_GAMMA1_MASK_LEN,
 >;
-
-impl Algorithm for MLDSA65 {
-    const ALG_NAME: &'static str = ML_DSA_65_NAME;
-    const MAX_SECURITY_STRENGTH: SecurityStrength = SecurityStrength::_192bit;
-}
-/// Assigned by NIST in the Computer Security Objects Register: id-ml-dsa-65 { sigAlgs 18 }
-impl AlgorithmOID for MLDSA65 {
-    const OID: &'static [u32] = &[2, 16, 840, 1, 101, 3, 4, 3, 18];
-    const OID_DER: &'static [u8] =
-        &[0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x03, 0x12];
-}
 
 /// The ML-DSA-87 algorithm.
 pub type MLDSA87 = MLDSA<
+    MLDSA87Params,
+    MLDSA87PublicKey,
+    MLDSA87PrivateKey,
     MLDSA87_PK_LEN,
     MLDSA87_SK_LEN,
     MLDSA87_SIG_LEN,
-    MLDSA87PublicKey,
-    MLDSA87PrivateKey,
-    MLDSA87_TAU,
-    MLDSA87_LAMBDA,
-    MLDSA87_GAMMA1,
-    MLDSA87_GAMMA2,
-    MLDSA87_k,
-    MLDSA87_l,
-    MLDSA87_ETA,
-    MLDSA87_BETA,
-    MLDSA87_OMEGA,
-    MLDSA87_C_TILDE,
-    MLDSA87_POLY_Z_PACKED_LEN,
-    MLDSA87_POLY_W1_PACKED_LEN,
-    MLDSA87_LAMBDA_over_4,
-    MLDSA87_GAMMA1_MINUS_BETA,
-    MLDSA87_GAMMA2_MINUS_BETA,
-    MLDSA87_GAMMA1_MASK_LEN,
 >;
 
-impl Algorithm for MLDSA87 {
-    const ALG_NAME: &'static str = ML_DSA_87_NAME;
-    const MAX_SECURITY_STRENGTH: SecurityStrength = SecurityStrength::_256bit;
+/// The name and claimed strength of an ML-DSA algorithm are properties of its parameter set, so
+/// one impl covers all three; `MLDSAParams` is sealed, so those are the only three that exist.
+impl<
+    P: MLDSAParams,
+    PK: MLDSAPublicKeyTrait<P, PK_LEN> + MLDSAPublicKeyInternalTrait<P, PK_LEN>,
+    SK: MLDSAPrivateKeyTrait<P, SK_LEN, PK_LEN> + MLDSAPrivateKeyInternalTrait<P, SK_LEN, PK_LEN>,
+    const PK_LEN: usize,
+    const SK_LEN: usize,
+    const SIG_LEN: usize,
+> Algorithm for MLDSA<P, PK, SK, PK_LEN, SK_LEN, SIG_LEN>
+{
+    const ALG_NAME: &'static str = P::ALG_NAME;
+    const MAX_SECURITY_STRENGTH: SecurityStrength = P::MAX_SECURITY_STRENGTH;
 }
-/// Assigned by NIST in the Computer Security Objects Register: id-ml-dsa-87 { sigAlgs 19 }
-impl AlgorithmOID for MLDSA87 {
-    const OID: &'static [u32] = &[2, 16, 840, 1, 101, 3, 4, 3, 19];
-    const OID_DER: &'static [u8] =
-        &[0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x03, 0x13];
+
+/// The OIDs NIST assigned in the Computer Security Objects Register: id-ml-dsa-44 { sigAlgs 17 },
+/// id-ml-dsa-65 { sigAlgs 18 } and id-ml-dsa-87 { sigAlgs 19 }. As with [`Algorithm`], the values
+/// belong to the parameter set, so one impl covers all three.
+impl<
+    P: MLDSAParams,
+    PK: MLDSAPublicKeyTrait<P, PK_LEN> + MLDSAPublicKeyInternalTrait<P, PK_LEN>,
+    SK: MLDSAPrivateKeyTrait<P, SK_LEN, PK_LEN> + MLDSAPrivateKeyInternalTrait<P, SK_LEN, PK_LEN>,
+    const PK_LEN: usize,
+    const SK_LEN: usize,
+    const SIG_LEN: usize,
+> AlgorithmOID for MLDSA<P, PK, SK, PK_LEN, SK_LEN, SIG_LEN>
+{
+    const OID: &'static [u32] = P::OID;
+    const OID_DER: &'static [u8] = P::OID_DER;
 }
 
 /// The core internal implementation of the ML-DSA algorithm.
@@ -738,30 +625,14 @@ impl AlgorithmOID for MLDSA87 {
 /// but it shouldn't ever need to be used directly.
 /// Please use the named public types [`MLDSA44`], [`MLDSA65`], [`MLDSA87`] instead.
 pub struct MLDSA<
+    P: MLDSAParams,
+    PK: MLDSAPublicKeyTrait<P, PK_LEN> + MLDSAPublicKeyInternalTrait<P, PK_LEN>,
+    SK: MLDSAPrivateKeyTrait<P, SK_LEN, PK_LEN> + MLDSAPrivateKeyInternalTrait<P, SK_LEN, PK_LEN>,
     const PK_LEN: usize,
     const SK_LEN: usize,
     const SIG_LEN: usize,
-    PK: MLDSAPublicKeyTrait<k, l, PK_LEN> + MLDSAPublicKeyInternalTrait<k, PK_LEN>,
-    SK: MLDSAPrivateKeyTrait<k, l, ETA, SK_LEN, PK_LEN>
-        + MLDSAPrivateKeyInternalTrait<k, l, ETA, SK_LEN, PK_LEN>,
-    const TAU: i32,
-    const LAMBDA: i32,
-    const GAMMA1: i32,
-    const GAMMA2: i32,
-    const k: usize,
-    const l: usize,
-    const ETA: usize,
-    const BETA: i32,
-    const OMEGA: i32,
-    const C_TILDE: usize,
-    const POLY_VEC_H_PACKED_LEN: usize,
-    const POLY_W1_PACKED_LEN: usize,
-    const LAMBDA_over_4: usize,
-    const GAMMA1_MINUS_BETA: i32,
-    const GAMMA2_MINUS_BETA: i32,
-    const GAMMA1_MASK_LEN: usize,
 > {
-    _phantom: PhantomData<(PK, SK)>,
+    _phantom: PhantomData<(P, PK, SK)>,
 
     /// used for streaming the message for both signing and verifying
     mu_builder: MuBuilder,
@@ -779,52 +650,13 @@ pub struct MLDSA<
 }
 
 impl<
+    P: MLDSAParams,
+    PK: MLDSAPublicKeyTrait<P, PK_LEN> + MLDSAPublicKeyInternalTrait<P, PK_LEN>,
+    SK: MLDSAPrivateKeyTrait<P, SK_LEN, PK_LEN> + MLDSAPrivateKeyInternalTrait<P, SK_LEN, PK_LEN>,
     const PK_LEN: usize,
     const SK_LEN: usize,
     const SIG_LEN: usize,
-    PK: MLDSAPublicKeyTrait<k, l, PK_LEN> + MLDSAPublicKeyInternalTrait<k, PK_LEN>,
-    SK: MLDSAPrivateKeyTrait<k, l, ETA, SK_LEN, PK_LEN>
-        + MLDSAPrivateKeyInternalTrait<k, l, ETA, SK_LEN, PK_LEN>,
-    const TAU: i32,
-    const LAMBDA: i32,
-    const GAMMA1: i32,
-    const GAMMA2: i32,
-    const k: usize,
-    const l: usize,
-    const ETA: usize,
-    const BETA: i32,
-    const OMEGA: i32,
-    const C_TILDE: usize,
-    const POLY_Z_PACKED_LEN: usize,
-    const POLY_W1_PACKED_LEN: usize,
-    const LAMBDA_over_4: usize,
-    const GAMMA1_MINUS_BETA: i32,
-    const GAMMA2_MINUS_BETA: i32,
-    const GAMMA1_MASK_LEN: usize,
->
-    MLDSA<
-        PK_LEN,
-        SK_LEN,
-        SIG_LEN,
-        PK,
-        SK,
-        TAU,
-        LAMBDA,
-        GAMMA1,
-        GAMMA2,
-        k,
-        l,
-        ETA,
-        BETA,
-        OMEGA,
-        C_TILDE,
-        POLY_Z_PACKED_LEN,
-        POLY_W1_PACKED_LEN,
-        LAMBDA_over_4,
-        GAMMA1_MINUS_BETA,
-        GAMMA2_MINUS_BETA,
-        GAMMA1_MASK_LEN,
-    >
+> MLDSA<P, PK, SK, PK_LEN, SK_LEN, SIG_LEN>
 {
     /// Implements Algorithm 6 of FIPS 204
     /// Note: NIST has made a special exception in the FIPS 204 FAQ that this _internal function
@@ -844,7 +676,7 @@ impl<
             ));
         }
 
-        if seed.security_strength() < SecurityStrength::from_bits(LAMBDA as usize) {
+        if seed.security_strength() < SecurityStrength::from_bits(P::LAMBDA as usize) {
             return Err(SignatureError::KeyGenError(
                 "Seed SecurityStrength must match algorithm security strength",
             ));
@@ -859,8 +691,8 @@ impl<
             // scope for h
             let mut h = H::default();
             h.absorb(seed.ref_to_bytes()).expect("absorb before squeeze is infallible");
-            h.absorb(&(k as u8).to_le_bytes()).expect("absorb before squeeze is infallible");
-            h.absorb(&(l as u8).to_le_bytes()).expect("absorb before squeeze is infallible");
+            h.absorb(&(P::k as u8).to_le_bytes()).expect("absorb before squeeze is infallible");
+            h.absorb(&(P::l as u8).to_le_bytes()).expect("absorb before squeeze is infallible");
             let bytes_written = h.squeeze_out(&mut rho);
             debug_assert_eq!(bytes_written, 32);
             let mut rho_prime: [u8; 64] = [0u8; 64];
@@ -870,7 +702,7 @@ impl<
             debug_assert_eq!(bytes_written, 32);
 
             // 4: (𝐬1, 𝐬2) ← ExpandS(𝜌′)
-            let (mut s1, s2) = expandS::<k, l, ETA>(&rho_prime);
+            let (mut s1, s2) = expandS::<P>(&rho_prime);
 
             s1.ntt();
             (s1, s2)
@@ -879,7 +711,7 @@ impl<
         let t_hat = {
             // scope for s1_hat
             // 3: 𝐀_hat ← ExpandA(𝜌) ▷ 𝐀 is generated and stored in NTT representation as 𝐀
-            let A_hat = expandA::<k, l>(&rho);
+            let A_hat = expandA::<P>(&rho);
 
             // 5: 𝐭 ← NTT−1(𝐀 ∘ NTT(𝐬1)) + 𝐬2
             //   ▷ compute 𝐭 = 𝐀𝐬1 + 𝐬2
@@ -896,7 +728,7 @@ impl<
             // 6: (𝐭1, 𝐭0) ← Power2Round(𝐭)
             //   ▷ compress 𝐭
             //   ▷ PowerTwoRound is applied componentwise (see explanatory text in Section 7.4)
-            power_2_round_vec::<k>(&t)
+            power_2_round_vec(&t)
         };
 
         // 8: 𝑝𝑘 ← pkEncode(𝜌, 𝐭1)
@@ -928,7 +760,7 @@ impl<
     /// modified to take an externally-computed mu instead of M', and to take the public matrix A_hat
     fn sign_internal(
         sk: &SK,
-        A_hat: &Matrix<k, l>,
+        A_hat: &P::MatrixA,
         mu: &[u8; 64],
         rnd: [u8; 32],
         output: &mut [u8; SIG_LEN],
@@ -972,22 +804,22 @@ impl<
         //  ▷ rejection sampling loop
 
         // these need to be outside the loop because they form the encoded signature value
-        let mut sig_val_c_tilde = [0u8; LAMBDA_over_4];
-        let mut sig_val_z: Vector<l>;
-        let mut sig_val_h: Vector<k>;
+        let mut sig_val_c_tilde = <P::SigCTilde as ZeroizablePrimitive>::ZEROED;
+        let mut sig_val_z: P::VecL;
+        let mut sig_val_h: P::VecK;
         loop {
             // FIPS 204 s. 6.2 allows:
             //   "Implementations may limit the number of iterations in this loop to not exceed a finite maximum value."
             // mutants note: there is no test for this because, at this point,
             // we don't know of a KAT that will exceed this limit.
-            if kappa > 1000 * k as u16 {
+            if kappa > 1000 * P::k as u16 {
                 return Err(SignatureError::GenericError(
                     "Rejection sampling loop exceeded max iterations, try again with a different signing nonce.",
                 ));
             }
 
             // 11: 𝐲 ∈ 𝑅^ℓ ← ExpandMask(𝜌″, 𝜅)
-            let mut y = expand_mask::<l, GAMMA1, GAMMA1_MASK_LEN>(&rho_p_p, kappa);
+            let mut y = expand_mask::<P>(&rho_p_p, kappa);
 
             let w = {
                 // scope for y_hat
@@ -1002,7 +834,7 @@ impl<
 
             // 13: 𝐰1 ← HighBits(𝐰)
             //  ▷ signer’s commitment
-            let w1 = w.high_bits::<GAMMA2>();
+            let w1 = w.high_bits::<P>();
 
             {
                 // scope for h
@@ -1010,15 +842,15 @@ impl<
                 //  ▷ commitment hash
                 let mut hash = H::new();
                 hash.absorb(mu).expect("absorb before squeeze is infallible");
-                w1.w1_encode_and_hash::<POLY_W1_PACKED_LEN>(&mut hash);
-                hash.squeeze_out(&mut sig_val_c_tilde);
+                w1.w1_encode_and_hash::<P>(&mut hash);
+                hash.squeeze_out(sig_val_c_tilde.as_mut());
             }
 
             // 16: 𝑐 ∈ 𝑅𝑞 ← SampleInBall(c_tilde)
             //  ▷ verifier’s challenge
             let c_hat = {
                 // scope for c
-                let mut c = sample_in_ball::<LAMBDA_over_4, TAU>(&sig_val_c_tilde);
+                let mut c = sample_in_ball::<P>(&sig_val_c_tilde);
 
                 // 17: 𝑐_hat ← NTT(𝑐)
                 c.ntt();
@@ -1038,8 +870,8 @@ impl<
             //  ▷ validity checks
             // This is done out-of-order on purpose for performance reasons:
             // rejection sampling check is done before any extra heavy computation
-            if sig_val_z.check_norm::<GAMMA1_MINUS_BETA>() {
-                kappa += l as u16;
+            if sig_val_z.check_norm(P::GAMMA1_MINUS_BETA) {
+                kappa += P::l as u16;
                 continue;
             };
 
@@ -1048,7 +880,7 @@ impl<
             cs2.inv_ntt();
 
             // 21: 𝐫0 ← LowBits(𝐰 − ⟨⟨𝑐𝐬2⟩⟩)
-            let mut r0 = w.sub_vector(&cs2).low_bits::<GAMMA2>();
+            let mut r0 = w.sub_vector(&cs2).low_bits::<P>();
 
             // 23 (second half): if ||𝐳||∞ ≥ 𝛾1 − 𝛽 or ||𝐫0||∞ ≥ 𝛾2 − 𝛽 then (z, h) ← ⊥
             //  ▷ validity checks
@@ -1058,8 +890,8 @@ impl<
             //      and checking whether ‖r0‖∞ < γ2 − β and r1 = w1, it is equivalent to just check that
             //      ‖w0 − cs2‖∞ < γ2 − β, where w0 is the low part of w. If this check passes, w0 − cs2
             //      is the low part of w − cs2."
-            if r0.check_norm::<GAMMA2_MINUS_BETA>() {
-                kappa += l as u16;
+            if r0.check_norm(P::GAMMA2_MINUS_BETA) {
+                kappa += P::l as u16;
                 continue;
             };
 
@@ -1071,8 +903,8 @@ impl<
             // This is done out-of-order on purpose for performance reasons:
             // rejection sampling check is done before any extra heavy computation
             // mutants note: there is currently no unit test that triggers this branch
-            if ct0.check_norm::<GAMMA2>() {
-                kappa += l as u16;
+            if ct0.check_norm(P::GAMMA2) {
+                kappa += P::l as u16;
                 continue;
             };
 
@@ -1083,15 +915,15 @@ impl<
             let hint_hamming_weight: i32;
             sig_val_h = {
                 // scope for hint
-                let (hint, inner_hint_hamming_weight) = make_hint_vecs::<k, GAMMA2>(&r0, &w1);
+                let (hint, inner_hint_hamming_weight) = make_hint_vecs::<P>(&r0, &w1);
                 hint_hamming_weight = inner_hint_hamming_weight;
                 hint
             };
 
             // 28 (second half): if ||⟨⟨𝑐𝐭0⟩⟩||∞ ≥ 𝛾2 or the number of 1’s in 𝐡 is greater than 𝜔, then (z, h) ← ⊥
             // mutants note: there is no test KAT that triggers this branch
-            if hint_hamming_weight > OMEGA {
-                kappa += l as u16;
+            if hint_hamming_weight > P::OMEGA {
+                kappa += P::l as u16;
                 continue;
             };
 
@@ -1106,9 +938,7 @@ impl<
 
         // 33: 𝜎 ← sigEncode(𝑐, 𝐳̃ mod±𝑞, 𝐡)
         let bytes_written =
-            sig_encode::<GAMMA1, k, l, LAMBDA_over_4, OMEGA, POLY_Z_PACKED_LEN, SIG_LEN>(
-                &sig_val_c_tilde, &sig_val_z, &sig_val_h, output,
-            );
+            sig_encode::<P, SIG_LEN>(&sig_val_c_tilde, &sig_val_z, &sig_val_h, output);
 
         Ok(bytes_written)
     }
@@ -1119,7 +949,7 @@ impl<
     /// Input: Signature 𝜎 ∈ 𝔹𝜆/4+ℓ⋅32⋅(1+bitlen (𝛾1−1))+𝜔+𝑘.
     fn verify_internal(
         pk: &PK,
-        A_hat: &Matrix<k, l>,
+        A_hat: &P::MatrixA,
         mu: &[u8; 64],
         sig: &[u8; SIG_LEN],
     ) -> Result<(), SignatureError> {
@@ -1129,12 +959,11 @@ impl<
         // 2: (𝑐_tilde, 𝐳, 𝐡) ← sigDecode(𝜎)
         //  ▷ signer’s commitment hash c_tilde, response 𝐳, and hint 𝐡
         // 3: if 𝐡 = ⊥ then return false
-        let (c_tilde, z, h) =
-            sig_decode::<GAMMA1, k, l, LAMBDA_over_4, OMEGA, POLY_Z_PACKED_LEN, SIG_LEN>(&sig)
-                .map_err(|_| SignatureError::SignatureVerificationFailed)?;
+        let (c_tilde, z, h) = sig_decode::<P, SIG_LEN>(&sig)
+            .map_err(|_| SignatureError::SignatureVerificationFailed)?;
 
         // 13 (first half) return [[ ||𝐳||∞ < 𝛾1 − 𝛽]]
-        if z.check_norm::<GAMMA1_MINUS_BETA>() {
+        if z.check_norm(P::GAMMA1_MINUS_BETA) {
             return Err(SignatureError::SignatureVerificationFailed);
         }
 
@@ -1151,7 +980,7 @@ impl<
 
         // 8: 𝑐 ∈ 𝑅𝑞 ← SampleInBall(c_tilde)
         let c_hat = {
-            let mut c = sample_in_ball::<LAMBDA_over_4, TAU>(&c_tilde);
+            let mut c = sample_in_ball::<P>(&c_tilde);
             c.ntt();
 
             c
@@ -1173,7 +1002,7 @@ impl<
             };
             let ct1 = {
                 // potential optimization -- pre-compute this on key load?
-                let mut t1_shift_hat = pk.t1().shift_left::<d>();
+                let mut t1_shift_hat = pk.t1().shift_left_d();
                 t1_shift_hat.ntt();
                 t1_shift_hat.scalar_vector_ntt(&c_hat)
             };
@@ -1183,23 +1012,23 @@ impl<
 
             // 10: 𝐰1′ ← UseHint(𝐡, 𝐰'_approx)
             // ▷ reconstruction of signer’s commitment
-            use_hint_vecs::<k, GAMMA2>(&h, &wp_approx)
+            use_hint_vecs::<P>(&h, &wp_approx)
         };
         // 12: 𝑐_tilde_p ← H(𝜇||w1Encode(𝐰1'), 𝜆/4)
         // ▷ hash it; this should match 𝑐_tilde
         let c_tilde_p = {
-            let mut c_tilde_p = [0u8; LAMBDA_over_4];
+            let mut c_tilde_p = <P::SigCTilde as ZeroizablePrimitive>::ZEROED;
             let mut hash = H::new();
             hash.absorb(mu).expect("absorb before squeeze is infallible");
-            w1p.w1_encode_and_hash::<POLY_W1_PACKED_LEN>(&mut hash);
-            hash.squeeze_out(&mut c_tilde_p);
+            w1p.w1_encode_and_hash::<P>(&mut hash);
+            hash.squeeze_out(c_tilde_p.as_mut());
 
             c_tilde_p
         };
 
         // verification probably doesn't technically need to be constant-time, but why not?
         // 13 (second half): return [[ ||𝐳||∞ < 𝛾1 − 𝛽]] and [[𝑐 ̃ = 𝑐′ ]]
-        if bouncycastle_utils::ct::ct_eq_bytes(&c_tilde, &c_tilde_p) {
+        if bouncycastle_utils::ct::ct_eq_bytes(c_tilde.as_ref(), c_tilde_p.as_ref()) {
             Ok(())
         } else {
             Err(SignatureError::SignatureVerificationFailed)
@@ -1208,52 +1037,13 @@ impl<
 }
 
 impl<
+    P: MLDSAParams,
+    PK: MLDSAPublicKeyTrait<P, PK_LEN> + MLDSAPublicKeyInternalTrait<P, PK_LEN>,
+    SK: MLDSAPrivateKeyTrait<P, SK_LEN, PK_LEN> + MLDSAPrivateKeyInternalTrait<P, SK_LEN, PK_LEN>,
     const PK_LEN: usize,
     const SK_LEN: usize,
     const SIG_LEN: usize,
-    PK: MLDSAPublicKeyTrait<k, l, PK_LEN> + MLDSAPublicKeyInternalTrait<k, PK_LEN>,
-    SK: MLDSAPrivateKeyTrait<k, l, ETA, SK_LEN, PK_LEN>
-        + MLDSAPrivateKeyInternalTrait<k, l, ETA, SK_LEN, PK_LEN>,
-    const TAU: i32,
-    const LAMBDA: i32,
-    const GAMMA1: i32,
-    const GAMMA2: i32,
-    const k: usize,
-    const l: usize,
-    const ETA: usize,
-    const BETA: i32,
-    const OMEGA: i32,
-    const C_TILDE: usize,
-    const POLY_Z_PACKED_LEN: usize,
-    const POLY_W1_PACKED_LEN: usize,
-    const LAMBDA_over_4: usize,
-    const GAMMA1_MINUS_BETA: i32,
-    const GAMMA2_MINUS_BETA: i32,
-    const GAMMA1_MASK_LEN: usize,
-> MLDSATrait<PK_LEN, SK_LEN, SIG_LEN, PK, SK, LAMBDA, k, l, ETA>
-    for MLDSA<
-        PK_LEN,
-        SK_LEN,
-        SIG_LEN,
-        PK,
-        SK,
-        TAU,
-        LAMBDA,
-        GAMMA1,
-        GAMMA2,
-        k,
-        l,
-        ETA,
-        BETA,
-        OMEGA,
-        C_TILDE,
-        POLY_Z_PACKED_LEN,
-        POLY_W1_PACKED_LEN,
-        LAMBDA_over_4,
-        GAMMA1_MINUS_BETA,
-        GAMMA2_MINUS_BETA,
-        GAMMA1_MASK_LEN,
-    >
+> MLDSATrait<P, PK, SK, PK_LEN, SK_LEN, SIG_LEN> for MLDSA<P, PK, SK, PK_LEN, SK_LEN, SIG_LEN>
 {
     fn keygen_from_seed(seed: &KeyMaterial<32>) -> Result<(PK, SK), SignatureError> {
         Self::keygen_internal(seed)
@@ -1290,21 +1080,21 @@ impl<
         MuBuilder::compute_mu(tr, msg, ctx)
     }
     fn compute_mu_from_pk(
-        pk: &impl MLDSAPublicKeyTrait<k, l, PK_LEN>,
+        pk: &impl MLDSAPublicKeyTrait<P, PK_LEN>,
         msg: &[u8],
         ctx: Option<&[u8]>,
     ) -> Result<[u8; 64], SignatureError> {
         MuBuilder::compute_mu(&pk.compute_tr(), msg, ctx)
     }
     fn compute_mu_from_sk(
-        sk: &impl MLDSAPrivateKeyTrait<k, l, ETA, SK_LEN, PK_LEN>,
+        sk: &impl MLDSAPrivateKeyTrait<P, SK_LEN, PK_LEN>,
         msg: &[u8],
         ctx: Option<&[u8]>,
     ) -> Result<[u8; 64], SignatureError> {
         MuBuilder::compute_mu(&sk.tr(), msg, ctx)
     }
     fn sign_with_expanded_key(
-        sk: &MLDSAPrivateKeyExpanded<k, l, ETA, PK, SK, SK_LEN, PK_LEN>,
+        sk: &MLDSAPrivateKeyExpanded<P, PK, SK, SK_LEN, PK_LEN>,
         msg: &[u8],
         ctx: Option<&[u8]>,
     ) -> Result<[u8; SIG_LEN], SignatureError> {
@@ -1313,7 +1103,7 @@ impl<
     }
 
     fn sign_with_expanded_key_out(
-        sk: &MLDSAPrivateKeyExpanded<k, l, ETA, PK, SK, SK_LEN, PK_LEN>,
+        sk: &MLDSAPrivateKeyExpanded<P, PK, SK, SK_LEN, PK_LEN>,
         msg: &[u8],
         ctx: Option<&[u8]>,
         out: &mut [u8; SIG_LEN],
@@ -1326,7 +1116,7 @@ impl<
 
     fn sign_mu(
         sk: &SK,
-        A_hat: Option<&Matrix<k, l>>,
+        A_hat: Option<&P::MatrixA>,
         mu: &[u8; 64],
     ) -> Result<[u8; SIG_LEN], SignatureError> {
         let mut out: [u8; SIG_LEN] = [0u8; SIG_LEN];
@@ -1336,7 +1126,7 @@ impl<
     }
     fn sign_mu_out(
         sk: &SK,
-        A_hat: Option<&Matrix<k, l>>,
+        A_hat: Option<&P::MatrixA>,
         mu: &[u8; 64],
         output: &mut [u8; SIG_LEN],
     ) -> Result<usize, SignatureError> {
@@ -1348,8 +1138,8 @@ impl<
         Self::sign_mu_deterministic_out(sk, A_hat, mu, rnd, output)
     }
     fn sign_mu_with_expanded_key(
-        sk: &MLDSAPrivateKeyExpanded<k, l, ETA, PK, SK, SK_LEN, PK_LEN>,
-        A_hat: Option<&Matrix<k, l>>,
+        sk: &MLDSAPrivateKeyExpanded<P, PK, SK, SK_LEN, PK_LEN>,
+        A_hat: Option<&P::MatrixA>,
         mu: &[u8; 64],
     ) -> Result<[u8; SIG_LEN], SignatureError> {
         let mut out: [u8; SIG_LEN] = [0u8; SIG_LEN];
@@ -1358,8 +1148,8 @@ impl<
         Ok(out)
     }
     fn sign_mu_with_expanded_key_out(
-        sk: &MLDSAPrivateKeyExpanded<k, l, ETA, PK, SK, SK_LEN, PK_LEN>,
-        A_hat: Option<&Matrix<k, l>>,
+        sk: &MLDSAPrivateKeyExpanded<P, PK, SK, SK_LEN, PK_LEN>,
+        A_hat: Option<&P::MatrixA>,
         mu: &[u8; 64],
         out: &mut [u8; SIG_LEN],
     ) -> Result<usize, SignatureError> {
@@ -1370,7 +1160,7 @@ impl<
 
     fn sign_mu_deterministic(
         sk: &SK,
-        A_hat: Option<&Matrix<k, l>>,
+        A_hat: Option<&P::MatrixA>,
         mu: &[u8; 64],
         rnd: [u8; 32],
     ) -> Result<[u8; SIG_LEN], SignatureError> {
@@ -1381,7 +1171,7 @@ impl<
     }
     fn sign_mu_deterministic_out(
         sk: &SK,
-        A_hat: Option<&Matrix<k, l>>,
+        A_hat: Option<&P::MatrixA>,
         mu: &[u8; 64],
         rnd: [u8; 32],
         output: &mut [u8; SIG_LEN],
@@ -1409,7 +1199,7 @@ impl<
     /// This is a middle ground between keygen_from_seed()+sign_mu() and
     /// the fully streamed low-memory implementation.
     // TODO: benchmark peak memory + runtime against
-    // keygen_from_seed() + sign_mu_deterministic() to confirm the separate path earns being kept.
+    //       keygen_from_seed() + sign_mu_deterministic() to confirm the separate path earns being kept.
     // Note: this path intentionally avoids the public key entirely
     // (no pkEncode / tr = H(pk)) since μ is supplied externally.
     fn sign_mu_deterministic_from_seed_out(
@@ -1436,7 +1226,7 @@ impl<
             ));
         }
 
-        if seed.security_strength() < SecurityStrength::from_bits(LAMBDA as usize) {
+        if seed.security_strength() < SecurityStrength::from_bits(P::LAMBDA as usize) {
             return Err(SignatureError::KeyGenError(
                 "Seed SecurityStrength must match algorithm security strength: 128-bit (ML-DSA-44), 192-bit (ML-DSA-65), or 256-bit (ML-DSA-87).",
             ));
@@ -1453,8 +1243,8 @@ impl<
             let (rho, rho_prime, K) = {
                 let mut h = H::default();
                 h.absorb(seed.ref_to_bytes()).expect("absorb before squeeze is infallible");
-                h.absorb(&(k as u8).to_le_bytes()).expect("absorb before squeeze is infallible");
-                h.absorb(&(l as u8).to_le_bytes()).expect("absorb before squeeze is infallible");
+                h.absorb(&(P::k as u8).to_le_bytes()).expect("absorb before squeeze is infallible");
+                h.absorb(&(P::l as u8).to_le_bytes()).expect("absorb before squeeze is infallible");
                 let mut rho = [0u8; 32];
                 let bytes_written = h.squeeze_out(&mut rho);
                 debug_assert_eq!(bytes_written, 32);
@@ -1481,7 +1271,7 @@ impl<
             };
 
             // 4: (𝐬1, 𝐬2) ← ExpandS(𝜌′)
-            let (s1, s2) = expandS::<k, l, ETA>(&rho_prime);
+            let (s1, s2) = expandS::<P>(&rho_prime);
 
             (rho, rho_p_p, s1, s2)
         };
@@ -1494,7 +1284,7 @@ impl<
         // as 20 or even 80 times. So moving expandA() inside the loop would be a pretty drastic speed-for-memory tradeoff
         // whose generality falls out of the scope of this implementation.
         // It is left as an optimization that can be made by users that require further reduction of memory usage
-        let A_hat = expandA::<k, l>(&rho);
+        let A_hat = expandA::<P>(&rho);
 
         // Alg 7; 8: 𝜅 ← 0
         //  ▷ initialize counter 𝜅
@@ -1507,21 +1297,21 @@ impl<
         //  ▷ rejection sampling loop
 
         // these need to be outside the loop because they form the encoded signature value
-        let mut sig_val_c_tilde = [0u8; LAMBDA_over_4];
-        let mut sig_val_z: Vector<l>;
-        let mut sig_val_h: Vector<k>;
+        let mut sig_val_c_tilde = <P::SigCTilde as ZeroizablePrimitive>::ZEROED;
+        let mut sig_val_z: P::VecL;
+        let mut sig_val_h: P::VecK;
         loop {
             // FIPS 204 s. 6.2 allows:
             //   "Implementations may limit the number of iterations in this loop to not exceed a finite maximum value."
             // mutants note: there is no test for this because we don't know of a KAT that will exceed this limit.
-            if kappa > 1000 * k as u16 {
+            if kappa > 1000 * P::k as u16 {
                 return Err(SignatureError::GenericError(
                     "Rejection sampling loop exceeded max iterations, try again with a different signing nonce.",
                 ));
             }
 
             // Alg 7; 11: 𝐲 ∈ 𝑅^ℓ ← ExpandMask(𝜌″, 𝜅)
-            let mut y = expand_mask::<l, GAMMA1, GAMMA1_MASK_LEN>(&rho_p_p, kappa);
+            let mut y = expand_mask::<P>(&rho_p_p, kappa);
 
             let w = {
                 // scope for y_hat
@@ -1536,7 +1326,7 @@ impl<
 
             // Alg 7; 13: 𝐰1 ← HighBits(𝐰)
             //  ▷ signer’s commitment
-            let w1 = w.high_bits::<GAMMA2>();
+            let w1 = w.high_bits::<P>();
 
             {
                 // scope for h
@@ -1544,22 +1334,22 @@ impl<
                 //  ▷ commitment hash
                 let mut hash = H::new();
                 hash.absorb(mu).expect("absorb before squeeze is infallible");
-                w1.w1_encode_and_hash::<POLY_W1_PACKED_LEN>(&mut hash);
-                hash.squeeze_out(&mut sig_val_c_tilde);
+                w1.w1_encode_and_hash::<P>(&mut hash);
+                hash.squeeze_out(sig_val_c_tilde.as_mut());
             }
 
             // Alg 7; 16: 𝑐 ∈ 𝑅𝑞 ← SampleInBall(c_tilde)
             //  ▷ verifier’s challenge
             let c_hat = {
                 // scope for c
-                let mut c = sample_in_ball::<LAMBDA_over_4, TAU>(&sig_val_c_tilde);
+                let mut c = sample_in_ball::<P>(&sig_val_c_tilde);
 
                 // 17: 𝑐_hat ← NTT(𝑐)
                 c.ntt();
                 c
             };
 
-            let t_hat: Vector<k>;
+            let t_hat: P::VecK;
             sig_val_z = {
                 // scope for s1_hat, cs1
                 // Alg 7; 2: 𝐬1̂_hat ← NTT(𝐬1)
@@ -1591,13 +1381,13 @@ impl<
             //  ▷ validity checks
             // This is done out-of-order on purpose for performance reasons:
             // rejection sampling check is done before any extra heavy computation
-            if sig_val_z.check_norm::<GAMMA1_MINUS_BETA>() {
-                kappa += l as u16;
+            if sig_val_z.check_norm(P::GAMMA1_MINUS_BETA) {
+                kappa += P::l as u16;
                 continue;
             };
 
-            let t0: Vector<k>;
-            let mut r0: Vector<k> = {
+            let t0: P::VecK;
+            let mut r0: P::VecK = {
                 // scope for s2_hat and cs2
                 // 3: 𝐬2̂_hat ← NTT(𝐬2)
                 let mut s2_hat = s2.clone();
@@ -1608,7 +1398,7 @@ impl<
                 cs2.inv_ntt();
 
                 // 21: 𝐫0 ← LowBits(𝐰 − ⟨⟨𝑐𝐬2⟩⟩)
-                let r0 = w.sub_vector(&cs2).low_bits::<GAMMA2>();
+                let r0 = w.sub_vector(&cs2).low_bits::<P>();
 
                 // while s2_hat is in scope, derive t0
                 let mut t = t_hat;
@@ -1619,7 +1409,7 @@ impl<
                 // 6: (𝐭1, 𝐭0) ← Power2Round(𝐭)
                 //   ▷ compress 𝐭
                 //   ▷ PowerTwoRound is applied componentwise (see explanatory text in Section 7.4)
-                let (_t1tmp, t0tmp) = power_2_round_vec::<k>(&t);
+                let (_t1tmp, t0tmp) = power_2_round_vec(&t);
                 t0 = t0tmp;
 
                 r0
@@ -1627,14 +1417,14 @@ impl<
 
             // Alg 7; 23 (second half): if ||𝐳||∞ ≥ 𝛾1 − 𝛽 or ||𝐫0||∞ ≥ 𝛾2 − 𝛽 then (z, h) ← ⊥
             //  ▷ validity checks
-            if r0.check_norm::<GAMMA2_MINUS_BETA>() {
+            if r0.check_norm(P::GAMMA2_MINUS_BETA) {
                 // mutants note: mutants thinks this can be replaced with -=, but in practice that makes
                 //               the rejection sampling loop go forever, so is a false positive.
-                kappa += l as u16;
+                kappa += P::l as u16;
                 continue;
             };
 
-            let ct0: Vector<k> = {
+            let ct0: P::VecK = {
                 // scope for t0_hat
                 // 4: 𝐭0̂_hat ← NTT(𝐭0)̂
                 let mut t0_hat = t0.clone();
@@ -1650,8 +1440,8 @@ impl<
             // out-of-order on purpose for performance reasons:
             //   might as well do the rejection sampling check before any extra heavy computation
             // mutants note: there is currently no unit test that triggers this branch
-            if ct0.check_norm::<GAMMA2>() {
-                kappa += l as u16;
+            if ct0.check_norm(P::GAMMA2) {
+                kappa += P::l as u16;
                 continue;
             };
 
@@ -1662,15 +1452,15 @@ impl<
             let hint_hamming_weight: i32;
             sig_val_h = {
                 // scope for hint
-                let (hint, inner_hint_hamming_weight) = make_hint_vecs::<k, GAMMA2>(&r0, &w1);
+                let (hint, inner_hint_hamming_weight) = make_hint_vecs::<P>(&r0, &w1);
                 hint_hamming_weight = inner_hint_hamming_weight;
                 hint
             };
 
             // Alg 7; 28 (second half): if ||⟨⟨𝑐𝐭0⟩⟩||∞ ≥ 𝛾2 or the number of 1’s in 𝐡 is greater than 𝜔, then (z, h) ← ⊥
             // mutants note: there is currently no unit test that triggers this branch
-            if hint_hamming_weight > OMEGA {
-                kappa += l as u16;
+            if hint_hamming_weight > P::OMEGA {
+                kappa += P::l as u16;
                 continue;
             };
 
@@ -1686,9 +1476,7 @@ impl<
 
         // Alg 7; 33: 𝜎 ← sigEncode(𝑐, 𝐳̃ mod±𝑞, 𝐡)
         let bytes_written =
-            sig_encode::<GAMMA1, k, l, LAMBDA_over_4, OMEGA, POLY_Z_PACKED_LEN, SIG_LEN>(
-                &sig_val_c_tilde, &sig_val_z, &sig_val_h, output,
-            );
+            sig_encode::<P, SIG_LEN>(&sig_val_c_tilde, &sig_val_z, &sig_val_h, output);
 
         Ok(bytes_written)
     }
@@ -1711,7 +1499,7 @@ impl<
     }
 
     fn verify_with_expanded_key(
-        pk: &MLDSAPublicKeyExpanded<k, l, PK, PK_LEN>,
+        pk: &MLDSAPublicKeyExpanded<P, PK, PK_LEN>,
         msg: &[u8],
         ctx: Option<&[u8]>,
         sig: &[u8],
@@ -1725,7 +1513,7 @@ impl<
 
     fn verify_mu(
         pk: &PK,
-        A_hat: Option<&Matrix<k, l>>,
+        A_hat: Option<&P::MatrixA>,
         mu: &[u8; 64],
         sig: &[u8; SIG_LEN],
     ) -> Result<(), SignatureError> {
@@ -1738,16 +1526,12 @@ impl<
 
 /// Trait for all three of the ML-DSA algorithm variants.
 pub trait MLDSATrait<
+    P: MLDSAParams,
+    PK: MLDSAPublicKeyTrait<P, PK_LEN> + MLDSAPublicKeyInternalTrait<P, PK_LEN>,
+    SK: MLDSAPrivateKeyTrait<P, SK_LEN, PK_LEN> + MLDSAPrivateKeyInternalTrait<P, SK_LEN, PK_LEN>,
     const PK_LEN: usize,
     const SK_LEN: usize,
     const SIG_LEN: usize,
-    PK: MLDSAPublicKeyTrait<k, l, PK_LEN> + MLDSAPublicKeyInternalTrait<k, PK_LEN>,
-    SK: MLDSAPrivateKeyTrait<k, l, ETA, SK_LEN, PK_LEN>
-        + MLDSAPrivateKeyInternalTrait<k, l, ETA, SK_LEN, PK_LEN>,
-    const LAMBDA: i32,
-    const k: usize,
-    const l: usize,
-    const ETA: usize,
 >: Sized
 {
     /// Runs a key generation using the library's default RNG, seeded from the OS.
@@ -1762,7 +1546,7 @@ pub trait MLDSATrait<
     // Should still be ok in FIPS mode, provided that you're using the FIPS-approved RNG.
     fn keygen_from_rng(rng: &mut dyn RNG) -> Result<(PK, SK), SignatureError> {
         // Source the seed from the provided RNG
-        if rng.security_strength() < SecurityStrength::from_bits(LAMBDA as usize) {
+        if rng.security_strength() < SecurityStrength::from_bits(P::LAMBDA as usize) {
             return Err(RNGError::SecurityStrengthInsufficientForAlgorithm)?;
         }
         let mut seed = KeyMaterial256::new();
@@ -1829,26 +1613,26 @@ pub trait MLDSATrait<
     ) -> Result<[u8; 64], SignatureError>;
     /// Same as [`MLDSATrait::compute_mu_from_tr`], but extracts tr from the public key.
     fn compute_mu_from_pk(
-        pk: &impl MLDSAPublicKeyTrait<k, l, PK_LEN>,
+        pk: &impl MLDSAPublicKeyTrait<P, PK_LEN>,
         msg: &[u8],
         ctx: Option<&[u8]>,
     ) -> Result<[u8; 64], SignatureError>;
     /// Same as [`MLDSATrait::compute_mu_from_tr`], but extracts tr from the private key.
     // dev note: defined sk this way so that it accepts either MLDSAPrivateKey or MLDSAPRivateKeyExpanded
     fn compute_mu_from_sk(
-        sk: &impl MLDSAPrivateKeyTrait<k, l, ETA, SK_LEN, PK_LEN>,
+        sk: &impl MLDSAPrivateKeyTrait<P, SK_LEN, PK_LEN>,
         msg: &[u8],
         ctx: Option<&[u8]>,
     ) -> Result<[u8; 64], SignatureError>;
     /// Same as [`Signer::sign`], but signs from an [`MLDSAPrivateKeyExpanded`].
     fn sign_with_expanded_key(
-        sk: &MLDSAPrivateKeyExpanded<k, l, ETA, PK, SK, SK_LEN, PK_LEN>,
+        sk: &MLDSAPrivateKeyExpanded<P, PK, SK, SK_LEN, PK_LEN>,
         msg: &[u8],
         ctx: Option<&[u8]>,
     ) -> Result<[u8; SIG_LEN], SignatureError>;
     /// Same as [`MLDSATrait::sign_with_expanded_key`], but takes an output array.
     fn sign_with_expanded_key_out(
-        sk: &MLDSAPrivateKeyExpanded<k, l, ETA, PK, SK, SK_LEN, PK_LEN>,
+        sk: &MLDSAPrivateKeyExpanded<P, PK, SK, SK_LEN, PK_LEN>,
         msg: &[u8],
         ctx: Option<&[u8]>,
         out: &mut [u8; SIG_LEN],
@@ -1861,7 +1645,7 @@ pub trait MLDSATrait<
     /// Optionally, takes a pre-expanded public matrix `A_hat`.
     fn sign_mu(
         sk: &SK,
-        A_hat: Option<&Matrix<k, l>>,
+        A_hat: Option<&P::MatrixA>,
         mu: &[u8; 64],
     ) -> Result<[u8; SIG_LEN], SignatureError>;
     /// Performs an ML-DSA signature using the provided external message representative `mu`.
@@ -1876,20 +1660,20 @@ pub trait MLDSATrait<
     /// Returns the number of bytes written to the output buffer. Can be called with an oversized buffer.
     fn sign_mu_out(
         sk: &SK,
-        A_hat: Option<&Matrix<k, l>>,
+        A_hat: Option<&P::MatrixA>,
         mu: &[u8; 64],
         output: &mut [u8; SIG_LEN],
     ) -> Result<usize, SignatureError>;
     /// Same as [`MLDSATrait::sign_mu`], but signs from an [`MLDSAPrivateKeyExpanded`].
     fn sign_mu_with_expanded_key(
-        sk: &MLDSAPrivateKeyExpanded<k, l, ETA, PK, SK, SK_LEN, PK_LEN>,
-        A_hat: Option<&Matrix<k, l>>,
+        sk: &MLDSAPrivateKeyExpanded<P, PK, SK, SK_LEN, PK_LEN>,
+        A_hat: Option<&P::MatrixA>,
         mu: &[u8; 64],
     ) -> Result<[u8; SIG_LEN], SignatureError>;
     /// Same as [`MLDSATrait::sign_mu_out`], but signs from an [`MLDSAPrivateKeyExpanded`].
     fn sign_mu_with_expanded_key_out(
-        sk: &MLDSAPrivateKeyExpanded<k, l, ETA, PK, SK, SK_LEN, PK_LEN>,
-        A_hat: Option<&Matrix<k, l>>,
+        sk: &MLDSAPrivateKeyExpanded<P, PK, SK, SK_LEN, PK_LEN>,
+        A_hat: Option<&P::MatrixA>,
         mu: &[u8; 64],
         output: &mut [u8; SIG_LEN],
     ) -> Result<usize, SignatureError>;
@@ -1916,7 +1700,7 @@ pub trait MLDSATrait<
     /// prevent accidental nonce reuse, this function moves `rnd`.
     fn sign_mu_deterministic(
         sk: &SK,
-        A_hat: Option<&Matrix<k, l>>,
+        A_hat: Option<&P::MatrixA>,
         mu: &[u8; 64],
         rnd: [u8; 32],
     ) -> Result<[u8; SIG_LEN], SignatureError>;
@@ -1945,7 +1729,7 @@ pub trait MLDSATrait<
     /// Returns the number of bytes written to the output buffer. Can be called with an oversized buffer.
     fn sign_mu_deterministic_out(
         sk: &SK,
-        A_hat: Option<&Matrix<k, l>>,
+        A_hat: Option<&P::MatrixA>,
         mu: &[u8; 64],
         rnd: [u8; 32],
         output: &mut [u8; SIG_LEN],
@@ -1978,7 +1762,7 @@ pub trait MLDSATrait<
     ) -> Result<Self, SignatureError>;
     /// Same as [`SignatureVerifier::verify`], but signs from an expanded key object.
     fn verify_with_expanded_key(
-        pk: &MLDSAPublicKeyExpanded<k, l, PK, PK_LEN>,
+        pk: &MLDSAPublicKeyExpanded<P, PK, PK_LEN>,
         msg: &[u8],
         ctx: Option<&[u8]>,
         sig: &[u8],
@@ -1989,59 +1773,20 @@ pub trait MLDSATrait<
     /// Optionally, takes a pre-expanded public matrix `A_hat`.
     fn verify_mu(
         pk: &PK,
-        A_hat: Option<&Matrix<k, l>>,
+        A_hat: Option<&P::MatrixA>,
         mu: &[u8; 64],
         sig: &[u8; SIG_LEN],
     ) -> Result<(), SignatureError>;
 }
 
 impl<
+    P: MLDSAParams,
+    PK: MLDSAPublicKeyTrait<P, PK_LEN> + MLDSAPublicKeyInternalTrait<P, PK_LEN>,
+    SK: MLDSAPrivateKeyTrait<P, SK_LEN, PK_LEN> + MLDSAPrivateKeyInternalTrait<P, SK_LEN, PK_LEN>,
     const PK_LEN: usize,
     const SK_LEN: usize,
     const SIG_LEN: usize,
-    PK: MLDSAPublicKeyTrait<k, l, PK_LEN> + MLDSAPublicKeyInternalTrait<k, PK_LEN>,
-    SK: MLDSAPrivateKeyTrait<k, l, ETA, SK_LEN, PK_LEN>
-        + MLDSAPrivateKeyInternalTrait<k, l, ETA, SK_LEN, PK_LEN>,
-    const TAU: i32,
-    const LAMBDA: i32,
-    const GAMMA1: i32,
-    const GAMMA2: i32,
-    const k: usize,
-    const l: usize,
-    const ETA: usize,
-    const BETA: i32,
-    const OMEGA: i32,
-    const C_TILDE: usize,
-    const POLY_Z_PACKED_LEN: usize,
-    const POLY_W1_PACKED_LEN: usize,
-    const LAMBDA_over_4: usize,
-    const GAMMA1_MINUS_BETA: i32,
-    const GAMMA2_MINUS_BETA: i32,
-    const GAMMA1_MASK_LEN: usize,
-> Signer<SK, SK_LEN, SIG_LEN>
-    for MLDSA<
-        PK_LEN,
-        SK_LEN,
-        SIG_LEN,
-        PK,
-        SK,
-        TAU,
-        LAMBDA,
-        GAMMA1,
-        GAMMA2,
-        k,
-        l,
-        ETA,
-        BETA,
-        OMEGA,
-        C_TILDE,
-        POLY_Z_PACKED_LEN,
-        POLY_W1_PACKED_LEN,
-        LAMBDA_over_4,
-        GAMMA1_MINUS_BETA,
-        GAMMA2_MINUS_BETA,
-        GAMMA1_MASK_LEN,
-    >
+> Signer<SK, SK_LEN, SIG_LEN> for MLDSA<P, PK, SK, PK_LEN, SK_LEN, SIG_LEN>
 {
     fn sign(sk: &SK, msg: &[u8], ctx: Option<&[u8]>) -> Result<[u8; SIG_LEN], SignatureError> {
         let mut out = [0u8; SIG_LEN];
@@ -2125,52 +1870,13 @@ impl<
 }
 
 impl<
+    P: MLDSAParams,
+    PK: MLDSAPublicKeyTrait<P, PK_LEN> + MLDSAPublicKeyInternalTrait<P, PK_LEN>,
+    SK: MLDSAPrivateKeyTrait<P, SK_LEN, PK_LEN> + MLDSAPrivateKeyInternalTrait<P, SK_LEN, PK_LEN>,
     const PK_LEN: usize,
     const SK_LEN: usize,
     const SIG_LEN: usize,
-    PK: MLDSAPublicKeyTrait<k, l, PK_LEN> + MLDSAPublicKeyInternalTrait<k, PK_LEN>,
-    SK: MLDSAPrivateKeyTrait<k, l, ETA, SK_LEN, PK_LEN>
-        + MLDSAPrivateKeyInternalTrait<k, l, ETA, SK_LEN, PK_LEN>,
-    const TAU: i32,
-    const LAMBDA: i32,
-    const GAMMA1: i32,
-    const GAMMA2: i32,
-    const k: usize,
-    const l: usize,
-    const ETA: usize,
-    const BETA: i32,
-    const OMEGA: i32,
-    const C_TILDE: usize,
-    const POLY_Z_PACKED_LEN: usize,
-    const POLY_W1_PACKED_LEN: usize,
-    const LAMBDA_over_4: usize,
-    const GAMMA1_MINUS_BETA: i32,
-    const GAMMA2_MINUS_BETA: i32,
-    const GAMMA1_MASK_LEN: usize,
-> SignatureVerifier<PK, PK_LEN, SIG_LEN>
-    for MLDSA<
-        PK_LEN,
-        SK_LEN,
-        SIG_LEN,
-        PK,
-        SK,
-        TAU,
-        LAMBDA,
-        GAMMA1,
-        GAMMA2,
-        k,
-        l,
-        ETA,
-        BETA,
-        OMEGA,
-        C_TILDE,
-        POLY_Z_PACKED_LEN,
-        POLY_W1_PACKED_LEN,
-        LAMBDA_over_4,
-        GAMMA1_MINUS_BETA,
-        GAMMA2_MINUS_BETA,
-        GAMMA1_MASK_LEN,
-    >
+> SignatureVerifier<PK, PK_LEN, SIG_LEN> for MLDSA<P, PK, SK, PK_LEN, SK_LEN, SIG_LEN>
 {
     fn verify(pk: &PK, msg: &[u8], ctx: Option<&[u8]>, sig: &[u8]) -> Result<(), SignatureError> {
         let mu = MuBuilder::compute_mu(&pk.compute_tr(), msg, ctx)?;

--- a/crypto/mldsa/src/mldsa.rs
+++ b/crypto/mldsa/src/mldsa.rs
@@ -676,7 +676,7 @@ impl<
             ));
         }
 
-        if seed.security_strength() < SecurityStrength::from_bits(P::LAMBDA as usize) {
+        if seed.security_strength() < P::MAX_SECURITY_STRENGTH {
             return Err(SignatureError::KeyGenError(
                 "Seed SecurityStrength must match algorithm security strength",
             ));
@@ -870,7 +870,7 @@ impl<
             //  ▷ validity checks
             // This is done out-of-order on purpose for performance reasons:
             // rejection sampling check is done before any extra heavy computation
-            if sig_val_z.check_norm(P::GAMMA1_MINUS_BETA) {
+            if sig_val_z.check_norm(P::gamma1_minus_beta) {
                 kappa += P::l as u16;
                 continue;
             };
@@ -890,7 +890,7 @@ impl<
             //      and checking whether ‖r0‖∞ < γ2 − β and r1 = w1, it is equivalent to just check that
             //      ‖w0 − cs2‖∞ < γ2 − β, where w0 is the low part of w. If this check passes, w0 − cs2
             //      is the low part of w − cs2."
-            if r0.check_norm(P::GAMMA2_MINUS_BETA) {
+            if r0.check_norm(P::gamma2_minus_beta) {
                 kappa += P::l as u16;
                 continue;
             };
@@ -903,7 +903,7 @@ impl<
             // This is done out-of-order on purpose for performance reasons:
             // rejection sampling check is done before any extra heavy computation
             // mutants note: there is currently no unit test that triggers this branch
-            if ct0.check_norm(P::GAMMA2) {
+            if ct0.check_norm(P::gamma2) {
                 kappa += P::l as u16;
                 continue;
             };
@@ -922,7 +922,7 @@ impl<
 
             // 28 (second half): if ||⟨⟨𝑐𝐭0⟩⟩||∞ ≥ 𝛾2 or the number of 1’s in 𝐡 is greater than 𝜔, then (z, h) ← ⊥
             // mutants note: there is no test KAT that triggers this branch
-            if hint_hamming_weight > P::OMEGA {
+            if hint_hamming_weight > P::omega {
                 kappa += P::l as u16;
                 continue;
             };
@@ -963,7 +963,7 @@ impl<
             .map_err(|_| SignatureError::SignatureVerificationFailed)?;
 
         // 13 (first half) return [[ ||𝐳||∞ < 𝛾1 − 𝛽]]
-        if z.check_norm(P::GAMMA1_MINUS_BETA) {
+        if z.check_norm(P::gamma1_minus_beta) {
             return Err(SignatureError::SignatureVerificationFailed);
         }
 
@@ -1226,7 +1226,7 @@ impl<
             ));
         }
 
-        if seed.security_strength() < SecurityStrength::from_bits(P::LAMBDA as usize) {
+        if seed.security_strength() < P::MAX_SECURITY_STRENGTH {
             return Err(SignatureError::KeyGenError(
                 "Seed SecurityStrength must match algorithm security strength: 128-bit (ML-DSA-44), 192-bit (ML-DSA-65), or 256-bit (ML-DSA-87).",
             ));
@@ -1381,7 +1381,7 @@ impl<
             //  ▷ validity checks
             // This is done out-of-order on purpose for performance reasons:
             // rejection sampling check is done before any extra heavy computation
-            if sig_val_z.check_norm(P::GAMMA1_MINUS_BETA) {
+            if sig_val_z.check_norm(P::gamma1_minus_beta) {
                 kappa += P::l as u16;
                 continue;
             };
@@ -1417,7 +1417,7 @@ impl<
 
             // Alg 7; 23 (second half): if ||𝐳||∞ ≥ 𝛾1 − 𝛽 or ||𝐫0||∞ ≥ 𝛾2 − 𝛽 then (z, h) ← ⊥
             //  ▷ validity checks
-            if r0.check_norm(P::GAMMA2_MINUS_BETA) {
+            if r0.check_norm(P::gamma2_minus_beta) {
                 // mutants note: mutants thinks this can be replaced with -=, but in practice that makes
                 //               the rejection sampling loop go forever, so is a false positive.
                 kappa += P::l as u16;
@@ -1440,7 +1440,7 @@ impl<
             // out-of-order on purpose for performance reasons:
             //   might as well do the rejection sampling check before any extra heavy computation
             // mutants note: there is currently no unit test that triggers this branch
-            if ct0.check_norm(P::GAMMA2) {
+            if ct0.check_norm(P::gamma2) {
                 kappa += P::l as u16;
                 continue;
             };
@@ -1459,7 +1459,7 @@ impl<
 
             // Alg 7; 28 (second half): if ||⟨⟨𝑐𝐭0⟩⟩||∞ ≥ 𝛾2 or the number of 1’s in 𝐡 is greater than 𝜔, then (z, h) ← ⊥
             // mutants note: there is currently no unit test that triggers this branch
-            if hint_hamming_weight > P::OMEGA {
+            if hint_hamming_weight > P::omega {
                 kappa += P::l as u16;
                 continue;
             };
@@ -1546,7 +1546,7 @@ pub trait MLDSATrait<
     // Should still be ok in FIPS mode, provided that you're using the FIPS-approved RNG.
     fn keygen_from_rng(rng: &mut dyn RNG) -> Result<(PK, SK), SignatureError> {
         // Source the seed from the provided RNG
-        if rng.security_strength() < SecurityStrength::from_bits(P::LAMBDA as usize) {
+        if rng.security_strength() < P::MAX_SECURITY_STRENGTH {
             return Err(RNGError::SecurityStrengthInsufficientForAlgorithm)?;
         }
         let mut seed = KeyMaterial256::new();

--- a/crypto/mldsa/src/mldsa.rs
+++ b/crypto/mldsa/src/mldsa.rs
@@ -512,7 +512,7 @@ pub const ML_DSA_65_NAME: &str = "ML-DSA-65";
 ///
 pub const ML_DSA_87_NAME: &str = "ML-DSA-87";
 
-// From FIPS 204 Table 1 and Table 2
+/*** From FIPS 204 Table 1 and Table 2 ***/
 
 // Constants that are the same for all parameter sets
 pub(crate) const N: usize = 256;
@@ -532,25 +532,25 @@ pub(crate) const POLY_T1PACKED_LEN: usize = 320;
 
 /*** Re-exporting length constants that a caller will need instead of the entire Params objects which contains a bunch of internal algorithm detail ***/
 
-/// Length of the \[u8] holding a ML-DSA-44 public key.
+/// Length of the \[u8] holding an ML-DSA-44 public key.
 pub const MLDSA44_PK_LEN: usize = MLDSA44Params::PK_LEN;
-/// Length of the \[u8] holding a ML-DSA-44 private key.
+/// Length of the \[u8] holding an ML-DSA-44 private key.
 pub const MLDSA44_SK_LEN: usize = MLDSA44Params::SK_LEN;
-/// Length of the \[u8] holding a ML-DSA-44 signature value.
+/// Length of the \[u8] holding an ML-DSA-44 signature value.
 pub const MLDSA44_SIG_LEN: usize = MLDSA44Params::SIG_LEN;
 
-/// Length of the \[u8] holding a ML-DSA-65 public key.
+/// Length of the \[u8] holding an ML-DSA-65 public key.
 pub const MLDSA65_PK_LEN: usize = MLDSA65Params::PK_LEN;
-/// Length of the \[u8] holding a ML-DSA-65 private key.
+/// Length of the \[u8] holding an ML-DSA-65 private key.
 pub const MLDSA65_SK_LEN: usize = MLDSA65Params::SK_LEN;
-/// Length of the \[u8] holding a ML-DSA-65 signature value.
+/// Length of the \[u8] holding an ML-DSA-65 signature value.
 pub const MLDSA65_SIG_LEN: usize = MLDSA65Params::SIG_LEN;
 
-/// Length of the \[u8] holding a ML-DSA-87 public key.
+/// Length of the \[u8] holding an ML-DSA-87 public key.
 pub const MLDSA87_PK_LEN: usize = MLDSA87Params::PK_LEN;
-/// Length of the \[u8] holding a ML-DSA-87 private key.
+/// Length of the \[u8] holding an ML-DSA-87 private key.
 pub const MLDSA87_SK_LEN: usize = MLDSA87Params::SK_LEN;
-/// Length of the \[u8] holding a ML-DSA-87 signature value.
+/// Length of the \[u8] holding an ML-DSA-87 signature value.
 pub const MLDSA87_SIG_LEN: usize = MLDSA87Params::SIG_LEN;
 
 // Typedefs just to make the algorithms look more like the FIPS 204 sample code.

--- a/crypto/mldsa/src/mldsa_keys.rs
+++ b/crypto/mldsa/src/mldsa_keys.rs
@@ -581,7 +581,7 @@ impl<P: MLDSAParams, const SK_LEN: usize, const PK_LEN: usize>
         {
             // Deviation from the FIPS:
             // Because s2 is in ntt form, it is necessary to reverse that here before adding it to t
-            let mut s2 = *self.s2_hat;
+            let mut s2: Secret<P::VecK> = self.s2_hat.clone();
             s2.reduce();
             s2.inv_ntt();
 

--- a/crypto/mldsa/src/mldsa_keys.rs
+++ b/crypto/mldsa/src/mldsa_keys.rs
@@ -1,6 +1,6 @@
 use crate::aux_functions::{
-    bit_pack_eta, bit_pack_t0, bit_unpack_eta, bit_unpack_t0, bitlen_eta, expandA,
-    power_2_round_vec, simple_bit_pack_t1, simple_bit_unpack_t1,
+    bit_pack_eta, bit_pack_t0, bit_unpack_eta, bit_unpack_t0, expandA, power_2_round_vec,
+    simple_bit_pack_t1, simple_bit_unpack_t1,
 };
 use crate::matrix::{MatrixTrait, VectorTrait};
 use crate::mldsa::H;
@@ -447,7 +447,7 @@ impl<P: MLDSAParams, const SK_LEN: usize, const PK_LEN: usize> MLDSAPrivateKey<P
         off += 128;
 
         let mut buf = [0u8; 32 * 4]; // largest possible buffer
-        let eta_pack_len = bitlen_eta(P::ETA);
+        let eta_pack_len = P::POLY_ETA_PACKED_LEN;
 
         let sk_chunks = out[off..off + P::l * eta_pack_len].chunks_mut(eta_pack_len);
         debug_assert_eq!(sk_chunks.len(), P::l);
@@ -611,8 +611,8 @@ impl<P: MLDSAParams, const SK_LEN: usize, const PK_LEN: usize>
         };
         key.K.copy_from_slice(&sk[32..64]);
         let mut off = 128;
-        let eta_pack_len = bitlen_eta(P::ETA);
-        let eta = P::ETA as i32;
+        let eta_pack_len = P::POLY_ETA_PACKED_LEN;
+        let eta = P::eta as i32;
 
         // unpack s1 directly into key.s1_hat so that we don't make additional non-Secret copies.
         let sk_chunks = sk[off..off + (P::l * eta_pack_len)].chunks(eta_pack_len);

--- a/crypto/mldsa/src/mldsa_keys.rs
+++ b/crypto/mldsa/src/mldsa_keys.rs
@@ -2,13 +2,10 @@ use crate::aux_functions::{
     bit_pack_eta, bit_pack_t0, bit_unpack_eta, bit_unpack_t0, bitlen_eta, expandA,
     power_2_round_vec, simple_bit_pack_t1, simple_bit_unpack_t1,
 };
-use crate::matrix::{Matrix, Vector};
+use crate::matrix::{MatrixTrait, VectorTrait};
 use crate::mldsa::H;
-use crate::mldsa::{MLDSA44_ETA, MLDSA44_PK_LEN, MLDSA44_SK_LEN, MLDSA44_k, MLDSA44_l};
-use crate::mldsa::{MLDSA65_ETA, MLDSA65_PK_LEN, MLDSA65_SK_LEN, MLDSA65_k, MLDSA65_l};
-use crate::mldsa::{MLDSA87_ETA, MLDSA87_PK_LEN, MLDSA87_SK_LEN, MLDSA87_k, MLDSA87_l};
 use crate::mldsa::{POLY_T0PACKED_LEN, POLY_T1PACKED_LEN};
-use crate::{ML_DSA_44_NAME, ML_DSA_65_NAME, ML_DSA_87_NAME};
+use crate::params::{MLDSA44Params, MLDSA65Params, MLDSA87Params, MLDSAParams};
 use bouncycastle_core::errors::SignatureError;
 use bouncycastle_core::key_material::KeyMaterial;
 use bouncycastle_core::traits::{SignaturePrivateKey, SignaturePublicKey, XOF};
@@ -25,71 +22,83 @@ use crate::polynomial::Polynomial;
 /* Pub Types */
 
 /// ML-DSA-44 Public Key
-pub type MLDSA44PublicKey = MLDSAPublicKey<MLDSA44_k, MLDSA44_l, MLDSA44_PK_LEN>;
+pub type MLDSA44PublicKey = MLDSAPublicKey<MLDSA44Params, { MLDSA44Params::PK_LEN }>;
 /// ML-DSA-44 Private Key
 pub type MLDSA44PrivateKey =
-    MLDSAPrivateKey<MLDSA44_k, MLDSA44_l, MLDSA44_ETA, MLDSA44_SK_LEN, MLDSA44_PK_LEN>;
+    MLDSAPrivateKey<MLDSA44Params, { MLDSA44Params::SK_LEN }, { MLDSA44Params::PK_LEN }>;
 /// ML-DSA-65 Public Key
-pub type MLDSA65PublicKey = MLDSAPublicKey<MLDSA65_k, MLDSA65_l, MLDSA65_PK_LEN>;
+pub type MLDSA65PublicKey = MLDSAPublicKey<MLDSA65Params, { MLDSA65Params::PK_LEN }>;
 /// ML-DSA-65 Private Key
 pub type MLDSA65PrivateKey =
-    MLDSAPrivateKey<MLDSA65_k, MLDSA65_l, MLDSA65_ETA, MLDSA65_SK_LEN, MLDSA65_PK_LEN>;
+    MLDSAPrivateKey<MLDSA65Params, { MLDSA65Params::SK_LEN }, { MLDSA65Params::PK_LEN }>;
 /// ML-DSA-87 Public Key
-pub type MLDSA87PublicKey = MLDSAPublicKey<MLDSA87_k, MLDSA87_l, MLDSA87_PK_LEN>;
+pub type MLDSA87PublicKey = MLDSAPublicKey<MLDSA87Params, { MLDSA87Params::PK_LEN }>;
 /// ML-DSA-87 Private Key
 pub type MLDSA87PrivateKey =
-    MLDSAPrivateKey<MLDSA87_k, MLDSA87_l, MLDSA87_ETA, MLDSA87_SK_LEN, MLDSA87_PK_LEN>;
+    MLDSAPrivateKey<MLDSA87Params, { MLDSA87Params::SK_LEN }, { MLDSA87Params::PK_LEN }>;
 
 /* Pre-expanded keys for repeated operations */
 
 /// ML-DSA-44 Public Key with a pre-expanded public matrix A for repeated encaps operations.
 pub type MLDSA44PublicKeyExpanded =
-    MLDSAPublicKeyExpanded<MLDSA44_k, MLDSA44_l, MLDSA44PublicKey, MLDSA44_PK_LEN>;
+    MLDSAPublicKeyExpanded<MLDSA44Params, MLDSA44PublicKey, { MLDSA44Params::PK_LEN }>;
 /// ML-DSA-44 Private Key with a pre-expanded public matrix A for repeated decaps operations.
 pub type MLDSA44PrivateKeyExpanded = MLDSAPrivateKeyExpanded<
-    MLDSA44_k,
-    MLDSA44_l,
-    MLDSA44_ETA,
+    MLDSA44Params,
     MLDSA44PublicKey,
     MLDSA44PrivateKey,
-    MLDSA44_SK_LEN,
-    MLDSA44_PK_LEN,
+    { MLDSA44Params::SK_LEN },
+    { MLDSA44Params::PK_LEN },
 >;
 /// ML-DSA-65 Public Key with a pre-expanded public matrix A for repeated encaps operations.
 pub type MLDSA65PublicKeyExpanded =
-    MLDSAPublicKeyExpanded<MLDSA65_k, MLDSA65_l, MLDSA65PublicKey, MLDSA65_PK_LEN>;
+    MLDSAPublicKeyExpanded<MLDSA65Params, MLDSA65PublicKey, { MLDSA65Params::PK_LEN }>;
 /// ML-DSA-65 Private Key with a pre-expanded public matrix A for repeated decaps operations.
 pub type MLDSA65PrivateKeyExpanded = MLDSAPrivateKeyExpanded<
-    MLDSA65_k,
-    MLDSA65_l,
-    MLDSA65_ETA,
+    MLDSA65Params,
     MLDSA65PublicKey,
     MLDSA65PrivateKey,
-    MLDSA65_SK_LEN,
-    MLDSA65_PK_LEN,
+    { MLDSA65Params::SK_LEN },
+    { MLDSA65Params::PK_LEN },
 >;
 /// ML-DSA-87 Public Key with a pre-expanded public matrix A for repeated encaps operations.
 pub type MLDSA87PublicKeyExpanded =
-    MLDSAPublicKeyExpanded<MLDSA87_k, MLDSA87_l, MLDSA87PublicKey, MLDSA87_PK_LEN>;
+    MLDSAPublicKeyExpanded<MLDSA87Params, MLDSA87PublicKey, { MLDSA87Params::PK_LEN }>;
 /// ML-DSA-87 Private Key with a pre-expanded public matrix A for repeated decaps operations.
 pub type MLDSA87PrivateKeyExpanded = MLDSAPrivateKeyExpanded<
-    MLDSA87_k,
-    MLDSA87_l,
-    MLDSA87_ETA,
+    MLDSA87Params,
     MLDSA87PublicKey,
     MLDSA87PrivateKey,
-    MLDSA87_SK_LEN,
-    MLDSA87_PK_LEN,
+    { MLDSA87Params::SK_LEN },
+    { MLDSA87Params::PK_LEN },
 >;
 
 /// An ML-DSA public key.
-#[derive(Clone)]
-pub struct MLDSAPublicKey<const k: usize, const l: usize, const PK_LEN: usize> {
+///
+/// `PK_LEN` duplicates `MLDSAParams::PK_LEN`; it has to be carried separately because
+/// [`SignaturePublicKey`] takes the encoded length as a const generic parameter, and an associated
+/// const of a type parameter may not be used as a const generic argument. The two are checked
+/// against each other at compile time -- see the `ASSERT_PK_LEN` const on this type.
+pub struct MLDSAPublicKey<P: MLDSAParams, const PK_LEN: usize> {
     rho: [u8; 32],
-    t1: Vector<k>,
+    t1: P::VecK,
 }
 
-impl<const k: usize, const l: usize, const PK_LEN: usize> MLDSAPublicKey<k, l, PK_LEN> {
+// Written out rather than derived: `#[derive(Clone)]` would demand `P: Clone`, and `P` is a
+// marker for the parameter set that is never stored, only used to name the field types.
+impl<P: MLDSAParams, const PK_LEN: usize> Clone for MLDSAPublicKey<P, PK_LEN> {
+    fn clone(&self) -> Self {
+        Self { rho: self.rho, t1: self.t1 }
+    }
+}
+
+impl<P: MLDSAParams, const PK_LEN: usize> MLDSAPublicKey<P, PK_LEN> {
+    /// Fails to evaluate, and so fails the build, if this type is instantiated with a `PK_LEN`
+    /// that is not the parameter set's own. Referenced from every constructor so that it is
+    /// reached during monomorphization.
+    const ASSERT_PK_LEN: () =
+        assert!(PK_LEN == P::PK_LEN, "PK_LEN does not match MLDSAParams::PK_LEN");
+
     /// Algorithm 22 pkEncode(𝜌, 𝐭1)
     /// Encodes a public key for ML-DSA into a byte string.
     /// Input:𝜌 ∈ 𝔹32, 𝐭1 ∈ 𝑅𝑘 with coefficients in [0, 2bitlen (𝑞−1)−𝑑 − 1].
@@ -102,11 +111,11 @@ impl<const k: usize, const l: usize, const PK_LEN: usize> MLDSAPublicKey<k, l, P
         let (pk_chunks, last_chunk) = out[32..].as_chunks_mut::<POLY_T1PACKED_LEN>();
 
         // that should divide evenly the remainder of the array
-        debug_assert_eq!(pk_chunks.len(), k);
+        debug_assert_eq!(pk_chunks.len(), P::k);
         debug_assert_eq!(last_chunk.len(), 0);
 
-        for (pk_chunk, t1_i) in pk_chunks.into_iter().zip(&self.t1.elems) {
-            pk_chunk.copy_from_slice(&simple_bit_pack_t1(&t1_i));
+        for (pk_chunk, t1_i) in pk_chunks.into_iter().zip(self.t1.elems()) {
+            pk_chunk.copy_from_slice(&simple_bit_pack_t1(t1_i));
         }
 
         PK_LEN
@@ -114,7 +123,7 @@ impl<const k: usize, const l: usize, const PK_LEN: usize> MLDSAPublicKey<k, l, P
 }
 
 /// General trait for all ML-DSA public keys types.
-pub trait MLDSAPublicKeyTrait<const k: usize, const l: usize, const PK_LEN: usize>:
+pub trait MLDSAPublicKeyTrait<P: MLDSAParams, const PK_LEN: usize>:
     SignaturePublicKey<PK_LEN>
 {
     /// Algorithm 23 pkDecode(𝑝𝑘)
@@ -124,7 +133,7 @@ pub trait MLDSAPublicKeyTrait<const k: usize, const l: usize, const PK_LEN: usiz
     fn pk_decode(pk: &[u8; PK_LEN]) -> Self;
 
     /// Get a copy of the expanded public matrix A_hat
-    fn A_hat(&self) -> Matrix<k, l>;
+    fn A_hat(&self) -> P::MatrixA;
 
     /// Compute the public key hash (tr) from the public key.
     ///
@@ -135,43 +144,43 @@ pub trait MLDSAPublicKeyTrait<const k: usize, const l: usize, const PK_LEN: usiz
     fn compute_tr(&self) -> [u8; 64];
 }
 
-pub(crate) trait MLDSAPublicKeyInternalTrait<const k: usize, const PK_LEN: usize>:
+pub(crate) trait MLDSAPublicKeyInternalTrait<P: MLDSAParams, const PK_LEN: usize>:
     SignaturePublicKey<PK_LEN>
 {
     /// Not exposing a constructor publicly because you should have to get an instance either by
     /// running a keygen, or by decoding an existing key.
-    fn new(rho: [u8; 32], t1: Vector<k>) -> Self;
+    fn new(rho: [u8; 32], t1: P::VecK) -> Self;
 
     /// Get a ref to t1
-    fn t1(&self) -> &Vector<k>;
+    fn t1(&self) -> &P::VecK;
 }
 
-impl<const k: usize, const l: usize, const PK_LEN: usize> MLDSAPublicKeyTrait<k, l, PK_LEN>
-    for MLDSAPublicKey<k, l, PK_LEN>
+impl<P: MLDSAParams, const PK_LEN: usize> MLDSAPublicKeyTrait<P, PK_LEN>
+    for MLDSAPublicKey<P, PK_LEN>
 {
     // todo: block a t1 of all zeros? Maybe add to consistency_check() ?
     fn pk_decode(pk: &[u8; PK_LEN]) -> Self {
         let rho = pk[0..32].try_into().unwrap();
-        let mut t1 = Vector::<k>::new();
+        let mut t1 = P::VecK::new();
 
         let (pk_chunks, last_chunk) = pk[32..].as_chunks::<POLY_T1PACKED_LEN>();
 
         // that should divide evenly the remainder of the array
-        debug_assert_eq!(pk_chunks.len(), k);
+        debug_assert_eq!(pk_chunks.len(), P::k);
         debug_assert_eq!(last_chunk.len(), 0);
 
-        for (t1_i, pk_chunk) in t1.elems.iter_mut().zip(pk_chunks) {
+        for (t1_i, pk_chunk) in t1.elems_mut().iter_mut().zip(pk_chunks) {
             // 3: 𝐭1[𝑖] ← SimpleBitUnpack(𝑧𝑖, 2bitlen (𝑞−1)−𝑑 − 1)
             //  ▷ This is always in the correct range
             //  Therefore, we don't need to check that the coeeffs are in range
             t1_i.coeffs.copy_from_slice(&simple_bit_unpack_t1(pk_chunk).coeffs);
         }
 
-        Self::new(rho, t1)
+        <Self as MLDSAPublicKeyInternalTrait<P, PK_LEN>>::new(rho, t1)
     }
 
-    fn A_hat(&self) -> Matrix<k, l> {
-        expandA::<k, l>(&self.rho)
+    fn A_hat(&self) -> P::MatrixA {
+        expandA::<P>(&self.rho)
     }
 
     fn compute_tr(&self) -> [u8; 64] {
@@ -182,21 +191,20 @@ impl<const k: usize, const l: usize, const PK_LEN: usize> MLDSAPublicKeyTrait<k,
     }
 }
 
-impl<const k: usize, const l: usize, const PK_LEN: usize> MLDSAPublicKeyInternalTrait<k, PK_LEN>
-    for MLDSAPublicKey<k, l, PK_LEN>
+impl<P: MLDSAParams, const PK_LEN: usize> MLDSAPublicKeyInternalTrait<P, PK_LEN>
+    for MLDSAPublicKey<P, PK_LEN>
 {
-    fn new(rho: [u8; 32], t1: Vector<k>) -> Self {
+    fn new(rho: [u8; 32], t1: P::VecK) -> Self {
+        let () = Self::ASSERT_PK_LEN;
         Self { rho, t1 }
     }
 
-    fn t1(&self) -> &Vector<k> {
+    fn t1(&self) -> &P::VecK {
         &self.t1
     }
 }
 
-impl<const k: usize, const l: usize, const PK_LEN: usize> SignaturePublicKey<PK_LEN>
-    for MLDSAPublicKey<k, l, PK_LEN>
-{
+impl<P: MLDSAParams, const PK_LEN: usize> SignaturePublicKey<PK_LEN> for MLDSAPublicKey<P, PK_LEN> {
     fn encode(&self) -> [u8; PK_LEN] {
         let mut pk = [0u8; PK_LEN];
         let bytes_written = self.encode_out(&mut pk);
@@ -218,15 +226,13 @@ impl<const k: usize, const l: usize, const PK_LEN: usize> SignaturePublicKey<PK_
             ));
         }
         let bytes_sized: [u8; PK_LEN] = bytes[..PK_LEN].try_into().unwrap();
-        Ok(Self::pk_decode(&bytes_sized))
+        Ok(<Self as MLDSAPublicKeyTrait<P, PK_LEN>>::pk_decode(&bytes_sized))
     }
 }
 
-impl<const k: usize, const l: usize, const PK_LEN: usize> Eq for MLDSAPublicKey<k, l, PK_LEN> {}
+impl<P: MLDSAParams, const PK_LEN: usize> Eq for MLDSAPublicKey<P, PK_LEN> {}
 
-impl<const k: usize, const l: usize, const PK_LEN: usize> PartialEq
-    for MLDSAPublicKey<k, l, PK_LEN>
-{
+impl<P: MLDSAParams, const PK_LEN: usize> PartialEq for MLDSAPublicKey<P, PK_LEN> {
     fn eq(&self, other: &Self) -> bool {
         let self_encoded = self.encode();
         let other_encoded = other.encode();
@@ -234,50 +240,54 @@ impl<const k: usize, const l: usize, const PK_LEN: usize> PartialEq
     }
 }
 
-impl<const k: usize, const l: usize, const PK_LEN: usize> Debug for MLDSAPublicKey<k, l, PK_LEN> {
+impl<P: MLDSAParams, const PK_LEN: usize> Debug for MLDSAPublicKey<P, PK_LEN> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let alg = match k {
-            4 => ML_DSA_44_NAME,
-            6 => ML_DSA_65_NAME,
-            8 => ML_DSA_87_NAME,
-            _ => panic!("Unsupported key length"),
-        };
-        write!(f, "MLDSAPublicKey {{ alg: {}, pub_key_hash (tr): {:x?} }}", alg, self.compute_tr(),)
+        write!(
+            f,
+            "MLDSAPublicKey {{ alg: {}, pub_key_hash (tr): {:x?} }}",
+            P::ALG_NAME,
+            <Self as MLDSAPublicKeyTrait<P, PK_LEN>>::compute_tr(self),
+        )
     }
 }
 
-impl<const k: usize, const l: usize, const PK_LEN: usize> Display for MLDSAPublicKey<k, l, PK_LEN> {
+impl<P: MLDSAParams, const PK_LEN: usize> Display for MLDSAPublicKey<P, PK_LEN> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        let alg = match k {
-            4 => ML_DSA_44_NAME,
-            6 => ML_DSA_65_NAME,
-            8 => ML_DSA_87_NAME,
-            _ => panic!("Unsupported key length"),
-        };
-        write!(f, "MLDSAPublicKey {{ alg: {}, pub_key_hash (tr): {:x?} }}", alg, self.compute_tr(),)
+        write!(
+            f,
+            "MLDSAPublicKey {{ alg: {}, pub_key_hash (tr): {:x?} }}",
+            P::ALG_NAME,
+            <Self as MLDSAPublicKeyTrait<P, PK_LEN>>::compute_tr(self),
+        )
     }
 }
 
 /// A fully expanded ML-DSA public key that includes the intermediate values needed for performing
 /// multiple verification operations against the same public key, which causes the public key struct
 /// to take up more memory, but results in more efficient repeated verify() operations.
-#[derive(Clone)]
 pub struct MLDSAPublicKeyExpanded<
-    const k: usize,
-    const l: usize,
-    PK: MLDSAPublicKeyInternalTrait<k, PK_LEN>,
+    P: MLDSAParams,
+    PK: MLDSAPublicKeyInternalTrait<P, PK_LEN>,
     const PK_LEN: usize,
 > {
     pub(crate) pk: PK,
-    pub(crate) A_hat: Matrix<k, l>,
+    pub(crate) A_hat: P::MatrixA,
+}
+
+/// See the note on [`MLDSAPublicKey`]'s `Clone` for why this is not derived.
+impl<P: MLDSAParams, PK: MLDSAPublicKeyInternalTrait<P, PK_LEN>, const PK_LEN: usize> Clone
+    for MLDSAPublicKeyExpanded<P, PK, PK_LEN>
+{
+    fn clone(&self) -> Self {
+        Self { pk: self.pk.clone(), A_hat: self.A_hat.clone() }
+    }
 }
 
 impl<
-    const k: usize,
-    const l: usize,
-    PK: MLDSAPublicKeyTrait<k, l, PK_LEN> + MLDSAPublicKeyInternalTrait<k, PK_LEN>,
+    P: MLDSAParams,
+    PK: MLDSAPublicKeyTrait<P, PK_LEN> + MLDSAPublicKeyInternalTrait<P, PK_LEN>,
     const PK_LEN: usize,
-> SignaturePublicKey<PK_LEN> for MLDSAPublicKeyExpanded<k, l, PK, PK_LEN>
+> SignaturePublicKey<PK_LEN> for MLDSAPublicKeyExpanded<P, PK, PK_LEN>
 {
     fn encode(&self) -> [u8; PK_LEN] {
         self.pk.encode()
@@ -296,16 +306,15 @@ impl<
             ));
         }
         let bytes_sized: [u8; PK_LEN] = bytes[..PK_LEN].try_into().unwrap();
-        Ok(Self::pk_decode(&bytes_sized))
+        Ok(<Self as MLDSAPublicKeyTrait<P, PK_LEN>>::pk_decode(&bytes_sized))
     }
 }
 
 impl<
-    const k: usize,
-    const l: usize,
-    PK: MLDSAPublicKeyTrait<k, l, PK_LEN> + MLDSAPublicKeyInternalTrait<k, PK_LEN>,
+    P: MLDSAParams,
+    PK: MLDSAPublicKeyTrait<P, PK_LEN> + MLDSAPublicKeyInternalTrait<P, PK_LEN>,
     const PK_LEN: usize,
-> PartialEq for MLDSAPublicKeyExpanded<k, l, PK, PK_LEN>
+> PartialEq for MLDSAPublicKeyExpanded<P, PK, PK_LEN>
 {
     fn eq(&self, other: &Self) -> bool {
         self.pk.eq(&other.pk)
@@ -313,66 +322,50 @@ impl<
 }
 
 impl<
-    const k: usize,
-    const l: usize,
-    PK: MLDSAPublicKeyTrait<k, l, PK_LEN> + MLDSAPublicKeyInternalTrait<k, PK_LEN>,
+    P: MLDSAParams,
+    PK: MLDSAPublicKeyTrait<P, PK_LEN> + MLDSAPublicKeyInternalTrait<P, PK_LEN>,
     const PK_LEN: usize,
-> Eq for MLDSAPublicKeyExpanded<k, l, PK, PK_LEN>
+> Eq for MLDSAPublicKeyExpanded<P, PK, PK_LEN>
 {
 }
 
 impl<
-    const k: usize,
-    const l: usize,
-    PK: MLDSAPublicKeyTrait<k, l, PK_LEN> + MLDSAPublicKeyInternalTrait<k, PK_LEN>,
+    P: MLDSAParams,
+    PK: MLDSAPublicKeyTrait<P, PK_LEN> + MLDSAPublicKeyInternalTrait<P, PK_LEN>,
     const PK_LEN: usize,
-> Debug for MLDSAPublicKeyExpanded<k, l, PK, PK_LEN>
+> Debug for MLDSAPublicKeyExpanded<P, PK, PK_LEN>
 {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        let alg = match k {
-            4 => ML_DSA_44_NAME,
-            6 => ML_DSA_65_NAME,
-            8 => ML_DSA_87_NAME,
-            _ => panic!("Unsupported key length"),
-        };
         write!(
             f,
             "MLDSAPublicKeyExpanded {{ alg: {}, pub_key_hash (tr): {:x?} }}",
-            alg,
-            self.compute_tr(),
+            P::ALG_NAME,
+            self.pk.compute_tr(),
         )
     }
 }
 
 impl<
-    const k: usize,
-    const l: usize,
-    PK: MLDSAPublicKeyTrait<k, l, PK_LEN> + MLDSAPublicKeyInternalTrait<k, PK_LEN>,
+    P: MLDSAParams,
+    PK: MLDSAPublicKeyTrait<P, PK_LEN> + MLDSAPublicKeyInternalTrait<P, PK_LEN>,
     const PK_LEN: usize,
-> Display for MLDSAPublicKeyExpanded<k, l, PK, PK_LEN>
+> Display for MLDSAPublicKeyExpanded<P, PK, PK_LEN>
 {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        let alg = match k {
-            4 => ML_DSA_44_NAME,
-            6 => ML_DSA_65_NAME,
-            8 => ML_DSA_87_NAME,
-            _ => panic!("Unsupported key length"),
-        };
         write!(
             f,
             "MLDSAPublicKeyExpanded {{ alg: {}, pub_key_hash (tr): {:x?} }}",
-            alg,
-            self.compute_tr(),
+            P::ALG_NAME,
+            self.pk.compute_tr(),
         )
     }
 }
 
 impl<
-    const k: usize,
-    const l: usize,
-    PK: MLDSAPublicKeyTrait<k, l, PK_LEN> + MLDSAPublicKeyInternalTrait<k, PK_LEN>,
+    P: MLDSAParams,
+    PK: MLDSAPublicKeyTrait<P, PK_LEN> + MLDSAPublicKeyInternalTrait<P, PK_LEN>,
     const PK_LEN: usize,
-> From<&PK> for MLDSAPublicKeyExpanded<k, l, PK, PK_LEN>
+> From<&PK> for MLDSAPublicKeyExpanded<P, PK, PK_LEN>
 {
     /// Fully expands the intermediate values needed for performing multiple encaps operations
     /// against the same public key, which causes the MLKEMPublicKey struct to take up
@@ -384,11 +377,10 @@ impl<
 }
 
 impl<
-    const k: usize,
-    const l: usize,
-    PK: MLDSAPublicKeyTrait<k, l, PK_LEN> + MLDSAPublicKeyInternalTrait<k, PK_LEN>,
+    P: MLDSAParams,
+    PK: MLDSAPublicKeyTrait<P, PK_LEN> + MLDSAPublicKeyInternalTrait<P, PK_LEN>,
     const PK_LEN: usize,
-> MLDSAPublicKeyTrait<k, l, PK_LEN> for MLDSAPublicKeyExpanded<k, l, PK, PK_LEN>
+> MLDSAPublicKeyTrait<P, PK_LEN> for MLDSAPublicKeyExpanded<P, PK, PK_LEN>
 {
     fn pk_decode(pk: &[u8; PK_LEN]) -> Self {
         let pk1 = PK::pk_decode(pk);
@@ -396,7 +388,7 @@ impl<
         Self { pk: pk1, A_hat }
     }
 
-    fn A_hat(&self) -> Matrix<k, l> {
+    fn A_hat(&self) -> P::MatrixA {
         self.A_hat.clone()
     }
 
@@ -407,15 +399,10 @@ impl<
 
 /// An ML-DSA private key.
 ///
+/// See [`MLDSAPublicKey`] for why `SK_LEN` and `PK_LEN` are carried alongside `P`.
+//
 // Dev note: This will automatically inherit the [`Secret`] protections because [`Polynomial`] wraps the underlying data with [`Secret`].
-#[derive(Clone)]
-pub struct MLDSAPrivateKey<
-    const k: usize,
-    const l: usize,
-    const eta: usize,
-    const SK_LEN: usize,
-    const PK_LEN: usize,
-> {
+pub struct MLDSAPrivateKey<P: MLDSAParams, const SK_LEN: usize, const PK_LEN: usize> {
     rho: [u8; 32],
     K: Secret<[u8; 32]>,
     tr: [u8; 64],
@@ -425,16 +412,31 @@ pub struct MLDSAPrivateKey<
     //  So we are going to hold them as s1_hat, s2_hat, and t0_hat.
     //  Note: these are not necessarily in their reduced form; so you'll need to reduce them before
     //  inv_ntt()'ing them or hashing them.
-    s1_hat: Secret<Vector<l>>,
-    s2_hat: Secret<Vector<k>>,
-    t0_hat: Vector<k>,
+    s1_hat: Secret<P::VecL>,
+    s2_hat: Secret<P::VecK>,
+    t0_hat: P::VecK,
     // note: KeyMaterial is inherently Secret
     seed: Option<KeyMaterial<32>>,
 }
 
-impl<const k: usize, const l: usize, const eta: usize, const SK_LEN: usize, const PK_LEN: usize>
-    MLDSAPrivateKey<k, l, eta, SK_LEN, PK_LEN>
+/// See the note on [`MLDSAPublicKey`]'s `Clone` for why this is not derived.
+impl<P: MLDSAParams, const SK_LEN: usize, const PK_LEN: usize> Clone
+    for MLDSAPrivateKey<P, SK_LEN, PK_LEN>
 {
+    fn clone(&self) -> Self {
+        Self {
+            rho: self.rho,
+            K: self.K.clone(),
+            tr: self.tr,
+            s1_hat: self.s1_hat.clone(),
+            s2_hat: self.s2_hat.clone(),
+            t0_hat: self.t0_hat,
+            seed: self.seed.clone(),
+        }
+    }
+}
+
+impl<P: MLDSAParams, const SK_LEN: usize, const PK_LEN: usize> MLDSAPrivateKey<P, SK_LEN, PK_LEN> {
     /// Algorithm 24 skEncode(𝜌, 𝐾, 𝑡𝑟, 𝐬1, 𝐬2, 𝐭0)
     /// Encodes a secret key for ML-DSA into a byte string.
     /// Input: 𝜌 ∈ 𝔹32, 𝐾 ∈ 𝔹32, 𝑡𝑟 ∈ 𝔹64 , 𝐬1 ∈ 𝑅ℓ with coefficients in [−𝜂, 𝜂], 𝐬2 ∈ 𝑅𝑘 with
@@ -452,47 +454,44 @@ impl<const k: usize, const l: usize, const eta: usize, const SK_LEN: usize, cons
         off += 128;
 
         let mut buf = [0u8; 32 * 4]; // largest possible buffer
-        let eta_pack_len = bitlen_eta(eta);
+        let eta_pack_len = bitlen_eta(P::ETA);
 
-        let sk_chunks = out[off..off + l * bitlen_eta(eta)].chunks_mut(bitlen_eta(eta));
-        debug_assert_eq!(sk_chunks.len(), l);
-        for (sk_chunk, s1_hat_i) in sk_chunks.into_iter().zip(&self.s1_hat.elems) {
+        let sk_chunks = out[off..off + P::l * eta_pack_len].chunks_mut(eta_pack_len);
+        debug_assert_eq!(sk_chunks.len(), P::l);
+        for (sk_chunk, s1_hat_i) in sk_chunks.into_iter().zip(self.s1_hat.elems()) {
             // Deviation from the FIPS:
             //   We are holding these in ntt form, so need to convert back to standard form
-            let mut s1_hat_i = s1_hat_i.clone();
-            s1_hat_i.reduce();
-            s1_hat_i.inv_ntt();
-            let s1_i = s1_hat_i;
+            let mut s1_i = *s1_hat_i;
+            s1_i.reduce();
+            s1_i.inv_ntt();
 
-            bit_pack_eta::<eta>(&s1_i, &mut buf);
+            bit_pack_eta::<P>(&s1_i, &mut buf);
             sk_chunk.copy_from_slice(&buf[..eta_pack_len]);
         }
-        off += l * bitlen_eta(eta);
+        off += P::l * eta_pack_len;
 
-        let sk_chunks = out[off..off + k * bitlen_eta(eta)].chunks_mut(bitlen_eta(eta));
-        debug_assert_eq!(sk_chunks.len(), k);
-        for (sk_chunk, s2_hat_i) in sk_chunks.into_iter().zip(&self.s2_hat.elems) {
+        let sk_chunks = out[off..off + P::k * eta_pack_len].chunks_mut(eta_pack_len);
+        debug_assert_eq!(sk_chunks.len(), P::k);
+        for (sk_chunk, s2_hat_i) in sk_chunks.into_iter().zip(self.s2_hat.elems()) {
             // Deviation from the FIPS:
             //   We are holding these in ntt form, so need to convert back to standard form
-            let mut s2_hat_i = s2_hat_i.clone();
-            s2_hat_i.reduce();
-            s2_hat_i.inv_ntt();
-            let s2_i = s2_hat_i;
+            let mut s2_i = *s2_hat_i;
+            s2_i.reduce();
+            s2_i.inv_ntt();
 
-            bit_pack_eta::<eta>(&s2_i, &mut buf);
+            bit_pack_eta::<P>(&s2_i, &mut buf);
             sk_chunk.copy_from_slice(&buf[..eta_pack_len]);
         }
-        off += k * bitlen_eta(eta);
+        off += P::k * eta_pack_len;
 
-        let sk_chunks = out[off..off + k * POLY_T0PACKED_LEN].chunks_mut(POLY_T0PACKED_LEN);
-        debug_assert_eq!(sk_chunks.len(), k);
-        for (sk_chunk, t0_hat_i) in sk_chunks.into_iter().zip(&self.t0_hat.elems) {
+        let sk_chunks = out[off..off + P::k * POLY_T0PACKED_LEN].chunks_mut(POLY_T0PACKED_LEN);
+        debug_assert_eq!(sk_chunks.len(), P::k);
+        for (sk_chunk, t0_hat_i) in sk_chunks.into_iter().zip(self.t0_hat.elems()) {
             // Deviation from the FIPS:
             //   We are holding these in ntt form, so need to convert back to standard form
-            let mut t0_hat_i = t0_hat_i.clone();
-            t0_hat_i.reduce();
-            t0_hat_i.inv_ntt();
-            let t0_i = t0_hat_i;
+            let mut t0_i = *t0_hat_i;
+            t0_i.reduce();
+            t0_i.inv_ntt();
 
             sk_chunk.copy_from_slice(&bit_pack_t0(&t0_i));
         }
@@ -502,13 +501,8 @@ impl<const k: usize, const l: usize, const eta: usize, const SK_LEN: usize, cons
 }
 
 /// General trait for all ML-DSA private keys types.
-pub trait MLDSAPrivateKeyTrait<
-    const k: usize,
-    const l: usize,
-    const eta: usize,
-    const SK_LEN: usize,
-    const PK_LEN: usize,
->: SignaturePrivateKey<SK_LEN>
+pub trait MLDSAPrivateKeyTrait<P: MLDSAParams, const SK_LEN: usize, const PK_LEN: usize>:
+    SignaturePrivateKey<SK_LEN>
 {
     /// Get a ref to the seed, if there is one stored with this private key
     fn seed(&self) -> Option<&KeyMaterial<32>>;
@@ -517,10 +511,10 @@ pub trait MLDSAPrivateKeyTrait<
     fn tr(&self) -> &[u8; 64];
 
     /// Get the public matrix A_hat.
-    fn A_hat(&self) -> Matrix<k, l>;
+    fn A_hat(&self) -> P::MatrixA;
 
     /// This is a partial implementation of keygen_internal(), and probably not allowed in FIPS mode.
-    fn derive_pk(&self) -> MLDSAPublicKey<k, l, PK_LEN>;
+    fn derive_pk(&self) -> MLDSAPublicKey<P, PK_LEN>;
     /// Algorithm 25 skDecode(𝑠𝑘)
     /// Reverses the procedure skEncode.
     /// Input: Private key 𝑠𝑘 ∈ 𝔹32+32+64+32⋅((ℓ+𝑘)⋅bitlen (2𝜂)+𝑑𝑘).
@@ -533,9 +527,7 @@ pub trait MLDSAPrivateKeyTrait<
 }
 
 pub(crate) trait MLDSAPrivateKeyInternalTrait<
-    const k: usize,
-    const l: usize,
-    const eta: usize,
+    P: MLDSAParams,
     const SK_LEN: usize,
     const PK_LEN: usize,
 >
@@ -546,23 +538,23 @@ pub(crate) trait MLDSAPrivateKeyInternalTrait<
         rho: [u8; 32],
         K: Secret<[u8; 32]>,
         tr: [u8; 64],
-        s1_hat: Secret<Vector<l>>,
-        s2_hat: Secret<Vector<k>>,
-        t0_hat: Vector<k>,
+        s1_hat: Secret<P::VecL>,
+        s2_hat: Secret<P::VecK>,
+        t0_hat: P::VecK,
         seed: Option<KeyMaterial<32>>,
     ) -> Self;
     /// Get a ref to K
     fn K(&self) -> &Secret<[u8; 32]>;
     /// Get a ref to s1
-    fn s1_hat(&self) -> &Vector<l>;
+    fn s1_hat(&self) -> &P::VecL;
     /// Get a ref to s2
-    fn s2_hat(&self) -> &Vector<k>;
+    fn s2_hat(&self) -> &P::VecK;
     /// Get a ref to t0
-    fn t0_hat(&self) -> &Vector<k>;
+    fn t0_hat(&self) -> &P::VecK;
 }
 
-impl<const k: usize, const l: usize, const eta: usize, const SK_LEN: usize, const PK_LEN: usize>
-    MLDSAPrivateKeyTrait<k, l, eta, SK_LEN, PK_LEN> for MLDSAPrivateKey<k, l, eta, SK_LEN, PK_LEN>
+impl<P: MLDSAParams, const SK_LEN: usize, const PK_LEN: usize>
+    MLDSAPrivateKeyTrait<P, SK_LEN, PK_LEN> for MLDSAPrivateKey<P, SK_LEN, PK_LEN>
 {
     fn seed(&self) -> Option<&KeyMaterial<32>> {
         match self.seed {
@@ -575,18 +567,18 @@ impl<const k: usize, const l: usize, const eta: usize, const SK_LEN: usize, cons
         &self.tr
     }
 
-    fn A_hat(&self) -> Matrix<k, l> {
-        expandA::<k, l>(&self.rho)
+    fn A_hat(&self) -> P::MatrixA {
+        expandA::<P>(&self.rho)
     }
 
-    fn derive_pk(&self) -> MLDSAPublicKey<k, l, PK_LEN> {
+    fn derive_pk(&self) -> MLDSAPublicKey<P, PK_LEN> {
         // 5: 𝐭 ← NTT−1(𝐀 ∘ NTT(𝐬1)) + 𝐬2
         //   ▷ compute 𝐭 = 𝐀𝐬1 + 𝐬2
         let mut t = {
             // scope for A_hat
             // 3: 𝐀 ← ExpandA(𝜌)
             //   ▷ 𝐀 is generated and stored in NTT representation as 𝐀
-            let A_hat = expandA::<k, l>(&self.rho);
+            let A_hat = expandA::<P>(&self.rho);
 
             let mut t_ntt = A_hat.matrix_vector_ntt(&self.s1_hat);
             t_ntt.inv_ntt();
@@ -596,7 +588,7 @@ impl<const k: usize, const l: usize, const eta: usize, const SK_LEN: usize, cons
         {
             // Deviation from the FIPS:
             // Because s2 is in ntt form, it is necessary to reverse that here before adding it to t
-            let mut s2 = self.s2_hat.clone();
+            let mut s2 = *self.s2_hat;
             s2.reduce();
             s2.inv_ntt();
 
@@ -606,9 +598,9 @@ impl<const k: usize, const l: usize, const eta: usize, const SK_LEN: usize, cons
         // 6: (𝐭1, 𝐭0) ← Power2Round(𝐭)
         //   ▷ compress 𝐭
         //   ▷ PowerTwoRound is applied componentwise (see explanatory text in Section 7.4)
-        let (t1, _) = power_2_round_vec::<k>(&t);
+        let (t1, _) = power_2_round_vec(&t);
 
-        MLDSAPublicKey::<k, l, PK_LEN>::new(self.rho.clone(), t1)
+        <MLDSAPublicKey<P, PK_LEN> as MLDSAPublicKeyInternalTrait<P, PK_LEN>>::new(self.rho, t1)
     }
     fn sk_decode(sk: &[u8; SK_LEN]) -> Result<Self, SignatureError> {
         // Construct the (Secret-protected) key up front and unpack each field directly into it,
@@ -621,23 +613,25 @@ impl<const k: usize, const l: usize, const eta: usize, const SK_LEN: usize, cons
             tr: sk[64..128].try_into().unwrap(),
             s1_hat: Secret::new(),
             s2_hat: Secret::new(),
-            t0_hat: Vector::<k>::new(),
+            t0_hat: P::VecK::new(),
             seed: None,
         };
         key.K.copy_from_slice(&sk[32..64]);
         let mut off = 128;
+        let eta_pack_len = bitlen_eta(P::ETA);
+        let eta = P::ETA as i32;
 
         // unpack s1 directly into key.s1_hat so that we don't make additional non-Secret copies.
-        let sk_chunks = sk[off..off + (l * bitlen_eta(eta))].chunks(bitlen_eta(eta));
-        debug_assert_eq!(sk_chunks.len(), l);
-        for (s1_i, sk_chunk) in key.s1_hat.elems.iter_mut().zip(sk_chunks) {
+        let sk_chunks = sk[off..off + (P::l * eta_pack_len)].chunks(eta_pack_len);
+        debug_assert_eq!(sk_chunks.len(), P::l);
+        for (s1_i, sk_chunk) in key.s1_hat.elems_mut().iter_mut().zip(sk_chunks) {
             // 3: 𝐬1[𝑖] ← BitUnpack(𝑦𝑖, 𝜂, 𝜂)
             //  ▷ this may lie outside [−𝜂, 𝜂] if input is malformed
-            s1_i.coeffs.copy_from_slice(&bit_unpack_eta::<eta>(&sk_chunk).coeffs);
+            s1_i.coeffs.copy_from_slice(&bit_unpack_eta::<P>(sk_chunk).coeffs);
 
             // check that the coefficients are within the expected range
             for coeff in s1_i.coeffs.iter() {
-                if *coeff < -(eta as i32) || *coeff > (eta as i32) {
+                if *coeff < -eta || *coeff > eta {
                     return Err(SignatureError::DecodingError("Invalid or corrupted key"));
                 }
             }
@@ -645,19 +639,19 @@ impl<const k: usize, const l: usize, const eta: usize, const SK_LEN: usize, cons
         // Deviation from the FIPS:
         //   Convert this to ntt form as part of decode
         key.s1_hat.ntt();
-        off += l * bitlen_eta(eta);
+        off += P::l * eta_pack_len;
 
         // unpack s2 directly into key.s2_hat so that we don't make additional non-Secret copies.
-        let sk_chunks = sk[off..off + (k * bitlen_eta(eta))].chunks(bitlen_eta(eta));
-        debug_assert_eq!(sk_chunks.len(), k);
-        for (s2_i, sk_chunk) in key.s2_hat.elems.iter_mut().zip(sk_chunks) {
+        let sk_chunks = sk[off..off + (P::k * eta_pack_len)].chunks(eta_pack_len);
+        debug_assert_eq!(sk_chunks.len(), P::k);
+        for (s2_i, sk_chunk) in key.s2_hat.elems_mut().iter_mut().zip(sk_chunks) {
             // 6: 𝐬2[𝑖] ← BitUnpack(𝑧𝑖, 𝜂, 𝜂)
             //  ▷ this may lie outside [−𝜂, 𝜂] if input is malformed
-            s2_i.coeffs.copy_from_slice(&bit_unpack_eta::<eta>(&sk_chunk).coeffs);
+            s2_i.coeffs.copy_from_slice(&bit_unpack_eta::<P>(sk_chunk).coeffs);
 
             // check that the coefficients are within the expected range
             for coeff in s2_i.coeffs.iter() {
-                if *coeff < -(eta as i32) || *coeff > (eta as i32) {
+                if *coeff < -eta || *coeff > eta {
                     return Err(SignatureError::DecodingError("Invalid or corrupted key"));
                 }
             }
@@ -665,17 +659,17 @@ impl<const k: usize, const l: usize, const eta: usize, const SK_LEN: usize, cons
         // Deviation from the FIPS:
         // Convert this to ntt form as part of decode
         key.s2_hat.ntt();
-        off += k * bitlen_eta(eta);
+        off += P::k * eta_pack_len;
 
         // unpack t0 directly into key.t0_hat
         let (sk_chunks, last_chunk) =
-            sk[off..off + (k * POLY_T0PACKED_LEN)].as_chunks::<POLY_T0PACKED_LEN>();
+            sk[off..off + (P::k * POLY_T0PACKED_LEN)].as_chunks::<POLY_T0PACKED_LEN>();
 
         // that should divide evenly the remainder of the array
-        debug_assert_eq!(sk_chunks.len(), k);
+        debug_assert_eq!(sk_chunks.len(), P::k);
         debug_assert_eq!(last_chunk.len(), 0);
 
-        for (t0_i, sk_chunk) in key.t0_hat.elems.iter_mut().zip(sk_chunks) {
+        for (t0_i, sk_chunk) in key.t0_hat.elems_mut().iter_mut().zip(sk_chunks) {
             t0_i.coeffs.copy_from_slice(&bit_unpack_t0(sk_chunk).coeffs);
         }
         // Deviation from the FIPS:
@@ -686,49 +680,40 @@ impl<const k: usize, const l: usize, const eta: usize, const SK_LEN: usize, cons
     }
 }
 
-impl<const k: usize, const l: usize, const eta: usize, const SK_LEN: usize, const PK_LEN: usize>
-    MLDSAPrivateKeyInternalTrait<k, l, eta, SK_LEN, PK_LEN>
-    for MLDSAPrivateKey<k, l, eta, SK_LEN, PK_LEN>
+impl<P: MLDSAParams, const SK_LEN: usize, const PK_LEN: usize>
+    MLDSAPrivateKeyInternalTrait<P, SK_LEN, PK_LEN> for MLDSAPrivateKey<P, SK_LEN, PK_LEN>
 {
     fn new(
         rho: [u8; 32],
         K: Secret<[u8; 32]>,
         tr: [u8; 64],
-        s1_hat: Secret<Vector<l>>,
-        s2_hat: Secret<Vector<k>>,
-        t0_hat: Vector<k>,
+        s1_hat: Secret<P::VecL>,
+        s2_hat: Secret<P::VecK>,
+        t0_hat: P::VecK,
         seed: Option<KeyMaterial<32>>,
     ) -> Self {
-        Self {
-            rho: rho.clone(),
-            K: K.clone(),
-            tr: tr.clone(),
-            s1_hat: s1_hat.clone(),
-            s2_hat: s2_hat.clone(),
-            t0_hat: t0_hat.clone(),
-            seed: seed.clone(),
-        }
+        Self { rho, K, tr, s1_hat, s2_hat, t0_hat, seed }
     }
 
     fn K(&self) -> &Secret<[u8; 32]> {
         &self.K
     }
 
-    fn s1_hat(&self) -> &Vector<l> {
+    fn s1_hat(&self) -> &P::VecL {
         &self.s1_hat
     }
 
-    fn s2_hat(&self) -> &Vector<k> {
+    fn s2_hat(&self) -> &P::VecK {
         &self.s2_hat
     }
 
-    fn t0_hat(&self) -> &Vector<k> {
+    fn t0_hat(&self) -> &P::VecK {
         &self.t0_hat
     }
 }
 
-impl<const k: usize, const l: usize, const eta: usize, const SK_LEN: usize, const PK_LEN: usize>
-    SignaturePrivateKey<SK_LEN> for MLDSAPrivateKey<k, l, eta, SK_LEN, PK_LEN>
+impl<P: MLDSAParams, const SK_LEN: usize, const PK_LEN: usize> SignaturePrivateKey<SK_LEN>
+    for MLDSAPrivateKey<P, SK_LEN, PK_LEN>
 {
     fn encode(&self) -> [u8; SK_LEN] {
         let mut out = [0u8; SK_LEN];
@@ -752,17 +737,17 @@ impl<const k: usize, const l: usize, const eta: usize, const SK_LEN: usize, cons
         }
         let bytes_sized: [u8; SK_LEN] = bytes[..SK_LEN].try_into().unwrap();
 
-        Ok(Self::sk_decode(&bytes_sized)?)
+        <Self as MLDSAPrivateKeyTrait<P, SK_LEN, PK_LEN>>::sk_decode(&bytes_sized)
     }
 }
 
-impl<const k: usize, const l: usize, const eta: usize, const SK_LEN: usize, const PK_LEN: usize> Eq
-    for MLDSAPrivateKey<k, l, eta, SK_LEN, PK_LEN>
+impl<P: MLDSAParams, const SK_LEN: usize, const PK_LEN: usize> Eq
+    for MLDSAPrivateKey<P, SK_LEN, PK_LEN>
 {
 }
 
-impl<const k: usize, const l: usize, const eta: usize, const SK_LEN: usize, const PK_LEN: usize>
-    PartialEq for MLDSAPrivateKey<k, l, eta, SK_LEN, PK_LEN>
+impl<P: MLDSAParams, const SK_LEN: usize, const PK_LEN: usize> PartialEq
+    for MLDSAPrivateKey<P, SK_LEN, PK_LEN>
 {
     fn eq(&self, other: &Self) -> bool {
         let self_encoded = self.encode();
@@ -772,20 +757,14 @@ impl<const k: usize, const l: usize, const eta: usize, const SK_LEN: usize, cons
 }
 
 /// Debug impl mainly to prevent the secret key from being printed in logs.
-impl<const k: usize, const l: usize, const eta: usize, const SK_LEN: usize, const PK_LEN: usize>
-    fmt::Debug for MLDSAPrivateKey<k, l, eta, SK_LEN, PK_LEN>
+impl<P: MLDSAParams, const SK_LEN: usize, const PK_LEN: usize> fmt::Debug
+    for MLDSAPrivateKey<P, SK_LEN, PK_LEN>
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let alg = match k {
-            4 => ML_DSA_44_NAME,
-            6 => ML_DSA_65_NAME,
-            8 => ML_DSA_87_NAME,
-            _ => panic!("Unsupported key length"),
-        };
         write!(
             f,
             "MLDSAPrivateKey {{ alg: {}, pub_key_hash (tr): {:x?}, has_seed: {} }}",
-            alg,
+            P::ALG_NAME,
             self.tr,
             self.seed.is_some(),
         )
@@ -793,20 +772,14 @@ impl<const k: usize, const l: usize, const eta: usize, const SK_LEN: usize, cons
 }
 
 /// Display impl mainly to prevent the secret key from being printed in logs.
-impl<const k: usize, const l: usize, const eta: usize, const SK_LEN: usize, const PK_LEN: usize>
-    Display for MLDSAPrivateKey<k, l, eta, SK_LEN, PK_LEN>
+impl<P: MLDSAParams, const SK_LEN: usize, const PK_LEN: usize> Display
+    for MLDSAPrivateKey<P, SK_LEN, PK_LEN>
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let alg = match k {
-            4 => ML_DSA_44_NAME,
-            6 => ML_DSA_65_NAME,
-            8 => ML_DSA_87_NAME,
-            _ => panic!("Unsupported key length"),
-        };
         write!(
             f,
             "MLDSAPrivateKey {{ alg: {}, pub_key_hash (tr): {:x?}, has_seed: {} }}",
-            alg,
+            P::ALG_NAME,
             self.tr,
             self.seed.is_some(),
         )
@@ -816,32 +789,39 @@ impl<const k: usize, const l: usize, const eta: usize, const SK_LEN: usize, cons
 /// A fully expanded ML-DSA private key that includes the intermediate values needed for performing
 /// multiple sign operations with the same private key, which causes the private ey struct to take up
 /// more memory, but results in more efficient repeated sign() operations.
-#[derive(Clone)]
 pub struct MLDSAPrivateKeyExpanded<
-    const k: usize,
-    const l: usize,
-    const eta: usize,
-    PK: MLDSAPublicKeyInternalTrait<k, PK_LEN>,
-    SK: MLDSAPrivateKeyTrait<k, l, eta, SK_LEN, PK_LEN>
-        + MLDSAPrivateKeyInternalTrait<k, l, eta, SK_LEN, PK_LEN>,
+    P: MLDSAParams,
+    PK: MLDSAPublicKeyInternalTrait<P, PK_LEN>,
+    SK: MLDSAPrivateKeyTrait<P, SK_LEN, PK_LEN> + MLDSAPrivateKeyInternalTrait<P, SK_LEN, PK_LEN>,
     const SK_LEN: usize,
     const PK_LEN: usize,
 > {
     _phantom: core::marker::PhantomData<PK>,
     pub(crate) sk: SK,
-    pub(crate) A_hat: Matrix<k, l>,
+    pub(crate) A_hat: P::MatrixA,
+}
+
+/// See the note on [`MLDSAPublicKey`]'s `Clone` for why this is not derived.
+impl<
+    P: MLDSAParams,
+    PK: MLDSAPublicKeyInternalTrait<P, PK_LEN>,
+    SK: MLDSAPrivateKeyTrait<P, SK_LEN, PK_LEN> + MLDSAPrivateKeyInternalTrait<P, SK_LEN, PK_LEN>,
+    const SK_LEN: usize,
+    const PK_LEN: usize,
+> Clone for MLDSAPrivateKeyExpanded<P, PK, SK, SK_LEN, PK_LEN>
+{
+    fn clone(&self) -> Self {
+        Self { _phantom: core::marker::PhantomData, sk: self.sk.clone(), A_hat: self.A_hat.clone() }
+    }
 }
 
 impl<
-    const k: usize,
-    const l: usize,
-    const eta: usize,
-    PK: MLDSAPublicKeyInternalTrait<k, PK_LEN>,
-    SK: MLDSAPrivateKeyTrait<k, l, eta, SK_LEN, PK_LEN>
-        + MLDSAPrivateKeyInternalTrait<k, l, eta, SK_LEN, PK_LEN>,
+    P: MLDSAParams,
+    PK: MLDSAPublicKeyInternalTrait<P, PK_LEN>,
+    SK: MLDSAPrivateKeyTrait<P, SK_LEN, PK_LEN> + MLDSAPrivateKeyInternalTrait<P, SK_LEN, PK_LEN>,
     const SK_LEN: usize,
     const PK_LEN: usize,
-> PartialEq for MLDSAPrivateKeyExpanded<k, l, eta, PK, SK, SK_LEN, PK_LEN>
+> PartialEq for MLDSAPrivateKeyExpanded<P, PK, SK, SK_LEN, PK_LEN>
 {
     fn eq(&self, other: &Self) -> bool {
         self.sk.eq(&other.sk)
@@ -849,40 +829,28 @@ impl<
 }
 
 impl<
-    const k: usize,
-    const l: usize,
-    const eta: usize,
-    PK: MLDSAPublicKeyInternalTrait<k, PK_LEN>,
-    SK: MLDSAPrivateKeyTrait<k, l, eta, SK_LEN, PK_LEN>
-        + MLDSAPrivateKeyInternalTrait<k, l, eta, SK_LEN, PK_LEN>,
+    P: MLDSAParams,
+    PK: MLDSAPublicKeyInternalTrait<P, PK_LEN>,
+    SK: MLDSAPrivateKeyTrait<P, SK_LEN, PK_LEN> + MLDSAPrivateKeyInternalTrait<P, SK_LEN, PK_LEN>,
     const SK_LEN: usize,
     const PK_LEN: usize,
-> Eq for MLDSAPrivateKeyExpanded<k, l, eta, PK, SK, SK_LEN, PK_LEN>
+> Eq for MLDSAPrivateKeyExpanded<P, PK, SK, SK_LEN, PK_LEN>
 {
 }
 
 impl<
-    const k: usize,
-    const l: usize,
-    const eta: usize,
-    PK: MLDSAPublicKeyInternalTrait<k, PK_LEN>,
-    SK: MLDSAPrivateKeyTrait<k, l, eta, SK_LEN, PK_LEN>
-        + MLDSAPrivateKeyInternalTrait<k, l, eta, SK_LEN, PK_LEN>,
+    P: MLDSAParams,
+    PK: MLDSAPublicKeyInternalTrait<P, PK_LEN>,
+    SK: MLDSAPrivateKeyTrait<P, SK_LEN, PK_LEN> + MLDSAPrivateKeyInternalTrait<P, SK_LEN, PK_LEN>,
     const SK_LEN: usize,
     const PK_LEN: usize,
-> Debug for MLDSAPrivateKeyExpanded<k, l, eta, PK, SK, SK_LEN, PK_LEN>
+> Debug for MLDSAPrivateKeyExpanded<P, PK, SK, SK_LEN, PK_LEN>
 {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        let alg = match k {
-            4 => ML_DSA_44_NAME,
-            6 => ML_DSA_65_NAME,
-            8 => ML_DSA_87_NAME,
-            _ => panic!("Unsupported key length"),
-        };
         write!(
             f,
             "MLDSAPrivateKeyExpanded {{ alg: {}, pub_key_hash (tr): {:x?}, has_seed: {} }}",
-            alg,
+            P::ALG_NAME,
             self.sk.tr(),
             self.sk.seed().is_some(),
         )
@@ -890,27 +858,18 @@ impl<
 }
 
 impl<
-    const k: usize,
-    const l: usize,
-    const eta: usize,
-    PK: MLDSAPublicKeyInternalTrait<k, PK_LEN>,
-    SK: MLDSAPrivateKeyTrait<k, l, eta, SK_LEN, PK_LEN>
-        + MLDSAPrivateKeyInternalTrait<k, l, eta, SK_LEN, PK_LEN>,
+    P: MLDSAParams,
+    PK: MLDSAPublicKeyInternalTrait<P, PK_LEN>,
+    SK: MLDSAPrivateKeyTrait<P, SK_LEN, PK_LEN> + MLDSAPrivateKeyInternalTrait<P, SK_LEN, PK_LEN>,
     const SK_LEN: usize,
     const PK_LEN: usize,
-> Display for MLDSAPrivateKeyExpanded<k, l, eta, PK, SK, SK_LEN, PK_LEN>
+> Display for MLDSAPrivateKeyExpanded<P, PK, SK, SK_LEN, PK_LEN>
 {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        let alg = match k {
-            4 => ML_DSA_44_NAME,
-            6 => ML_DSA_65_NAME,
-            8 => ML_DSA_87_NAME,
-            _ => panic!("Unsupported key length"),
-        };
         write!(
             f,
             "MLDSAPrivateKeyExpanded {{ alg: {}, pub_key_hash (tr): {:x?}, has_seed: {} }}",
-            alg,
+            P::ALG_NAME,
             self.sk.tr(),
             self.sk.seed().is_some(),
         )
@@ -918,35 +877,30 @@ impl<
 }
 
 impl<
-    const k: usize,
-    const l: usize,
-    const eta: usize,
-    PK: MLDSAPublicKeyInternalTrait<k, PK_LEN>,
-    SK: MLDSAPrivateKeyTrait<k, l, eta, SK_LEN, PK_LEN>
-        + MLDSAPrivateKeyInternalTrait<k, l, eta, SK_LEN, PK_LEN>,
+    P: MLDSAParams,
+    PK: MLDSAPublicKeyInternalTrait<P, PK_LEN>,
+    SK: MLDSAPrivateKeyTrait<P, SK_LEN, PK_LEN> + MLDSAPrivateKeyInternalTrait<P, SK_LEN, PK_LEN>,
     const SK_LEN: usize,
     const PK_LEN: usize,
-> From<&SK> for MLDSAPrivateKeyExpanded<k, l, eta, PK, SK, SK_LEN, PK_LEN>
+> From<&SK> for MLDSAPrivateKeyExpanded<P, PK, SK, SK_LEN, PK_LEN>
 {
     /// Fully expands the intermediate values needed for performing multiple encaps operations
     /// against the same public key, which causes the MLKEMPublicKey struct to take up
     fn from(sk: &SK) -> Self {
-        let A_hat = sk.derive_pk().A_hat();
+        let A_hat =
+            <MLDSAPublicKey<P, PK_LEN> as MLDSAPublicKeyTrait<P, PK_LEN>>::A_hat(&sk.derive_pk());
 
         Self { _phantom: core::marker::PhantomData, sk: sk.clone(), A_hat }
     }
 }
 
 impl<
-    const k: usize,
-    const l: usize,
-    const eta: usize,
-    PK: MLDSAPublicKeyInternalTrait<k, PK_LEN>,
-    SK: MLDSAPrivateKeyTrait<k, l, eta, SK_LEN, PK_LEN>
-        + MLDSAPrivateKeyInternalTrait<k, l, eta, SK_LEN, PK_LEN>,
+    P: MLDSAParams,
+    PK: MLDSAPublicKeyInternalTrait<P, PK_LEN>,
+    SK: MLDSAPrivateKeyTrait<P, SK_LEN, PK_LEN> + MLDSAPrivateKeyInternalTrait<P, SK_LEN, PK_LEN>,
     const SK_LEN: usize,
     const PK_LEN: usize,
-> SignaturePrivateKey<SK_LEN> for MLDSAPrivateKeyExpanded<k, l, eta, PK, SK, SK_LEN, PK_LEN>
+> SignaturePrivateKey<SK_LEN> for MLDSAPrivateKeyExpanded<P, PK, SK, SK_LEN, PK_LEN>
 {
     fn encode(&self) -> [u8; SK_LEN] {
         self.sk.encode()
@@ -965,16 +919,12 @@ impl<
 }
 
 impl<
-    const k: usize,
-    const l: usize,
-    const eta: usize,
-    PK: MLDSAPublicKeyInternalTrait<k, PK_LEN>,
-    SK: MLDSAPrivateKeyTrait<k, l, eta, SK_LEN, PK_LEN>
-        + MLDSAPrivateKeyInternalTrait<k, l, eta, SK_LEN, PK_LEN>,
+    P: MLDSAParams,
+    PK: MLDSAPublicKeyInternalTrait<P, PK_LEN>,
+    SK: MLDSAPrivateKeyTrait<P, SK_LEN, PK_LEN> + MLDSAPrivateKeyInternalTrait<P, SK_LEN, PK_LEN>,
     const SK_LEN: usize,
     const PK_LEN: usize,
-> MLDSAPrivateKeyTrait<k, l, eta, SK_LEN, PK_LEN>
-    for MLDSAPrivateKeyExpanded<k, l, eta, PK, SK, SK_LEN, PK_LEN>
+> MLDSAPrivateKeyTrait<P, SK_LEN, PK_LEN> for MLDSAPrivateKeyExpanded<P, PK, SK, SK_LEN, PK_LEN>
 {
     fn seed(&self) -> Option<&KeyMaterial<32>> {
         self.sk.seed()
@@ -984,17 +934,18 @@ impl<
         self.sk.tr()
     }
 
-    fn A_hat(&self) -> Matrix<k, l> {
+    fn A_hat(&self) -> P::MatrixA {
         self.sk.A_hat()
     }
 
-    fn derive_pk(&self) -> MLDSAPublicKey<k, l, PK_LEN> {
+    fn derive_pk(&self) -> MLDSAPublicKey<P, PK_LEN> {
         self.sk.derive_pk()
     }
 
     fn sk_decode(sk: &[u8; SK_LEN]) -> Result<Self, SignatureError> {
         let sk1 = SK::sk_decode(sk)?;
-        let A_hat = sk1.derive_pk().A_hat();
+        let A_hat =
+            <MLDSAPublicKey<P, PK_LEN> as MLDSAPublicKeyTrait<P, PK_LEN>>::A_hat(&sk1.derive_pk());
 
         Ok(Self { _phantom: core::marker::PhantomData, sk: sk1, A_hat })
     }

--- a/crypto/mldsa/src/mldsa_keys.rs
+++ b/crypto/mldsa/src/mldsa_keys.rs
@@ -77,8 +77,8 @@ pub type MLDSA87PrivateKeyExpanded = MLDSAPrivateKeyExpanded<
 ///
 /// `PK_LEN` duplicates `MLDSAParams::PK_LEN`; it has to be carried separately because
 /// [`SignaturePublicKey`] takes the encoded length as a const generic parameter, and an associated
-/// const of a type parameter may not be used as a const generic argument. The two are checked
-/// against each other at compile time -- see the `ASSERT_PK_LEN` const on this type.
+/// const of a type parameter may not be used as a const generic argument. The type aliases below
+/// wire the two together.
 pub struct MLDSAPublicKey<P: MLDSAParams, const PK_LEN: usize> {
     rho: [u8; 32],
     t1: P::VecK,
@@ -93,12 +93,6 @@ impl<P: MLDSAParams, const PK_LEN: usize> Clone for MLDSAPublicKey<P, PK_LEN> {
 }
 
 impl<P: MLDSAParams, const PK_LEN: usize> MLDSAPublicKey<P, PK_LEN> {
-    /// Fails to evaluate, and so fails the build, if this type is instantiated with a `PK_LEN`
-    /// that is not the parameter set's own. Referenced from every constructor so that it is
-    /// reached during monomorphization.
-    const ASSERT_PK_LEN: () =
-        assert!(PK_LEN == P::PK_LEN, "PK_LEN does not match MLDSAParams::PK_LEN");
-
     /// Algorithm 22 pkEncode(𝜌, 𝐭1)
     /// Encodes a public key for ML-DSA into a byte string.
     /// Input:𝜌 ∈ 𝔹32, 𝐭1 ∈ 𝑅𝑘 with coefficients in [0, 2bitlen (𝑞−1)−𝑑 − 1].
@@ -195,7 +189,6 @@ impl<P: MLDSAParams, const PK_LEN: usize> MLDSAPublicKeyInternalTrait<P, PK_LEN>
     for MLDSAPublicKey<P, PK_LEN>
 {
     fn new(rho: [u8; 32], t1: P::VecK) -> Self {
-        let () = Self::ASSERT_PK_LEN;
         Self { rho, t1 }
     }
 

--- a/crypto/mldsa/src/params.rs
+++ b/crypto/mldsa/src/params.rs
@@ -46,21 +46,21 @@ pub trait MLDSAParams: MLDSAParamsInternalTrait {
     /* FIPS 204, Table 1: the values assigned by each parameter set. */
 
     /// 𝜏, the number of ±1's in the polynomial 𝑐.
-    const TAU: i32;
+    const tau: i32;
     /// 𝜆, the collision strength of 𝑐̃, in bits.
-    const LAMBDA: i32;
+    const lambda: i32;
     /// 𝛾1, the coefficient range of 𝐲. Always a power of two.
-    const GAMMA1: i32;
+    const gamma1: i32;
     /// 𝛾2, the low-order rounding range.
-    const GAMMA2: i32;
+    const gamma2: i32;
     /// 𝑘, the number of rows of 𝐀.
     const k: usize;
     /// ℓ, the number of columns of 𝐀.
     const l: usize;
     /// 𝜂, the private key range.
-    const ETA: usize;
+    const eta: usize;
     /// 𝜔, the maximum number of 1's in the hint 𝐡.
-    const OMEGA: i32;
+    const omega: i32;
 
     /* FIPS 204, Table 2: sizes in bytes of keys and signatures. */
 
@@ -71,7 +71,7 @@ pub trait MLDSAParams: MLDSAParamsInternalTrait {
     /// The length of a signature.
     const SIG_LEN: usize;
 
-    /* Algorithm meta-data. */
+    /* Algorithm meta-data */
 
     /// The algorithm name, as reported by `Algorithm::ALG_NAME`.
     const ALG_NAME: &'static str;
@@ -85,28 +85,33 @@ pub trait MLDSAParams: MLDSAParamsInternalTrait {
     /* Derived. Never written out per parameter set -- see the module docs. */
 
     /// 𝛽, which FIPS 204, Table 1 defines as "𝛽 = 𝜏 ⋅ 𝜂".
-    const BETA: i32 = Self::TAU * Self::ETA as i32;
+    const beta: i32 = Self::tau * Self::eta as i32;
 
     /// The length of the commitment hash 𝑐̃, which FIPS 204, Algorithm 26 (sigEncode) gives as
     /// 𝑐̃ ∈ 𝔹^(𝜆/4).
-    const C_TILDE_LEN: usize = Self::LAMBDA as usize / 4;
+    const C_TILDE_LEN: usize = Self::lambda as usize / 4;
 
     /// The packed length of one coordinate of 𝐳: FIPS 204, Algorithm 26 (sigEncode) writes each of
     /// the ℓ coordinates as 𝔹^(32⋅(1+bitlen (𝛾1−1))).
     ///
     /// This is also the number of bytes ExpandMask squeezes per coordinate: FIPS 204,
     /// Algorithm 34, line 1 sets 𝑐 ← 1 + bitlen (𝛾1 − 1) and line 4 squeezes 32𝑐 bytes.
-    const POLY_Z_PACKED_LEN: usize = 32 * (1 + bitlen(Self::GAMMA1 as u32 - 1));
+    const POLY_Z_PACKED_LEN: usize = 32 * (1 + bitlen(Self::gamma1 as u32 - 1));
+
+    /// The packed length of one coordinate of 𝐬1 or 𝐬2: FIPS 204, Algorithm 24 (skEncode), line 3
+    /// packs each with BitPack(𝐬1[𝑖], 𝜂, 𝜂), and Algorithm 17 (BitPack) outputs
+    /// 𝔹^(32⋅bitlen (𝑎+𝑏)), so 32⋅bitlen (2𝜂).
+    const POLY_ETA_PACKED_LEN: usize = 32 * bitlen(2 * Self::eta as u32);
 
     /// The packed length of one coordinate of 𝐰1: FIPS 204, Algorithm 28 (w1Encode) outputs
     /// 𝔹^(32𝑘⋅bitlen ((𝑞−1)/(2𝛾2)−1)) for all 𝑘 coordinates together.
-    const POLY_W1_PACKED_LEN: usize = 32 * bitlen(((q - 1) / (2 * Self::GAMMA2)) as u32 - 1);
+    const POLY_W1_PACKED_LEN: usize = 32 * bitlen(((q - 1) / (2 * Self::gamma2)) as u32 - 1);
 
     /// 𝛾1 − 𝛽, the rejection bound on ‖𝐳‖∞ (FIPS 204, Algorithm 7, line 23).
-    const GAMMA1_MINUS_BETA: i32 = Self::GAMMA1 - Self::BETA;
+    const gamma1_minus_beta: i32 = Self::gamma1 - Self::beta;
 
     /// 𝛾2 − 𝛽, the rejection bound on ‖𝐫0‖∞ (FIPS 204, Algorithm 7, line 23).
-    const GAMMA2_MINUS_BETA: i32 = Self::GAMMA2 - Self::BETA;
+    const gamma2_minus_beta: i32 = Self::gamma2 - Self::beta;
 
     /* Types whose size depends on the parameter set. */
 
@@ -143,15 +148,15 @@ impl MLDSAParamsInternalTrait for MLDSA65Params {}
 impl MLDSAParamsInternalTrait for MLDSA87Params {}
 
 impl MLDSAParams for MLDSA44Params {
-    const TAU: i32 = 39;
-    const LAMBDA: i32 = 128;
-    const GAMMA1: i32 = 1 << 17;
+    const tau: i32 = 39;
+    const lambda: i32 = 128;
+    const gamma1: i32 = 1 << 17;
     // mutants note: because 𝛾1 is applied by bit-shifting, the "- 1" ends up not mattering.
-    const GAMMA2: i32 = (q - 1) / 88;
+    const gamma2: i32 = (q - 1) / 88;
     const k: usize = 4;
     const l: usize = 4;
-    const ETA: usize = 2;
-    const OMEGA: i32 = 80;
+    const eta: usize = 2;
+    const omega: i32 = 80;
 
     const PK_LEN: usize = 1312;
     const SK_LEN: usize = 2560;
@@ -174,15 +179,15 @@ impl MLDSAParams for MLDSA44Params {
 }
 
 impl MLDSAParams for MLDSA65Params {
-    const TAU: i32 = 49;
-    const LAMBDA: i32 = 192;
-    const GAMMA1: i32 = 1 << 19;
+    const tau: i32 = 49;
+    const lambda: i32 = 192;
+    const gamma1: i32 = 1 << 19;
     // mutants note: because 𝛾1 is applied by bit-shifting, the "- 1" ends up not mattering.
-    const GAMMA2: i32 = (q - 1) / 32;
+    const gamma2: i32 = (q - 1) / 32;
     const k: usize = 6;
     const l: usize = 5;
-    const ETA: usize = 4;
-    const OMEGA: i32 = 55;
+    const eta: usize = 4;
+    const omega: i32 = 55;
 
     const PK_LEN: usize = 1952;
     const SK_LEN: usize = 4032;
@@ -205,15 +210,15 @@ impl MLDSAParams for MLDSA65Params {
 }
 
 impl MLDSAParams for MLDSA87Params {
-    const TAU: i32 = 60;
-    const LAMBDA: i32 = 256;
-    const GAMMA1: i32 = 1 << 19;
+    const tau: i32 = 60;
+    const lambda: i32 = 256;
+    const gamma1: i32 = 1 << 19;
     // mutants note: because 𝛾1 is applied by bit-shifting, the "- 1" ends up not mattering.
-    const GAMMA2: i32 = (q - 1) / 32;
+    const gamma2: i32 = (q - 1) / 32;
     const k: usize = 8;
     const l: usize = 7;
-    const ETA: usize = 2;
-    const OMEGA: i32 = 75;
+    const eta: usize = 2;
+    const omega: i32 = 75;
 
     const PK_LEN: usize = 2592;
     const SK_LEN: usize = 4896;
@@ -239,17 +244,17 @@ impl MLDSAParams for MLDSA87Params {
 ///
 /// The bit-packing routines have one layout per distinct 𝛾1, so they dispatch on these rather than
 /// on the parameter set. ML-DSA-65 and ML-DSA-87 share the second value.
-pub(crate) const GAMMA1_2_POW_17: i32 = MLDSA44Params::GAMMA1;
+pub(crate) const GAMMA1_2_POW_17: i32 = MLDSA44Params::gamma1;
 /// See [`GAMMA1_2_POW_17`].
-pub(crate) const GAMMA1_2_POW_19: i32 = MLDSA65Params::GAMMA1;
+pub(crate) const GAMMA1_2_POW_19: i32 = MLDSA65Params::gamma1;
 
 /// The two distinct values 𝛾2 takes across the three parameter sets (FIPS 204, Table 1).
 ///
 /// As with 𝛾1, the routines that depend on 𝛾2 have one form per distinct value rather than one per
 /// parameter set. ML-DSA-65 and ML-DSA-87 share the second value.
-pub(crate) const GAMMA2_Q_MINUS_1_OVER_88: i32 = MLDSA44Params::GAMMA2;
+pub(crate) const GAMMA2_Q_MINUS_1_OVER_88: i32 = MLDSA44Params::gamma2;
 /// See [`GAMMA2_Q_MINUS_1_OVER_88`].
-pub(crate) const GAMMA2_Q_MINUS_1_OVER_32: i32 = MLDSA65Params::GAMMA2;
+pub(crate) const GAMMA2_Q_MINUS_1_OVER_32: i32 = MLDSA65Params::gamma2;
 
 /// The weaker of two security strengths.
 ///
@@ -384,15 +389,15 @@ mod tests {
 
     fn check_table_1<P: MLDSAParams>(i: usize) {
         let (tau, lambda, gamma1, gamma2, k, l, eta, omega) = TABLE_1[i];
-        assert_eq!(P::TAU, tau, "{}: 𝜏", P::ALG_NAME);
-        assert_eq!(P::LAMBDA, lambda, "{}: 𝜆", P::ALG_NAME);
-        assert_eq!(P::GAMMA1, gamma1, "{}: 𝛾1", P::ALG_NAME);
-        assert_eq!(P::GAMMA2, gamma2, "{}: 𝛾2", P::ALG_NAME);
+        assert_eq!(P::tau, tau, "{}: 𝜏", P::ALG_NAME);
+        assert_eq!(P::lambda, lambda, "{}: 𝜆", P::ALG_NAME);
+        assert_eq!(P::gamma1, gamma1, "{}: 𝛾1", P::ALG_NAME);
+        assert_eq!(P::gamma2, gamma2, "{}: 𝛾2", P::ALG_NAME);
         assert_eq!(P::k, k, "{}: 𝑘", P::ALG_NAME);
         assert_eq!(P::l, l, "{}: ℓ", P::ALG_NAME);
-        assert_eq!(P::ETA, eta, "{}: 𝜂", P::ALG_NAME);
-        assert_eq!(P::OMEGA, omega, "{}: 𝜔", P::ALG_NAME);
-        assert_eq!(P::BETA, TABLE_1_BETA[i], "{}: 𝛽 = 𝜏 ⋅ 𝜂", P::ALG_NAME);
+        assert_eq!(P::eta, eta, "{}: 𝜂", P::ALG_NAME);
+        assert_eq!(P::omega, omega, "{}: 𝜔", P::ALG_NAME);
+        assert_eq!(P::beta, TABLE_1_BETA[i], "{}: 𝛽 = 𝜏 ⋅ 𝜂", P::ALG_NAME);
     }
 
     fn check_table_2<P: MLDSAParams>(i: usize) {
@@ -411,13 +416,13 @@ mod tests {
 
         // Algorithm 24 (skEncode): 𝑠𝑘 ∈ 𝔹^(32+32+64+32⋅((𝑘+ℓ)⋅bitlen (2𝜂)+𝑑𝑘)).
         let sk_len =
-            32 + 32 + 64 + 32 * ((P::k + P::l) * bitlen(2 * P::ETA as u32) + d as usize * P::k);
+            32 + 32 + 64 + 32 * ((P::k + P::l) * bitlen(2 * P::eta as u32) + d as usize * P::k);
         assert_eq!(P::SK_LEN, sk_len, "{}: Algorithm 24 output size", P::ALG_NAME);
 
         // Algorithm 26 (sigEncode): 𝜎 ∈ 𝔹^(𝜆/4+ℓ⋅32⋅(1+bitlen (𝛾1−1))+𝜔+𝑘).
-        let sig_len = P::LAMBDA as usize / 4
-            + P::l * 32 * (1 + bitlen(P::GAMMA1 as u32 - 1))
-            + P::OMEGA as usize
+        let sig_len = P::lambda as usize / 4
+            + P::l * 32 * (1 + bitlen(P::gamma1 as u32 - 1))
+            + P::omega as usize
             + P::k;
         assert_eq!(P::SIG_LEN, sig_len, "{}: Algorithm 26 output size", P::ALG_NAME);
     }
@@ -476,48 +481,6 @@ mod tests {
     }
 
     #[test]
-    fn test_derived_lengths_match_the_values_they_replaced() {
-        // These three were hand-written per parameter set before the derivations above existed.
-        // They are pinned here so that a change to a `bitlen` formula cannot silently move them.
-        assert_eq!(
-            [MLDSA44Params::C_TILDE_LEN, MLDSA65Params::C_TILDE_LEN, MLDSA87Params::C_TILDE_LEN],
-            [32, 48, 64]
-        );
-        assert_eq!(
-            [
-                MLDSA44Params::POLY_Z_PACKED_LEN,
-                MLDSA65Params::POLY_Z_PACKED_LEN,
-                MLDSA87Params::POLY_Z_PACKED_LEN
-            ],
-            [576, 640, 640]
-        );
-        assert_eq!(
-            [
-                MLDSA44Params::POLY_W1_PACKED_LEN,
-                MLDSA65Params::POLY_W1_PACKED_LEN,
-                MLDSA87Params::POLY_W1_PACKED_LEN
-            ],
-            [192, 128, 128]
-        );
-        assert_eq!(
-            [
-                MLDSA44Params::GAMMA1_MINUS_BETA,
-                MLDSA65Params::GAMMA1_MINUS_BETA,
-                MLDSA87Params::GAMMA1_MINUS_BETA
-            ],
-            [131072 - 78, 524288 - 196, 524288 - 120]
-        );
-        assert_eq!(
-            [
-                MLDSA44Params::GAMMA2_MINUS_BETA,
-                MLDSA65Params::GAMMA2_MINUS_BETA,
-                MLDSA87Params::GAMMA2_MINUS_BETA
-            ],
-            [(q - 1) / 88 - 78, (q - 1) / 32 - 196, (q - 1) / 32 - 120]
-        );
-    }
-
-    #[test]
     fn test_bitlen_matches_its_definition() {
         // FIPS 204 Section 2.3 defines bitlen 𝑥 as the length of the binary expansion of 𝑥.
         assert_eq!(bitlen(0), 0);
@@ -535,10 +498,10 @@ mod tests {
     fn test_gamma_dispatch_constants_cover_every_parameter_set() {
         // The packing routines dispatch on these; a parameter set whose 𝛾 is neither value would
         // fall through to a panic at runtime rather than fail to compile, so pin them here.
-        for gamma1 in [MLDSA44Params::GAMMA1, MLDSA65Params::GAMMA1, MLDSA87Params::GAMMA1] {
+        for gamma1 in [MLDSA44Params::gamma1, MLDSA65Params::gamma1, MLDSA87Params::gamma1] {
             assert!(gamma1 == GAMMA1_2_POW_17 || gamma1 == GAMMA1_2_POW_19);
         }
-        for gamma2 in [MLDSA44Params::GAMMA2, MLDSA65Params::GAMMA2, MLDSA87Params::GAMMA2] {
+        for gamma2 in [MLDSA44Params::gamma2, MLDSA65Params::gamma2, MLDSA87Params::gamma2] {
             assert!(gamma2 == GAMMA2_Q_MINUS_1_OVER_88 || gamma2 == GAMMA2_Q_MINUS_1_OVER_32);
         }
         assert_ne!(GAMMA1_2_POW_17, GAMMA1_2_POW_19);

--- a/crypto/mldsa/src/params.rs
+++ b/crypto/mldsa/src/params.rs
@@ -151,7 +151,7 @@ impl MLDSAParams for MLDSA44Params {
     const tau: i32 = 39;
     const lambda: i32 = 128;
     const gamma1: i32 = 1 << 17;
-    // mutants note: because 𝛾1 is applied by bit-shifting, the "- 1" ends up not mattering.
+    // mutants note: because of the bitshifting, the "- 1" ends up not mattering.
     const gamma2: i32 = (q - 1) / 88;
     const k: usize = 4;
     const l: usize = 4;
@@ -182,7 +182,7 @@ impl MLDSAParams for MLDSA65Params {
     const tau: i32 = 49;
     const lambda: i32 = 192;
     const gamma1: i32 = 1 << 19;
-    // mutants note: because 𝛾1 is applied by bit-shifting, the "- 1" ends up not mattering.
+    // mutants note: because of the bitshifting, the "- 1" ends up not mattering.
     const gamma2: i32 = (q - 1) / 32;
     const k: usize = 6;
     const l: usize = 5;
@@ -213,7 +213,7 @@ impl MLDSAParams for MLDSA87Params {
     const tau: i32 = 60;
     const lambda: i32 = 256;
     const gamma1: i32 = 1 << 19;
-    // mutants note: because 𝛾1 is applied by bit-shifting, the "- 1" ends up not mattering.
+    // mutants note: because of the bitshifting, the "- 1" ends up not mattering.
     const gamma2: i32 = (q - 1) / 32;
     const k: usize = 8;
     const l: usize = 7;

--- a/crypto/mldsa/src/params.rs
+++ b/crypto/mldsa/src/params.rs
@@ -1,0 +1,547 @@
+//! The three ML-DSA parameter sets of FIPS 204, Section 4, and the six HashML-DSA pairings built on
+//! them, each as a sealed trait with one type per set.
+//!
+//! # Derived parameters
+//!
+//! FIPS 204, Table 1 assigns eight independent values per set (𝜏, 𝜆, 𝛾1, 𝛾2, (𝑘, ℓ), 𝜂, 𝜔) plus the
+//! three sizes of Table 2. Everything else this implementation needs is a function of those, so it
+//! is written once as a defaulted associated const rather than three times as a hand-computed
+//! number. `params::tests` checks every derivation against the values tabulated in FIPS 204.
+
+use crate::hash_mldsa::{
+    HASH_ML_DSA_44_with_SHA256_NAME, HASH_ML_DSA_44_with_SHA512_NAME,
+    HASH_ML_DSA_65_WITH_SHA256_NAME, HASH_ML_DSA_65_WITH_SHA512_NAME,
+    HASH_ML_DSA_87_WITH_SHA512_NAME, HASH_ML_DSA_87_with_SHA256_NAME,
+};
+use crate::matrix::{Matrix, MatrixTrait, Vector, VectorTrait};
+use crate::mldsa::{ML_DSA_44_NAME, ML_DSA_65_NAME, ML_DSA_87_NAME, q};
+use bouncycastle_core::traits::{Algorithm, AlgorithmOID, Hash, HashAlgParams, SecurityStrength};
+use bouncycastle_sha2::{SHA256, SHA512};
+use bouncycastle_utils::secret::ZeroizablePrimitive;
+
+/// `bitlen 𝑥`, the length of the binary expansion of 𝑥 (FIPS 204, Section 2.3).
+///
+/// `bitlen 0` is 0; every use below has a positive argument.
+pub(crate) const fn bitlen(x: u32) -> usize {
+    if x == 0 { 0 } else { x.ilog2() as usize + 1 }
+}
+
+/// A fixed-size byte buffer whose length depends on the parameter set.
+///
+/// [`ZeroizablePrimitive`] rather than [`Default`] supplies the all-zero value, because `Default`
+/// for arrays stops at 32 elements and every buffer here is longer than that.
+trait ByteBuffer: ZeroizablePrimitive + AsRef<[u8]> + AsMut<[u8]> {}
+impl<const N: usize> ByteBuffer for [u8; N] {}
+
+/// A crate-private (aka "sealed") trait that prevents a new ML-DSA parameter set from being defined
+/// outside this crate.
+trait MLDSAParamsInternalTrait {}
+
+/// One ML-DSA parameter set: the values of FIPS 204, Table 1 and Table 2, and the types whose size
+/// they determine.
+///
+/// Sealed via a private supertrait, so [`MLDSA44Params`], [`MLDSA65Params`] and [`MLDSA87Params`]
+/// are the only implementations.
+pub trait MLDSAParams: MLDSAParamsInternalTrait {
+    /* FIPS 204, Table 1: the values assigned by each parameter set. */
+
+    /// 𝜏, the number of ±1's in the polynomial 𝑐.
+    const TAU: i32;
+    /// 𝜆, the collision strength of 𝑐̃, in bits.
+    const LAMBDA: i32;
+    /// 𝛾1, the coefficient range of 𝐲. Always a power of two.
+    const GAMMA1: i32;
+    /// 𝛾2, the low-order rounding range.
+    const GAMMA2: i32;
+    /// 𝑘, the number of rows of 𝐀.
+    const k: usize;
+    /// ℓ, the number of columns of 𝐀.
+    const l: usize;
+    /// 𝜂, the private key range.
+    const ETA: usize;
+    /// 𝜔, the maximum number of 1's in the hint 𝐡.
+    const OMEGA: i32;
+
+    /* FIPS 204, Table 2: sizes in bytes of keys and signatures. */
+
+    /// The length of an encoded public key.
+    const PK_LEN: usize;
+    /// The length of an encoded private key.
+    const SK_LEN: usize;
+    /// The length of a signature.
+    const SIG_LEN: usize;
+
+    /* Algorithm meta-data. */
+
+    /// The algorithm name, as reported by `Algorithm::ALG_NAME`.
+    const ALG_NAME: &'static str;
+    /// The strength claimed for this parameter set, as reported by `Algorithm::MAX_SECURITY_STRENGTH`.
+    const MAX_SECURITY_STRENGTH: SecurityStrength;
+    /// The OID in component form, as reported by `AlgorithmOID::OID`.
+    const OID: &'static [u32];
+    /// The DER encoding of [`MLDSAParams::OID`], as reported by `AlgorithmOID::OID_DER`.
+    const OID_DER: &'static [u8];
+
+    /* Derived. Never written out per parameter set -- see the module docs. */
+
+    /// 𝛽, which FIPS 204, Table 1 defines as "𝛽 = 𝜏 ⋅ 𝜂".
+    const BETA: i32 = Self::TAU * Self::ETA as i32;
+
+    /// The length of the commitment hash 𝑐̃, which FIPS 204, Algorithm 26 (sigEncode) gives as
+    /// 𝑐̃ ∈ 𝔹^(𝜆/4).
+    const C_TILDE_LEN: usize = Self::LAMBDA as usize / 4;
+
+    /// The packed length of one coordinate of 𝐳: FIPS 204, Algorithm 26 (sigEncode) writes each of
+    /// the ℓ coordinates as 𝔹^(32⋅(1+bitlen (𝛾1−1))).
+    ///
+    /// This is also the number of bytes ExpandMask squeezes per coordinate: FIPS 204,
+    /// Algorithm 34, line 1 sets 𝑐 ← 1 + bitlen (𝛾1 − 1) and line 4 squeezes 32𝑐 bytes.
+    const POLY_Z_PACKED_LEN: usize = 32 * (1 + bitlen(Self::GAMMA1 as u32 - 1));
+
+    /// The packed length of one coordinate of 𝐰1: FIPS 204, Algorithm 28 (w1Encode) outputs
+    /// 𝔹^(32𝑘⋅bitlen ((𝑞−1)/(2𝛾2)−1)) for all 𝑘 coordinates together.
+    const POLY_W1_PACKED_LEN: usize = 32 * bitlen(((q - 1) / (2 * Self::GAMMA2)) as u32 - 1);
+
+    /// 𝛾1 − 𝛽, the rejection bound on ‖𝐳‖∞ (FIPS 204, Algorithm 7, line 23).
+    const GAMMA1_MINUS_BETA: i32 = Self::GAMMA1 - Self::BETA;
+
+    /// 𝛾2 − 𝛽, the rejection bound on ‖𝐫0‖∞ (FIPS 204, Algorithm 7, line 23).
+    const GAMMA2_MINUS_BETA: i32 = Self::GAMMA2 - Self::BETA;
+
+    /* Types whose size depends on the parameter set. */
+
+    /// A vector of 𝑘 polynomials, i.e. an element of 𝑅^𝑘.
+    type VecK: VectorTrait;
+    /// A vector of ℓ polynomials, i.e. an element of 𝑅^ℓ.
+    type VecL: VectorTrait;
+    /// The 𝑘 × ℓ public matrix 𝐀̂.
+    type MatrixA: MatrixTrait<VecL = Self::VecL, VecK = Self::VecK>;
+
+    /// The commitment hash 𝑐̃, of [`MLDSAParams::C_TILDE_LEN`] bytes.
+    type SigCTilde: ByteBuffer;
+    /// One packed coordinate of 𝐳, of [`MLDSAParams::POLY_Z_PACKED_LEN`] bytes.
+    ///
+    /// ExpandMask squeezes into a buffer of this same length; see
+    /// [`MLDSAParams::POLY_Z_PACKED_LEN`].
+    type PolyZPacked: ByteBuffer;
+    /// One packed coordinate of 𝐰1, of [`MLDSAParams::POLY_W1_PACKED_LEN`] bytes.
+    type PolyW1Packed: ByteBuffer;
+}
+
+/// The ML-DSA-44 parameter set (FIPS 204, Table 1).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MLDSA44Params;
+/// The ML-DSA-65 parameter set (FIPS 204, Table 1).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MLDSA65Params;
+/// The ML-DSA-87 parameter set (FIPS 204, Table 1).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MLDSA87Params;
+
+impl MLDSAParamsInternalTrait for MLDSA44Params {}
+impl MLDSAParamsInternalTrait for MLDSA65Params {}
+impl MLDSAParamsInternalTrait for MLDSA87Params {}
+
+impl MLDSAParams for MLDSA44Params {
+    const TAU: i32 = 39;
+    const LAMBDA: i32 = 128;
+    const GAMMA1: i32 = 1 << 17;
+    // mutants note: because 𝛾1 is applied by bit-shifting, the "- 1" ends up not mattering.
+    const GAMMA2: i32 = (q - 1) / 88;
+    const k: usize = 4;
+    const l: usize = 4;
+    const ETA: usize = 2;
+    const OMEGA: i32 = 80;
+
+    const PK_LEN: usize = 1312;
+    const SK_LEN: usize = 2560;
+    const SIG_LEN: usize = 2420;
+
+    const ALG_NAME: &'static str = ML_DSA_44_NAME;
+    const MAX_SECURITY_STRENGTH: SecurityStrength = SecurityStrength::_128bit;
+    /// Assigned by NIST in the Computer Security Objects Register: id-ml-dsa-44 { sigAlgs 17 }
+    const OID: &'static [u32] = &[2, 16, 840, 1, 101, 3, 4, 3, 17];
+    const OID_DER: &'static [u8] =
+        &[0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x03, 0x11];
+
+    type VecK = Vector<4>;
+    type VecL = Vector<4>;
+    type MatrixA = Matrix<4, 4>;
+
+    type SigCTilde = [u8; 32]; // 𝜆/4 = 128/4
+    type PolyZPacked = [u8; 576]; // 32 * (1 + bitlen(2^17 - 1)) = 32 * 18
+    type PolyW1Packed = [u8; 192]; // 32 * bitlen(44 - 1) = 32 * 6
+}
+
+impl MLDSAParams for MLDSA65Params {
+    const TAU: i32 = 49;
+    const LAMBDA: i32 = 192;
+    const GAMMA1: i32 = 1 << 19;
+    // mutants note: because 𝛾1 is applied by bit-shifting, the "- 1" ends up not mattering.
+    const GAMMA2: i32 = (q - 1) / 32;
+    const k: usize = 6;
+    const l: usize = 5;
+    const ETA: usize = 4;
+    const OMEGA: i32 = 55;
+
+    const PK_LEN: usize = 1952;
+    const SK_LEN: usize = 4032;
+    const SIG_LEN: usize = 3309;
+
+    const ALG_NAME: &'static str = ML_DSA_65_NAME;
+    const MAX_SECURITY_STRENGTH: SecurityStrength = SecurityStrength::_192bit;
+    /// Assigned by NIST in the Computer Security Objects Register: id-ml-dsa-65 { sigAlgs 18 }
+    const OID: &'static [u32] = &[2, 16, 840, 1, 101, 3, 4, 3, 18];
+    const OID_DER: &'static [u8] =
+        &[0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x03, 0x12];
+
+    type VecK = Vector<6>;
+    type VecL = Vector<5>;
+    type MatrixA = Matrix<6, 5>;
+
+    type SigCTilde = [u8; 48]; // 𝜆/4 = 192/4
+    type PolyZPacked = [u8; 640]; // 32 * (1 + bitlen(2^19 - 1)) = 32 * 20
+    type PolyW1Packed = [u8; 128]; // 32 * bitlen(16 - 1) = 32 * 4
+}
+
+impl MLDSAParams for MLDSA87Params {
+    const TAU: i32 = 60;
+    const LAMBDA: i32 = 256;
+    const GAMMA1: i32 = 1 << 19;
+    // mutants note: because 𝛾1 is applied by bit-shifting, the "- 1" ends up not mattering.
+    const GAMMA2: i32 = (q - 1) / 32;
+    const k: usize = 8;
+    const l: usize = 7;
+    const ETA: usize = 2;
+    const OMEGA: i32 = 75;
+
+    const PK_LEN: usize = 2592;
+    const SK_LEN: usize = 4896;
+    const SIG_LEN: usize = 4627;
+
+    const ALG_NAME: &'static str = ML_DSA_87_NAME;
+    const MAX_SECURITY_STRENGTH: SecurityStrength = SecurityStrength::_256bit;
+    /// Assigned by NIST in the Computer Security Objects Register: id-ml-dsa-87 { sigAlgs 19 }
+    const OID: &'static [u32] = &[2, 16, 840, 1, 101, 3, 4, 3, 19];
+    const OID_DER: &'static [u8] =
+        &[0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x03, 0x13];
+
+    type VecK = Vector<8>;
+    type VecL = Vector<7>;
+    type MatrixA = Matrix<8, 7>;
+
+    type SigCTilde = [u8; 64]; // 𝜆/4 = 256/4
+    type PolyZPacked = [u8; 640]; // 32 * (1 + bitlen(2^19 - 1)) = 32 * 20
+    type PolyW1Packed = [u8; 128]; // 32 * bitlen(16 - 1) = 32 * 4
+}
+
+/// The two distinct values 𝛾1 takes across the three parameter sets (FIPS 204, Table 1).
+///
+/// The bit-packing routines have one layout per distinct 𝛾1, so they dispatch on these rather than
+/// on the parameter set. ML-DSA-65 and ML-DSA-87 share the second value.
+pub(crate) const GAMMA1_2_POW_17: i32 = MLDSA44Params::GAMMA1;
+/// See [`GAMMA1_2_POW_17`].
+pub(crate) const GAMMA1_2_POW_19: i32 = MLDSA65Params::GAMMA1;
+
+/// The two distinct values 𝛾2 takes across the three parameter sets (FIPS 204, Table 1).
+///
+/// As with 𝛾1, the routines that depend on 𝛾2 have one form per distinct value rather than one per
+/// parameter set. ML-DSA-65 and ML-DSA-87 share the second value.
+pub(crate) const GAMMA2_Q_MINUS_1_OVER_88: i32 = MLDSA44Params::GAMMA2;
+/// See [`GAMMA2_Q_MINUS_1_OVER_88`].
+pub(crate) const GAMMA2_Q_MINUS_1_OVER_32: i32 = MLDSA65Params::GAMMA2;
+
+/// The weaker of two security strengths.
+///
+/// [`SecurityStrength`]'s discriminants are assigned in increasing order of strength, so comparing
+/// them as integers orders them. A `const fn` because the strength of a HashML-DSA pairing is a
+/// defaulted associated const.
+const fn weaker_of(a: SecurityStrength, b: SecurityStrength) -> SecurityStrength {
+    if (a as u8) <= (b as u8) { a } else { b }
+}
+
+/// A crate-private (aka "sealed") trait that prevents a new HashML-DSA pairing from being defined
+/// outside this crate.
+trait HashMLDSAParamsInternalTrait {}
+
+/// One HashML-DSA algorithm: an ML-DSA parameter set paired with a pre-hash function.
+///
+/// FIPS 204, Algorithm 4 (HashML-DSA.Sign) leaves the choice of PH open, so an instantiation is a
+/// pairing rather than a single parameter set. Everything that varies across the pairings lives
+/// here, so [`crate::hash_mldsa::HashMLDSA`] takes one type rather than a parameter set plus a
+/// hash function plus a digest length.
+///
+/// Sealed via a private supertrait, so the six types below are the only implementations.
+pub trait HashMLDSAParams: HashMLDSAParamsInternalTrait {
+    /// The ML-DSA parameter set underneath.
+    type MLDSA: MLDSAParams;
+    /// PH, the pre-hash function.
+    type PreHash: Hash + HashAlgParams + AlgorithmOID + Default;
+
+    /// The algorithm name, as reported by `Algorithm::ALG_NAME`.
+    ///
+    /// Written out per pairing rather than derived: it is the two component names spliced
+    /// together, and `&'static str` cannot be concatenated in a const context.
+    const ALG_NAME: &'static str;
+
+    /* Derived. Never written out per pairing. */
+
+    /// The length of the pre-hash `ph`, which is just PH's output length.
+    const PH_LEN: usize = <Self::PreHash as HashAlgParams>::OUTPUT_LEN;
+
+    /// The strength claimed for the pairing, as reported by `Algorithm::MAX_SECURITY_STRENGTH`.
+    ///
+    /// A HashML-DSA signature is no stronger than either of its two components, so this is the
+    /// weaker of the two. That is what caps, for example, HashML-DSA-87_with_SHA256 at 128 bits.
+    const MAX_SECURITY_STRENGTH: SecurityStrength = weaker_of(
+        <Self::MLDSA as MLDSAParams>::MAX_SECURITY_STRENGTH,
+        <Self::PreHash as Algorithm>::MAX_SECURITY_STRENGTH,
+    );
+}
+
+/// The HashML-DSA-44_with_SHA256 pairing.
+#[allow(non_camel_case_types)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct HashMLDSA44_with_SHA256Params;
+/// The HashML-DSA-65_with_SHA256 pairing.
+#[allow(non_camel_case_types)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct HashMLDSA65_with_SHA256Params;
+/// The HashML-DSA-87_with_SHA256 pairing.
+#[allow(non_camel_case_types)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct HashMLDSA87_with_SHA256Params;
+/// The HashML-DSA-44_with_SHA512 pairing.
+#[allow(non_camel_case_types)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct HashMLDSA44_with_SHA512Params;
+/// The HashML-DSA-65_with_SHA512 pairing.
+#[allow(non_camel_case_types)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct HashMLDSA65_with_SHA512Params;
+/// The HashML-DSA-87_with_SHA512 pairing.
+#[allow(non_camel_case_types)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct HashMLDSA87_with_SHA512Params;
+
+impl HashMLDSAParamsInternalTrait for HashMLDSA44_with_SHA256Params {}
+impl HashMLDSAParamsInternalTrait for HashMLDSA65_with_SHA256Params {}
+impl HashMLDSAParamsInternalTrait for HashMLDSA87_with_SHA256Params {}
+impl HashMLDSAParamsInternalTrait for HashMLDSA44_with_SHA512Params {}
+impl HashMLDSAParamsInternalTrait for HashMLDSA65_with_SHA512Params {}
+impl HashMLDSAParamsInternalTrait for HashMLDSA87_with_SHA512Params {}
+
+impl HashMLDSAParams for HashMLDSA44_with_SHA256Params {
+    type MLDSA = MLDSA44Params;
+    type PreHash = SHA256;
+    const ALG_NAME: &'static str = HASH_ML_DSA_44_with_SHA256_NAME;
+}
+impl HashMLDSAParams for HashMLDSA65_with_SHA256Params {
+    type MLDSA = MLDSA65Params;
+    type PreHash = SHA256;
+    const ALG_NAME: &'static str = HASH_ML_DSA_65_WITH_SHA256_NAME;
+}
+impl HashMLDSAParams for HashMLDSA87_with_SHA256Params {
+    type MLDSA = MLDSA87Params;
+    type PreHash = SHA256;
+    const ALG_NAME: &'static str = HASH_ML_DSA_87_with_SHA256_NAME;
+}
+impl HashMLDSAParams for HashMLDSA44_with_SHA512Params {
+    type MLDSA = MLDSA44Params;
+    type PreHash = SHA512;
+    const ALG_NAME: &'static str = HASH_ML_DSA_44_with_SHA512_NAME;
+}
+impl HashMLDSAParams for HashMLDSA65_with_SHA512Params {
+    type MLDSA = MLDSA65Params;
+    type PreHash = SHA512;
+    const ALG_NAME: &'static str = HASH_ML_DSA_65_WITH_SHA512_NAME;
+}
+impl HashMLDSAParams for HashMLDSA87_with_SHA512Params {
+    type MLDSA = MLDSA87Params;
+    type PreHash = SHA512;
+    const ALG_NAME: &'static str = HASH_ML_DSA_87_WITH_SHA512_NAME;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::mldsa::d;
+
+    /// FIPS 204, Table 1, transcribed column by column: the eight values each parameter set
+    /// assigns. `(tau, lambda, gamma1, gamma2, k, l, eta, omega)`.
+    const TABLE_1: [(i32, i32, i32, i32, usize, usize, usize, i32); 3] = [
+        (39, 128, 131072, (q - 1) / 88, 4, 4, 2, 80),
+        (49, 192, 524288, (q - 1) / 32, 6, 5, 4, 55),
+        (60, 256, 524288, (q - 1) / 32, 8, 7, 2, 75),
+    ];
+
+    /// FIPS 204, Table 2, transcribed row by row: `(private key, public key, signature)` in bytes.
+    const TABLE_2: [(usize, usize, usize); 3] =
+        [(2560, 1312, 2420), (4032, 1952, 3309), (4896, 2592, 4627)];
+
+    /// FIPS 204, Table 1 also tabulates 𝛽, which it labels "𝛽 = 𝜏 ⋅ 𝜂".
+    const TABLE_1_BETA: [i32; 3] = [78, 196, 120];
+
+    fn check_table_1<P: MLDSAParams>(i: usize) {
+        let (tau, lambda, gamma1, gamma2, k, l, eta, omega) = TABLE_1[i];
+        assert_eq!(P::TAU, tau, "{}: 𝜏", P::ALG_NAME);
+        assert_eq!(P::LAMBDA, lambda, "{}: 𝜆", P::ALG_NAME);
+        assert_eq!(P::GAMMA1, gamma1, "{}: 𝛾1", P::ALG_NAME);
+        assert_eq!(P::GAMMA2, gamma2, "{}: 𝛾2", P::ALG_NAME);
+        assert_eq!(P::k, k, "{}: 𝑘", P::ALG_NAME);
+        assert_eq!(P::l, l, "{}: ℓ", P::ALG_NAME);
+        assert_eq!(P::ETA, eta, "{}: 𝜂", P::ALG_NAME);
+        assert_eq!(P::OMEGA, omega, "{}: 𝜔", P::ALG_NAME);
+        assert_eq!(P::BETA, TABLE_1_BETA[i], "{}: 𝛽 = 𝜏 ⋅ 𝜂", P::ALG_NAME);
+    }
+
+    fn check_table_2<P: MLDSAParams>(i: usize) {
+        let (sk_len, pk_len, sig_len) = TABLE_2[i];
+        assert_eq!(P::SK_LEN, sk_len, "{}: private key size", P::ALG_NAME);
+        assert_eq!(P::PK_LEN, pk_len, "{}: public key size", P::ALG_NAME);
+        assert_eq!(P::SIG_LEN, sig_len, "{}: signature size", P::ALG_NAME);
+    }
+
+    /// Each of the three sizes of Table 2 also has a formula in FIPS 204, and the two must agree.
+    /// Table 2 is what is written down above; this is what re-derives it.
+    fn check_table_2_formulas<P: MLDSAParams>() {
+        // Algorithm 22 (pkEncode): 𝑝𝑘 ∈ 𝔹^(32+32𝑘(bitlen (𝑞−1)−𝑑)).
+        let pk_len = 32 + 32 * P::k * (bitlen((q - 1) as u32) - d as usize);
+        assert_eq!(P::PK_LEN, pk_len, "{}: Algorithm 22 output size", P::ALG_NAME);
+
+        // Algorithm 24 (skEncode): 𝑠𝑘 ∈ 𝔹^(32+32+64+32⋅((𝑘+ℓ)⋅bitlen (2𝜂)+𝑑𝑘)).
+        let sk_len =
+            32 + 32 + 64 + 32 * ((P::k + P::l) * bitlen(2 * P::ETA as u32) + d as usize * P::k);
+        assert_eq!(P::SK_LEN, sk_len, "{}: Algorithm 24 output size", P::ALG_NAME);
+
+        // Algorithm 26 (sigEncode): 𝜎 ∈ 𝔹^(𝜆/4+ℓ⋅32⋅(1+bitlen (𝛾1−1))+𝜔+𝑘).
+        let sig_len = P::LAMBDA as usize / 4
+            + P::l * 32 * (1 + bitlen(P::GAMMA1 as u32 - 1))
+            + P::OMEGA as usize
+            + P::k;
+        assert_eq!(P::SIG_LEN, sig_len, "{}: Algorithm 26 output size", P::ALG_NAME);
+    }
+
+    /// The associated types must be exactly as long as the consts that describe them; they are
+    /// written out by hand per parameter set, so this guards against a typo in one of them.
+    fn check_associated_type_sizes<P: MLDSAParams>() {
+        assert_eq!(
+            size_of::<P::SigCTilde>(),
+            P::C_TILDE_LEN,
+            "{}: SigCTilde vs C_TILDE_LEN",
+            P::ALG_NAME
+        );
+        assert_eq!(
+            size_of::<P::PolyZPacked>(),
+            P::POLY_Z_PACKED_LEN,
+            "{}: PolyZPacked vs POLY_Z_PACKED_LEN",
+            P::ALG_NAME
+        );
+        assert_eq!(
+            size_of::<P::PolyW1Packed>(),
+            P::POLY_W1_PACKED_LEN,
+            "{}: PolyW1Packed vs POLY_W1_PACKED_LEN",
+            P::ALG_NAME
+        );
+        assert_eq!(<P::VecK as VectorTrait>::LEN, P::k, "{}: VecK vs 𝑘", P::ALG_NAME);
+        assert_eq!(<P::VecL as VectorTrait>::LEN, P::l, "{}: VecL vs ℓ", P::ALG_NAME);
+    }
+
+    #[test]
+    fn test_parameter_sets_match_fips204_table_1() {
+        check_table_1::<MLDSA44Params>(0);
+        check_table_1::<MLDSA65Params>(1);
+        check_table_1::<MLDSA87Params>(2);
+    }
+
+    #[test]
+    fn test_sizes_match_fips204_table_2() {
+        check_table_2::<MLDSA44Params>(0);
+        check_table_2::<MLDSA65Params>(1);
+        check_table_2::<MLDSA87Params>(2);
+    }
+
+    #[test]
+    fn test_table_2_sizes_agree_with_the_encoding_formulas() {
+        check_table_2_formulas::<MLDSA44Params>();
+        check_table_2_formulas::<MLDSA65Params>();
+        check_table_2_formulas::<MLDSA87Params>();
+    }
+
+    #[test]
+    fn test_associated_types_are_the_length_their_consts_claim() {
+        check_associated_type_sizes::<MLDSA44Params>();
+        check_associated_type_sizes::<MLDSA65Params>();
+        check_associated_type_sizes::<MLDSA87Params>();
+    }
+
+    #[test]
+    fn test_derived_lengths_match_the_values_they_replaced() {
+        // These three were hand-written per parameter set before the derivations above existed.
+        // They are pinned here so that a change to a `bitlen` formula cannot silently move them.
+        assert_eq!(
+            [MLDSA44Params::C_TILDE_LEN, MLDSA65Params::C_TILDE_LEN, MLDSA87Params::C_TILDE_LEN],
+            [32, 48, 64]
+        );
+        assert_eq!(
+            [
+                MLDSA44Params::POLY_Z_PACKED_LEN,
+                MLDSA65Params::POLY_Z_PACKED_LEN,
+                MLDSA87Params::POLY_Z_PACKED_LEN
+            ],
+            [576, 640, 640]
+        );
+        assert_eq!(
+            [
+                MLDSA44Params::POLY_W1_PACKED_LEN,
+                MLDSA65Params::POLY_W1_PACKED_LEN,
+                MLDSA87Params::POLY_W1_PACKED_LEN
+            ],
+            [192, 128, 128]
+        );
+        assert_eq!(
+            [
+                MLDSA44Params::GAMMA1_MINUS_BETA,
+                MLDSA65Params::GAMMA1_MINUS_BETA,
+                MLDSA87Params::GAMMA1_MINUS_BETA
+            ],
+            [131072 - 78, 524288 - 196, 524288 - 120]
+        );
+        assert_eq!(
+            [
+                MLDSA44Params::GAMMA2_MINUS_BETA,
+                MLDSA65Params::GAMMA2_MINUS_BETA,
+                MLDSA87Params::GAMMA2_MINUS_BETA
+            ],
+            [(q - 1) / 88 - 78, (q - 1) / 32 - 196, (q - 1) / 32 - 120]
+        );
+    }
+
+    #[test]
+    fn test_bitlen_matches_its_definition() {
+        // FIPS 204 Section 2.3 defines bitlen 𝑥 as the length of the binary expansion of 𝑥.
+        assert_eq!(bitlen(0), 0);
+        assert_eq!(bitlen(1), 1);
+        assert_eq!(bitlen(2), 2);
+        assert_eq!(bitlen(3), 2);
+        assert_eq!(bitlen(4), 3);
+        // The two arguments the derivations above actually use, plus bitlen(𝑞 − 1) = 23.
+        assert_eq!(bitlen((1 << 17) - 1), 17);
+        assert_eq!(bitlen((1 << 19) - 1), 19);
+        assert_eq!(bitlen((q - 1) as u32), 23);
+    }
+
+    #[test]
+    fn test_gamma_dispatch_constants_cover_every_parameter_set() {
+        // The packing routines dispatch on these; a parameter set whose 𝛾 is neither value would
+        // fall through to a panic at runtime rather than fail to compile, so pin them here.
+        for gamma1 in [MLDSA44Params::GAMMA1, MLDSA65Params::GAMMA1, MLDSA87Params::GAMMA1] {
+            assert!(gamma1 == GAMMA1_2_POW_17 || gamma1 == GAMMA1_2_POW_19);
+        }
+        for gamma2 in [MLDSA44Params::GAMMA2, MLDSA65Params::GAMMA2, MLDSA87Params::GAMMA2] {
+            assert!(gamma2 == GAMMA2_Q_MINUS_1_OVER_88 || gamma2 == GAMMA2_Q_MINUS_1_OVER_32);
+        }
+        assert_ne!(GAMMA1_2_POW_17, GAMMA1_2_POW_19);
+        assert_ne!(GAMMA2_Q_MINUS_1_OVER_88, GAMMA2_Q_MINUS_1_OVER_32);
+    }
+}

--- a/crypto/mldsa/src/polynomial.rs
+++ b/crypto/mldsa/src/polynomial.rs
@@ -153,7 +153,7 @@ impl Polynomial {
         let mut out = <P::PolyW1Packed as ZeroizablePrimitive>::ZEROED;
         let r = out.as_mut();
 
-        match P::GAMMA2 {
+        match P::gamma2 {
             // ML-DSA-44: (𝑞 − 1)/(2𝛾2) − 1 = 43, so four 6-bit coefficients pack into three bytes.
             GAMMA2_Q_MINUS_1_OVER_88 => {
                 for i in 0..N / 4 {

--- a/crypto/mldsa/src/polynomial.rs
+++ b/crypto/mldsa/src/polynomial.rs
@@ -3,7 +3,9 @@
 use crate::aux_functions::{
     ZETAS, conditional_add_q, high_bits, low_bits, make_hint, montgomery_reduce,
 };
-use crate::mldsa::{MLDSA44_POLY_W1_PACKED_LEN, MLDSA65_POLY_W1_PACKED_LEN, N, q};
+use crate::mldsa::{N, d, q};
+use crate::params::{GAMMA2_Q_MINUS_1_OVER_32, GAMMA2_Q_MINUS_1_OVER_88, MLDSAParams};
+use bouncycastle_utils::secret::ZeroizablePrimitive;
 use core::ops::{Index, IndexMut};
 
 /// A polynomial over the ML-DSA ring.
@@ -12,8 +14,11 @@ use core::ops::{Index, IndexMut};
 /// Polynomials themselves are not inherently secret since sometimes they are part of public keys
 /// and sometimes private keys.
 /// It is the responsibility of the caller to wrap sensitive instances in `Secret<Polynomial>`.
+///
+/// Public only because it appears in [`crate::VectorTrait`]'s signatures; its fields and
+/// operations are crate-private, so from outside it is an opaque handle.
 #[derive(Clone, Copy)]
-pub(crate) struct Polynomial {
+pub struct Polynomial {
     pub(crate) coeffs: [i32; N],
 }
 
@@ -34,7 +39,7 @@ impl IndexMut<usize> for Polynomial {
 
 impl Polynomial {
     /// Create a new polynomial with all coefficients set to zero.
-    pub const fn new() -> Self {
+    pub(crate) const fn new() -> Self {
         Self { coeffs: [0i32; N] }
     }
 
@@ -65,25 +70,31 @@ impl Polynomial {
         }
     }
 
-    pub(crate) fn high_bits<const GAMMA2: i32>(&self) -> Self {
+    pub(crate) fn high_bits<P: MLDSAParams>(&self) -> Self {
         let mut w = Self::new();
         for i in 0..N {
-            w[i] = high_bits::<GAMMA2>(self[i]);
+            w[i] = high_bits::<P>(self[i]);
         }
 
         w
     }
 
-    pub(crate) fn low_bits<const GAMMA2: i32>(&self) -> Self {
+    pub(crate) fn low_bits<P: MLDSAParams>(&self) -> Self {
         let mut w = Self::new();
         for i in 0..N {
-            w[i] = low_bits::<GAMMA2>(self[i]);
+            w[i] = low_bits::<P>(self[i]);
         }
 
         w
     }
 
-    pub(crate) fn check_norm<const BOUND: i32>(&self) -> bool {
+    /// Tests whether any coefficient has absolute value at least `bound`.
+    ///
+    /// `bound` is a runtime argument rather than a const generic because every call site passes a
+    /// value derived from the parameter set (𝛾1 − 𝛽, 𝛾2 − 𝛽, or 𝛾2), and an associated const of a
+    /// type parameter cannot be used as a const generic argument. It is still a constant after
+    /// monomorphization, so this costs nothing.
+    pub(crate) fn check_norm(&self, bound: i32) -> bool {
         // It is acceptable that this function is not constant-time (returns true early)
         // The reason being because it is used in a rejection loop.
         // That is, the early quit here leads to rejection, dropping the secret values and
@@ -95,33 +106,38 @@ impl Polynomial {
         //  if bound > (q - 1) / 8 {
         //     return true;
         //  }
-        // but since BOUND is a constant here, a debug_assert is performed to make sure the value is what we expect.
-        debug_assert!(BOUND <= (q - 1) / 8);
+        // but since every caller passes a parameter-set constant, a debug_assert is performed
+        // instead to make sure the value is what we expect.
+        debug_assert!(bound <= (q - 1) / 8);
 
         let mut t: i32;
         for x in self.coeffs.iter() {
             t = *x >> 31;
             t = *x - (t & (2 * *x));
 
-            if t >= BOUND {
+            if t >= bound {
                 return true;
             }
         }
         false
     }
 
-    pub(crate) fn shift_left<const d: i32>(&mut self) {
+    /// Multiplies every coefficient by 2^𝑑.
+    ///
+    /// 𝑑 is 13 for all three parameter sets (FIPS 204, Table 1), so it is read from the global
+    /// constant rather than being passed in.
+    pub(crate) fn shift_left_d(&mut self) {
         for x in self.coeffs.iter_mut() {
             *x <<= d;
         }
     }
 
     /// Creates the hint vector, and also returns its hamming weight (i.e. the number of 1's).
-    pub(crate) fn make_hint<const GAMMA2: i32>(&self, r: &Self) -> (Self, i32) {
+    pub(crate) fn make_hint<P: MLDSAParams>(&self, r: &Self) -> (Self, i32) {
         let mut out = Polynomial::new();
         let mut count = 0i32;
         for i in 0..N {
-            let x = make_hint::<GAMMA2>(self[i], r[i]);
+            let x = make_hint::<P>(self[i], r[i]);
             out[i] = x;
 
             // mutants note: this chains up to hint_hamming_weight > OMEGA and there is no test KAT that triggers this branch
@@ -131,19 +147,24 @@ impl Polynomial {
         (out, count)
     }
 
-    pub(crate) fn w1_encode<const POLY_W1_PACKED_LEN: usize>(&self) -> [u8; POLY_W1_PACKED_LEN] {
-        let mut r = [0u8; POLY_W1_PACKED_LEN];
+    /// SimpleBitPack(𝐰1[𝑖], (𝑞 − 1)/(2𝛾2) − 1), the per-coordinate body of
+    /// FIPS 204, Algorithm 28 (w1Encode), line 3.
+    pub(crate) fn w1_encode<P: MLDSAParams>(&self) -> P::PolyW1Packed {
+        let mut out = <P::PolyW1Packed as ZeroizablePrimitive>::ZEROED;
+        let r = out.as_mut();
 
-        match POLY_W1_PACKED_LEN {
-            MLDSA44_POLY_W1_PACKED_LEN => {
+        match P::GAMMA2 {
+            // ML-DSA-44: (𝑞 − 1)/(2𝛾2) − 1 = 43, so four 6-bit coefficients pack into three bytes.
+            GAMMA2_Q_MINUS_1_OVER_88 => {
                 for i in 0..N / 4 {
                     r[3 * i] = ((self[4 * i]) as u8) | ((self[4 * i + 1] << 6) as u8);
                     r[3 * i + 1] = ((self[4 * i + 1] >> 2) as u8) | ((self[4 * i + 2] << 4) as u8);
                     r[3 * i + 2] = ((self[4 * i + 2] >> 4) as u8) | ((self[4 * i + 3] << 2) as u8);
                 }
             }
-            // ML-DSA65 and 87 share a POLY_W1_PACKED_LEN value
-            MLDSA65_POLY_W1_PACKED_LEN => {
+            // ML-DSA-65 and ML-DSA-87 share this 𝛾2: (𝑞 − 1)/(2𝛾2) − 1 = 15, so two 4-bit
+            // coefficients pack into one byte.
+            GAMMA2_Q_MINUS_1_OVER_32 => {
                 for i in 0..N / 2 {
                     r[i] = ((self[2 * i]) | (self[2 * i + 1] << 4)) as u8;
                 }
@@ -153,7 +174,7 @@ impl Polynomial {
             }
         }
 
-        r
+        out
     }
 
     /// Algorithm 41 NTT(𝑤)

--- a/crypto/mldsa/tests/hash_mldsa_tests.rs
+++ b/crypto/mldsa/tests/hash_mldsa_tests.rs
@@ -3,7 +3,7 @@ mod hash_mldsa_tests {
     use bouncycastle_core::errors::SignatureError;
     use bouncycastle_core::key_material::{KeyMaterial256, KeyType};
     use bouncycastle_core::traits::{
-        Hash, PHSignatureVerifier, PHSigner, SignatureVerifier, Signer,
+        Hash, PHSignatureVerifier, PHSigner, SecurityStrength, SignatureVerifier, Signer,
     };
     use bouncycastle_core_test_framework::signature::TestFrameworkSignature;
     use bouncycastle_hex as hex;
@@ -364,5 +364,74 @@ mod hash_mldsa_tests {
 
         let pk_expanded = MLDSA44PublicKeyExpanded::from(&pk);
         HashMLDSA44_with_SHA256::verify_with_expanded_key(&pk_expanded, msg, None, &sig).unwrap();
+    }
+
+    #[test]
+    fn algorithm_names_strengths_and_oids() {
+        use bouncycastle_core::traits::{Algorithm, AlgorithmOID};
+
+        // `Algorithm` is implemented once, generically over the pairing, so nothing else states
+        // these per algorithm. Pinned here so a wrong wiring of the blanket impl, or a typo in a
+        // pairing, is a test failure rather than a mislabelled algorithm.
+        assert_eq!(HashMLDSA44_with_SHA256::ALG_NAME, "HashML-DSA-44_with_SHA256");
+        assert_eq!(HashMLDSA65_with_SHA256::ALG_NAME, "HashML-DSA-65_with_SHA256");
+        assert_eq!(HashMLDSA87_with_SHA256::ALG_NAME, "HashML-DSA-87_with_SHA256");
+        assert_eq!(HashMLDSA44_with_SHA512::ALG_NAME, "HashML-DSA-44_with_SHA512");
+        assert_eq!(HashMLDSA65_with_SHA512::ALG_NAME, "HashML-DSA-65_with_SHA512");
+        assert_eq!(HashMLDSA87_with_SHA512::ALG_NAME, "HashML-DSA-87_with_SHA512");
+
+        // The claimed strength is derived as the weaker of the two components, so these pin the
+        // derivation rather than six hand-written values. SHA-256 caps every pairing it appears in
+        // at 128 bits; with SHA-512 the ML-DSA parameter set is what binds.
+        assert_eq!(HashMLDSA44_with_SHA256::MAX_SECURITY_STRENGTH, SecurityStrength::_128bit);
+        assert_eq!(HashMLDSA65_with_SHA256::MAX_SECURITY_STRENGTH, SecurityStrength::_128bit);
+        assert_eq!(HashMLDSA87_with_SHA256::MAX_SECURITY_STRENGTH, SecurityStrength::_128bit);
+        assert_eq!(HashMLDSA44_with_SHA512::MAX_SECURITY_STRENGTH, SecurityStrength::_128bit);
+        assert_eq!(HashMLDSA65_with_SHA512::MAX_SECURITY_STRENGTH, SecurityStrength::_192bit);
+        assert_eq!(HashMLDSA87_with_SHA512::MAX_SECURITY_STRENGTH, SecurityStrength::_256bit);
+
+        // NIST's Computer Security Objects Register: id-hash-ml-dsa-44-with-sha512 { sigAlgs 32 },
+        // -65- { sigAlgs 33 }, -87- { sigAlgs 34 }. The three SHA-256 pairings carry no OID in
+        // this implementation, which is why `AlgorithmOID` is still written out per alias rather
+        // than derived from the pairing like the name and strength above.
+        assert_eq!(HashMLDSA44_with_SHA512::OID, &[2, 16, 840, 1, 101, 3, 4, 3, 32]);
+        assert_eq!(HashMLDSA65_with_SHA512::OID, &[2, 16, 840, 1, 101, 3, 4, 3, 33]);
+        assert_eq!(HashMLDSA87_with_SHA512::OID, &[2, 16, 840, 1, 101, 3, 4, 3, 34]);
+
+        for (oid, der) in [
+            (HashMLDSA44_with_SHA512::OID, HashMLDSA44_with_SHA512::OID_DER),
+            (HashMLDSA65_with_SHA512::OID, HashMLDSA65_with_SHA512::OID_DER),
+            (HashMLDSA87_with_SHA512::OID, HashMLDSA87_with_SHA512::OID_DER),
+        ] {
+            assert_eq!(der[0], 0x06, "DER tag must be OBJECT IDENTIFIER");
+            assert_eq!(der[1] as usize, der.len() - 2, "DER length must match the content");
+            assert_eq!(
+                &der[2..],
+                &[0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x03, *oid.last().unwrap() as u8]
+            );
+        }
+    }
+
+    #[test]
+    fn prehash_lengths_match_the_hash_functions() {
+        // `PH_LEN` is still a const generic on `HashMLDSA` -- `PHSigner` takes it as one -- but it
+        // is derived on the pairing from the pre-hash's own `OUTPUT_LEN`, and the two are checked
+        // against each other at build time. This confirms both agree with the actual digest.
+        assert_eq!(SHA256::new().hash(b"").len(), 32);
+        assert_eq!(SHA512::new().hash(b"").len(), 64);
+
+        // A signature is produced from a `ph` of exactly that length, so a mismatch would fail
+        // here rather than silently truncating.
+        let msg = b"The quick brown fox";
+        let ph256: [u8; 32] = SHA256::new().hash(msg).try_into().unwrap();
+        let ph512: [u8; 64] = SHA512::new().hash(msg).try_into().unwrap();
+
+        let (pk, sk) = HashMLDSA65_with_SHA256::keygen().unwrap();
+        let sig = HashMLDSA65_with_SHA256::sign_ph(&sk, &ph256, None).unwrap();
+        HashMLDSA65_with_SHA256::verify_ph(&pk, &ph256, None, &sig).unwrap();
+
+        let (pk, sk) = HashMLDSA65_with_SHA512::keygen().unwrap();
+        let sig = HashMLDSA65_with_SHA512::sign_ph(&sk, &ph512, None).unwrap();
+        HashMLDSA65_with_SHA512::verify_ph(&pk, &ph512, None, &sig).unwrap();
     }
 }

--- a/crypto/mldsa/tests/hash_mldsa_tests.rs
+++ b/crypto/mldsa/tests/hash_mldsa_tests.rs
@@ -414,9 +414,11 @@ mod hash_mldsa_tests {
 
     #[test]
     fn prehash_lengths_match_the_hash_functions() {
-        // `PH_LEN` is still a const generic on `HashMLDSA` -- `PHSigner` takes it as one -- but it
-        // is derived on the pairing from the pre-hash's own `OUTPUT_LEN`, and the two are checked
-        // against each other at build time. This confirms both agree with the actual digest.
+        // `PH_LEN` is still a const generic on `HashMLDSA` -- `PHSigner` takes it as one -- but
+        // no alias hard-codes it: each passes `{ ...Params::PH_LEN }`, which is the pre-hash's own
+        // `HashAlgParams::OUTPUT_LEN`. So there is only one value, and nothing in the chain can
+        // disagree with itself. What is left to check is whether that value matches the digest
+        // the hash actually produces, which is what this test does.
         assert_eq!(SHA256::new().hash(b"").len(), 32);
         assert_eq!(SHA512::new().hash(b"").len(), 64);
 

--- a/crypto/mldsa/tests/mldsa_tests.rs
+++ b/crypto/mldsa/tests/mldsa_tests.rs
@@ -1071,6 +1071,46 @@ mod mldsa_tests {
             _ => panic!("Expected an error when loading a SHAKE128 state into a MuBuilder"),
         }
     }
+
+    #[test]
+    fn algorithm_names_and_oids() {
+        use bouncycastle_core::traits::{Algorithm, AlgorithmOID};
+
+        // `Algorithm` and `AlgorithmOID` are implemented once, generically over the parameter set,
+        // so nothing else states these per algorithm. Pinned here so that a wrong wiring of the
+        // blanket impls, or a typo in a parameter set, is a test failure rather than a silently
+        // mislabelled algorithm or an unparseable OID.
+        assert_eq!(MLDSA44::ALG_NAME, "ML-DSA-44");
+        assert_eq!(MLDSA65::ALG_NAME, "ML-DSA-65");
+        assert_eq!(MLDSA87::ALG_NAME, "ML-DSA-87");
+
+        assert_eq!(MLDSA44::MAX_SECURITY_STRENGTH, SecurityStrength::_128bit);
+        assert_eq!(MLDSA65::MAX_SECURITY_STRENGTH, SecurityStrength::_192bit);
+        assert_eq!(MLDSA87::MAX_SECURITY_STRENGTH, SecurityStrength::_256bit);
+
+        // NIST's Computer Security Objects Register: id-ml-dsa-44 { sigAlgs 17 },
+        // id-ml-dsa-65 { sigAlgs 18 }, id-ml-dsa-87 { sigAlgs 19 }, under
+        // joint-iso-itu-t(2) country(16) us(840) organization(1) gov(101) csor(3) nistAlgorithm(4)
+        // sigAlgs(3).
+        assert_eq!(MLDSA44::OID, &[2, 16, 840, 1, 101, 3, 4, 3, 17]);
+        assert_eq!(MLDSA65::OID, &[2, 16, 840, 1, 101, 3, 4, 3, 18]);
+        assert_eq!(MLDSA87::OID, &[2, 16, 840, 1, 101, 3, 4, 3, 19]);
+
+        // The DER encodings must be the OBJECT IDENTIFIER (tag 0x06) encodings of those arcs:
+        // 9 content bytes, the first being 40*2 + 16 = 0x60, then 840 as the two-byte 0x86 0x48.
+        for (oid, der) in [
+            (MLDSA44::OID, MLDSA44::OID_DER),
+            (MLDSA65::OID, MLDSA65::OID_DER),
+            (MLDSA87::OID, MLDSA87::OID_DER),
+        ] {
+            assert_eq!(der[0], 0x06, "DER tag must be OBJECT IDENTIFIER");
+            assert_eq!(der[1] as usize, der.len() - 2, "DER length must match the content");
+            assert_eq!(
+                &der[2..],
+                &[0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x03, *oid.last().unwrap() as u8]
+            );
+        }
+    }
 }
 
 struct Kat {

--- a/crypto/mlkem-lowmemory/src/aux_functions.rs
+++ b/crypto/mlkem-lowmemory/src/aux_functions.rs
@@ -146,7 +146,7 @@ pub(crate) fn sample_ntt(rho: &[u8; 32], nonce: &[u8; 2]) -> Polynomial {
 /// Takes a seed as input and outputs a pseudorandom sample from the distribution D𝜂(𝑅𝑞).
 /// Input: byte array 𝐵 ∈ 𝔹64𝜂 .
 /// Output: array 𝑓 ∈ ℤ256  ▷ the coefficients of the sampled polynomial
-pub(crate) fn sample_poly_cbd<const eta: i16>(bytes: &[u8]) -> Polynomial {
+pub(crate) fn sample_poly_cbd(bytes: &[u8], eta: i16) -> Polynomial {
     debug_assert_eq!(bytes.len(), 64 * eta as usize);
 
     let mut f = Polynomial::new();
@@ -193,7 +193,7 @@ pub(crate) fn sample_poly_cbd<const eta: i16>(bytes: &[u8]) -> Polynomial {
 
 /// SamplePolyCBD𝜂1(PRF𝜂1 (𝜎, 𝑁 ))
 /// Performs both the PRF and SamplePolyCBD steps
-pub(crate) fn sample_poly_CBD<const eta: i16>(b: &[u8; 32], n: u8) -> Polynomial {
+pub(crate) fn sample_poly_CBD(b: &[u8; 32], n: u8, eta: i16) -> Polynomial {
     // Alg 13: 9: 𝐬[𝑖] ← SamplePolyCBD𝜂1(PRF𝜂1 (𝜎, 𝑁 ))
     //  ▷ 𝐬[𝑖] ∈ ℤ256 sampled from CBD
     match eta {
@@ -208,7 +208,7 @@ pub(crate) fn sample_poly_CBD<const eta: i16>(b: &[u8; 32], n: u8) -> Polynomial
                 buf
             };
 
-            sample_poly_cbd::<eta>(&buf)
+            sample_poly_cbd(&buf, eta)
         }
         3 => {
             let buf = {
@@ -220,7 +220,7 @@ pub(crate) fn sample_poly_CBD<const eta: i16>(b: &[u8; 32], n: u8) -> Polynomial
                 buf
             };
 
-            sample_poly_cbd::<eta>(&buf)
+            sample_poly_cbd(&buf, eta)
         }
         _ => unreachable!(),
     }

--- a/crypto/mlkem-lowmemory/src/lib.rs
+++ b/crypto/mlkem-lowmemory/src/lib.rs
@@ -244,6 +244,7 @@ mod aux_functions;
 mod low_memory_helpers;
 pub mod mlkem;
 mod mlkem_keys;
+mod params;
 mod polynomial;
 
 /*** Exported types ***/
@@ -264,3 +265,6 @@ pub use mlkem::{MLKEM_RND_LEN, MLKEM_SEED_LEN, MLKEM_SS_LEN};
 pub use mlkem::{MLKEM512_CT_LEN, MLKEM512_PK_LEN, MLKEM512_SK_LEN};
 pub use mlkem::{MLKEM768_CT_LEN, MLKEM768_PK_LEN, MLKEM768_SK_LEN};
 pub use mlkem::{MLKEM1024_CT_LEN, MLKEM1024_PK_LEN, MLKEM1024_SK_LEN};
+
+/*** Parameter sets ***/
+pub use params::{MLKEM512Params, MLKEM768Params, MLKEM1024Params};

--- a/crypto/mlkem-lowmemory/src/lib.rs
+++ b/crypto/mlkem-lowmemory/src/lib.rs
@@ -267,4 +267,3 @@ pub use mlkem::{MLKEM768_CT_LEN, MLKEM768_PK_LEN, MLKEM768_SK_LEN};
 pub use mlkem::{MLKEM1024_CT_LEN, MLKEM1024_PK_LEN, MLKEM1024_SK_LEN};
 
 /*** Parameter sets ***/
-pub use params::{MLKEM512Params, MLKEM768Params, MLKEM1024Params};

--- a/crypto/mlkem-lowmemory/src/low_memory_helpers.rs
+++ b/crypto/mlkem-lowmemory/src/low_memory_helpers.rs
@@ -4,6 +4,7 @@
 
 use crate::aux_functions::{byte_decode, byte_encode, sample_ntt, sample_poly_CBD};
 use crate::mlkem::{N, POLY_BYTES, q};
+use crate::params::MLKEMParams;
 use crate::polynomial::Polynomial;
 
 /// Computes the element [i,j] of the A_hat public matrix
@@ -13,23 +14,23 @@ pub(crate) fn expandA_elem(rho: &[u8; 32], i: usize, j: usize) -> Polynomial {
 
 /// Computes a single row of the core keygen operation
 /// Alg 13: line 18: 𝐀_hat ∘ 𝐬_hat
-pub(crate) fn compute_A_hat_dot_s_hat<const k: usize, const eta1: i16>(
+pub(crate) fn compute_A_hat_dot_s_hat<P: MLKEMParams>(
     rho: &[u8; 32],
     sigma: &[u8; 32],
     row: usize,
 ) -> Polynomial {
     let mut t_hat_i: Polynomial = {
         let mut A_i0 = expandA_elem(rho, row, 0);
-        let mut s_0 = sample_poly_CBD::<eta1>(sigma, 0 as u8);
+        let mut s_0 = sample_poly_CBD(sigma, 0 as u8, P::eta1);
         s_0.ntt(); // now s_hat_0
         A_i0.base_mult_montgomery(&s_0);
 
         A_i0
     };
 
-    for j in 1..k {
+    for j in 1..P::k {
         let mut A_ij = expandA_elem(rho, row, j);
-        let mut s_j = sample_poly_CBD::<eta1>(sigma, j as u8);
+        let mut s_j = sample_poly_CBD(sigma, j as u8, P::eta1);
         s_j.ntt(); // now s_hat_j
         A_ij.base_mult_montgomery(&s_j);
         t_hat_i.add(&A_ij);
@@ -43,7 +44,7 @@ pub(crate) fn compute_A_hat_dot_s_hat<const k: usize, const eta1: i16>(
 
 /// Compute a single row of the core encaps operation
 /// Alg 14: line 19: NTT−1(𝐀_hat_T ∘ 𝐲_hat)
-pub(crate) fn compute_A_hat_dot_y_hat<const k: usize, const eta1: i16>(
+pub(crate) fn compute_A_hat_dot_y_hat<P: MLKEMParams>(
     rho: &[u8; 32],
     r: &[u8; 32],
     row: usize,
@@ -52,7 +53,7 @@ pub(crate) fn compute_A_hat_dot_y_hat<const k: usize, const eta1: i16>(
     //   ▷ re-generate matrix 𝐀 ∈ (ℤ256_𝑞 )𝑘×𝑘 sampled in Alg. 13
 
     // 9: for (𝑖 ← 0; 𝑖 < 𝑘; 𝑖++)
-    //  ▷ generate 𝐲 ∈ (ℤ256_𝑞)k
+    //  ▷ generate 𝐲 ∈ (ℤ256_𝑞)^𝑘
     // 10: 𝐲[𝑖] ← SamplePolyCBD𝜂1(PRF𝜂1 (𝑟, 𝑁))
     //   ▷ 𝐲[𝑖] ∈ ℤ256 sampled from CBD
     // 11: 𝑁 ← 𝑁 + 1
@@ -61,16 +62,16 @@ pub(crate) fn compute_A_hat_dot_y_hat<const k: usize, const eta1: i16>(
 
     let mut u_i: Polynomial = {
         let mut A_0i = expandA_elem(rho, 0, row);
-        let mut y_0 = sample_poly_CBD::<eta1>(r, /*N*/ 0);
+        let mut y_0 = sample_poly_CBD(r, /*N*/ 0, P::eta1);
         y_0.ntt();
         A_0i.base_mult_montgomery(&y_0);
 
         A_0i
     };
 
-    for j in 1..k {
+    for j in 1..P::k {
         let mut A_ji = expandA_elem(&rho, j, row);
-        let mut y_j = sample_poly_CBD::<eta1>(r, /*N*/ j as u8);
+        let mut y_j = sample_poly_CBD(r, /*N*/ j as u8, P::eta1);
         y_j.ntt();
         A_ji.base_mult_montgomery(&y_j);
         u_i.add(&A_ji);
@@ -82,12 +83,12 @@ pub(crate) fn compute_A_hat_dot_y_hat<const k: usize, const eta1: i16>(
 
 /// Compute a term of the output polynomial v of the core encaps operation based on a single row of t_hat_i and y_hat.
 /// Alg 14: line 21: 𝑣 ← NTT−1(𝐭_hat_T ∘ 𝐲_hat)
-pub(crate) fn compute_t_hat_dot_y_hat_row<const k: usize, const eta1: i16>(
+pub(crate) fn compute_t_hat_dot_y_hat_row<P: MLKEMParams>(
     r: &[u8; 32],
     t_hat_i: &Polynomial,
     row: usize,
 ) -> Polynomial {
-    let mut y_i = sample_poly_CBD::<eta1>(r, /*N*/ row as u8);
+    let mut y_i = sample_poly_CBD(r, /*N*/ row as u8, P::eta1);
     y_i.ntt();
     y_i.base_mult_montgomery(&t_hat_i);
     y_i.inv_ntt();
@@ -95,32 +96,29 @@ pub(crate) fn compute_t_hat_dot_y_hat_row<const k: usize, const eta1: i16>(
     y_i
 }
 
-pub(crate) fn pack_t_hat_row<const T_PACKED_LEN: usize>(
+pub(crate) fn pack_t_hat_row<P: MLKEMParams>(
     t_hat_i: &Polynomial,
     row: usize,
-    t_hat_packed: &mut [u8; T_PACKED_LEN],
+    t_hat_packed: &mut P::TPacked,
 ) {
     byte_encode::<12, POLY_BYTES>(
         &t_hat_i,
-        t_hat_packed[row * POLY_BYTES..(row + 1) * POLY_BYTES].as_mut().try_into().unwrap(),
+        (&mut t_hat_packed.as_mut()[row * POLY_BYTES..(row + 1) * POLY_BYTES]).try_into().unwrap(),
     );
 }
 
-pub(crate) fn unpack_t_hat_row<const T_PACKED_LEN: usize>(
-    t_hat_packed: &[u8; T_PACKED_LEN],
-    row: usize,
-) -> Polynomial {
+pub(crate) fn unpack_t_hat_row(t_hat_packed: &[u8], row: usize) -> Polynomial {
     byte_decode::<12, POLY_BYTES>(
         t_hat_packed[row * POLY_BYTES..(row + 1) * POLY_BYTES].try_into().unwrap(),
     )
 }
 
-pub(crate) fn pack_s_hat_row<const k: usize>(
+pub(crate) fn pack_s_hat_row<P: MLKEMParams>(
     s_hat_i: &Polynomial,
     row: usize,
     s_hat_packed: &mut [u8],
 ) {
-    debug_assert!(s_hat_packed.len() >= k * POLY_BYTES);
+    debug_assert!(s_hat_packed.len() >= P::k * POLY_BYTES);
 
     byte_encode::<12, POLY_BYTES>(
         s_hat_i,
@@ -130,28 +128,28 @@ pub(crate) fn pack_s_hat_row<const k: usize>(
 
 /// This is an optimized version of
 ///   ByteEncode_𝑑𝑢( Compress_𝑑𝑢(𝐮) )
-/// which packs a single row of the polynomial vector u according to the packing coefficient dv
+/// which packs a single row of the polynomial vector u according to the packing coefficient 𝑑𝑢
 /// into the correct location within the ciphertext
-pub(crate) fn compress_u_row<const du: i16, const CT_LEN: usize>(
+pub(crate) fn compress_u_row<P: MLKEMParams, const CT_LEN: usize>(
     u_i: Polynomial,
     row: usize,
     ct: &mut [u8; CT_LEN],
 ) {
-    // make sure we have received a dv
-    assert!(du == 10 || du == 11);
+    // make sure we received a supported 𝑑𝑢
+    assert!(P::du == 10 || P::du == 11);
 
     // bc-java has a conditional_sub_q() here, but I pass all unit tests without it, so I'm taking it out for performance.
     // let mut u_i = u_i.clone();
     // u_i.conditional_sub_q();
 
     // figure out where in the ct array we're going to write to
-    // each of the N i16's will take du bits, so a polynomial takes N * du bits, then we have k of them
-    let start: usize = row * (N * (du as usize) / 8);
-    let end: usize = (row + 1) * (N * (du as usize) / 8);
+    // each of the N i16's will take 𝑑𝑢 bits, so a polynomial takes N * 𝑑𝑢 bits, then we have 𝑘 of them
+    let start: usize = row * (N * (P::du as usize) / 8);
+    let end: usize = (row + 1) * (N * (P::du as usize) / 8);
     let out = &mut ct[start..end];
 
     let mut idx = 0;
-    match du {
+    match P::du {
         10 => {
             // MLKEM512 and MLKEM 768
             let mut t = [0i16; 4];
@@ -196,24 +194,24 @@ pub(crate) fn compress_u_row<const du: i16, const CT_LEN: usize>(
     }
 }
 
-pub(crate) fn unpack_ciphertext_u_row<const du: i16, const CT_LEN: usize>(
+pub(crate) fn unpack_ciphertext_u_row<P: MLKEMParams, const CT_LEN: usize>(
     row: usize,
     ct: &[u8; CT_LEN],
 ) -> Polynomial {
     let mut u_i = Polynomial::new();
 
-    // make sure to received a dv
-    assert!(du == 10 || du == 11);
+    // make sure we received a supported 𝑑𝑢
+    assert!(P::du == 10 || P::du == 11);
 
     // figure out where in the ct array we're going to write to
-    // each of the N i16's will take du bits, so a polynomial takes N * du bits, then we have k of them
-    let start: usize = row * (N * (du as usize) / 8);
-    let end: usize = (row + 1) * (N * (du as usize) / 8);
+    // each of the N i16's will take 𝑑𝑢 bits, so a polynomial takes N * 𝑑𝑢 bits, then we have 𝑘 of them
+    let start: usize = row * (N * (P::du as usize) / 8);
+    let end: usize = (row + 1) * (N * (P::du as usize) / 8);
     let compressed_u_i = &ct[start..end];
 
     let mut idx = 0;
 
-    match du {
+    match P::du {
         10 => {
             // MLKEM512 and MLKEM768
             let mut t = [0i16; 4];
@@ -269,18 +267,13 @@ pub(crate) fn unpack_ciphertext_u_row<const du: i16, const CT_LEN: usize>(
     u_i
 }
 
-pub(crate) fn unpack_ciphertext_v<
-    const k: usize,
-    const CT_LEN: usize,
-    const du: i16,
-    const dv: i16,
->(
+pub(crate) fn unpack_ciphertext_v<P: MLKEMParams, const CT_LEN: usize>(
     c: &[u8; CT_LEN],
 ) -> Polynomial {
-    // each of the N i16's will take du bits, so a polynomial takes N * du bits, then we have k of them
-    let lim: usize = k * (N * (du as usize) / 8);
+    // each of the N i16's will take 𝑑𝑢 bits, so a polynomial takes N * 𝑑𝑢 bits, then we have 𝑘 of them
+    let lim: usize = P::k * (N * (P::du as usize) / 8);
 
-    let v = Polynomial::decompress_poly::<dv>(&c[lim..]);
+    let v = Polynomial::decompress_poly::<P>(&c[lim..]);
 
     v
 }

--- a/crypto/mlkem-lowmemory/src/mlkem.rs
+++ b/crypto/mlkem-lowmemory/src/mlkem.rs
@@ -50,44 +50,40 @@ pub(crate) const POLY_BYTES: usize = 384;
 
 /* ML-KEM-512 params */
 
-/// Length of the \[u8] holding a ML-KEM-512 public key.
+/// Length of the \[u8] holding an ML-KEM-512 public key.
 pub const MLKEM512_PK_LEN: usize = MLKEM512Params::PK_LEN;
-/// Length of the \[u8] holding a ML-KEM-512 seed-based private key.
+/// Length of the \[u8] holding an ML-KEM-512 seed-based private key.
 pub const MLKEM512_SK_LEN: usize = MLKEM_SEED_LEN;
 /// Length of the \[u8] holding a full ML-KEM-512 private key in the NIST encoding.
 pub const MLKEM512_FULL_SK_LEN: usize = MLKEM512Params::FULL_SK_LEN;
-/// Length of the \[u8] holding a ML-KEM-512 ciphertext.
+/// Length of the \[u8] holding an ML-KEM-512 ciphertext.
 pub const MLKEM512_CT_LEN: usize = MLKEM512Params::CT_LEN;
 
-// internal derived values
+/*** internal derived values ***/
 
 /* ML-KEM-768 params */
 
-/// Length of the \[u8] holding a ML-KEM-768 public key.
+/// Length of the \[u8] holding an ML-KEM-768 public key.
 pub const MLKEM768_PK_LEN: usize = MLKEM768Params::PK_LEN;
-/// Length of the \[u8] holding a ML-KEM-768 seed-based private key.
+/// Length of the \[u8] holding an ML-KEM-768 seed-based private key.
 pub const MLKEM768_SK_LEN: usize = MLKEM_SEED_LEN;
 /// Length of the \[u8] holding a full ML-KEM-768 private key in the NIST encoding.
 pub const MLKEM768_FULL_SK_LEN: usize = MLKEM768Params::FULL_SK_LEN;
-/// Length of the \[u8] holding a ML-KEM-768 ciphertext.
+/// Length of the \[u8] holding an ML-KEM-768 ciphertext.
 pub const MLKEM768_CT_LEN: usize = MLKEM768Params::CT_LEN;
-
-// internal derived values
 
 /* ML-KEM-1024 params */
 
-/// Length of the \[u8] holding a ML-KEM-1024 public key.
+/// Length of the \[u8] holding an ML-KEM-1024 public key.
 pub const MLKEM1024_PK_LEN: usize = MLKEM1024Params::PK_LEN;
-/// Length of the \[u8] holding a ML-KEM-512 seed-based private key.
+/// Length of the \[u8] holding an ML-KEM-1024 seed-based private key.
 pub const MLKEM1024_SK_LEN: usize = MLKEM_SEED_LEN;
-/// Length of the \[u8] holding a full ML-KEM-512 private key in the NIST encoding.
+/// Length of the \[u8] holding a full ML-KEM-1024 private key in the NIST encoding.
 pub const MLKEM1024_FULL_SK_LEN: usize = MLKEM1024Params::FULL_SK_LEN;
-/// Length of the \[u8] holding a ML-KEM-1024 ciphertext.
+/// Length of the \[u8] holding an ML-KEM-1024 ciphertext.
 pub const MLKEM1024_CT_LEN: usize = MLKEM1024Params::CT_LEN;
 
-// internal derived values
-
-// Typedefs just to make the algorithms look more like the FIPS 204 sample code.
+/*** Typedefs just to make the algorithms look more like the FIPS 204 sample code. ***/
 pub(crate) type G = SHA3_512;
 pub(crate) type H = SHA3_256;
 pub(crate) type J = SHAKE256;

--- a/crypto/mlkem-lowmemory/src/mlkem.rs
+++ b/crypto/mlkem-lowmemory/src/mlkem.rs
@@ -11,6 +11,7 @@ use crate::mlkem_keys::{
 };
 use crate::mlkem_keys::{MLKEMPrivateKeyInternalTrait, MLKEMPrivateKeyTrait};
 use crate::mlkem_keys::{MLKEMPublicKeyInternalTrait, MLKEMPublicKeyTrait};
+use crate::params::{MLKEM512Params, MLKEM768Params, MLKEM1024Params, MLKEMParams};
 use crate::polynomial::Polynomial;
 use bouncycastle_core::errors::{KEMError, RNGError};
 use bouncycastle_core::key_material::{
@@ -45,68 +46,46 @@ pub const MLKEM_SS_LEN: usize = 32;
 pub(crate) const N: usize = 256;
 pub(crate) const q: i16 = 3329;
 pub(crate) const q_inv: i32 = 62209;
-pub(crate) const ETA2: i16 = 2;
 pub(crate) const POLY_BYTES: usize = 384;
 
 /* ML-KEM-512 params */
 
 /// Length of the \[u8] holding a ML-KEM-512 public key.
-pub const MLKEM512_PK_LEN: usize = 800;
+pub const MLKEM512_PK_LEN: usize = MLKEM512Params::PK_LEN;
 /// Length of the \[u8] holding a ML-KEM-512 seed-based private key.
 pub const MLKEM512_SK_LEN: usize = MLKEM_SEED_LEN;
 /// Length of the \[u8] holding a full ML-KEM-512 private key in the NIST encoding.
-pub const MLKEM512_FULL_SK_LEN: usize = 1632;
+pub const MLKEM512_FULL_SK_LEN: usize = MLKEM512Params::FULL_SK_LEN;
 /// Length of the \[u8] holding a ML-KEM-512 ciphertext.
-pub const MLKEM512_CT_LEN: usize = 768;
-pub(crate) const MLKEM512_k: usize = 2;
-pub(crate) const MLKEM512_ETA1: i16 = 3;
-pub(crate) const MLKEM512_DU: i16 = 10;
-pub(crate) const MLKEM512_DV: i16 = 4;
-/// Maps to "required RBG strength (bits)" in FIPS 203 Table 2
-pub(crate) const MLKEM512_LAMBDA: i16 = 128;
+pub const MLKEM512_CT_LEN: usize = MLKEM512Params::CT_LEN;
 
 // internal derived values
-pub(crate) const MLKEM512_T_PACKED_LEN: usize = 12 * MLKEM512_k * 32;
 
 /* ML-KEM-768 params */
 
 /// Length of the \[u8] holding a ML-KEM-768 public key.
-pub const MLKEM768_PK_LEN: usize = 1184;
+pub const MLKEM768_PK_LEN: usize = MLKEM768Params::PK_LEN;
 /// Length of the \[u8] holding a ML-KEM-768 seed-based private key.
 pub const MLKEM768_SK_LEN: usize = MLKEM_SEED_LEN;
 /// Length of the \[u8] holding a full ML-KEM-768 private key in the NIST encoding.
-pub const MLKEM768_FULL_SK_LEN: usize = 2400;
+pub const MLKEM768_FULL_SK_LEN: usize = MLKEM768Params::FULL_SK_LEN;
 /// Length of the \[u8] holding a ML-KEM-768 ciphertext.
-pub const MLKEM768_CT_LEN: usize = 1088;
-pub(crate) const MLKEM768_k: usize = 3;
-pub(crate) const MLKEM768_ETA1: i16 = 2;
-pub(crate) const MLKEM768_DU: i16 = 10;
-pub(crate) const MLKEM768_DV: i16 = 4;
-/// Maps to "required RBG strength (bits)" in FIPS 203 Table 2
-pub(crate) const MLKEM768_LAMBDA: i16 = 192;
+pub const MLKEM768_CT_LEN: usize = MLKEM768Params::CT_LEN;
 
 // internal derived values
-pub(crate) const MLKEM768_T_PACKED_LEN: usize = 12 * MLKEM768_k * 32;
 
 /* ML-KEM-1024 params */
 
 /// Length of the \[u8] holding a ML-KEM-1024 public key.
-pub const MLKEM1024_PK_LEN: usize = 1568;
+pub const MLKEM1024_PK_LEN: usize = MLKEM1024Params::PK_LEN;
 /// Length of the \[u8] holding a ML-KEM-512 seed-based private key.
 pub const MLKEM1024_SK_LEN: usize = MLKEM_SEED_LEN;
 /// Length of the \[u8] holding a full ML-KEM-512 private key in the NIST encoding.
-pub const MLKEM1024_FULL_SK_LEN: usize = 3168;
+pub const MLKEM1024_FULL_SK_LEN: usize = MLKEM1024Params::FULL_SK_LEN;
 /// Length of the \[u8] holding a ML-KEM-1024 ciphertext.
-pub const MLKEM1024_CT_LEN: usize = 1568;
-pub(crate) const MLKEM1024_k: usize = 4;
-pub(crate) const MLKEM1024_ETA1: i16 = 2;
-pub(crate) const MLKEM1024_DU: i16 = 11;
-pub(crate) const MLKEM1024_DV: i16 = 5;
-/// Maps to "required RBG strength (bits)" in FIPS 203 Table 2
-pub(crate) const MLKEM1024_LAMBDA: i16 = 256;
+pub const MLKEM1024_CT_LEN: usize = MLKEM1024Params::CT_LEN;
 
 // internal derived values
-pub(crate) const MLKEM1024_T_PACKED_LEN: usize = 12 * MLKEM1024_k * 32;
 
 // Typedefs just to make the algorithms look more like the FIPS 204 sample code.
 pub(crate) type G = SHA3_512;
@@ -117,86 +96,73 @@ pub(crate) type J = SHAKE256;
 
 /// The ML-KEM-512 algorithm.
 pub type MLKEM512 = MLKEM<
+    MLKEM512Params,
+    MLKEM512PublicKey,
+    MLKEM512PrivateKey,
     MLKEM512_PK_LEN,
     MLKEM512_SK_LEN,
     MLKEM512_FULL_SK_LEN,
     MLKEM512_CT_LEN,
     MLKEM_SS_LEN,
-    MLKEM512PublicKey,
-    MLKEM512PrivateKey,
-    MLKEM512_k,
-    MLKEM512_ETA1,
-    MLKEM512_DU,
-    MLKEM512_DV,
-    MLKEM512_LAMBDA,
-    MLKEM512_T_PACKED_LEN,
 >;
-
-impl Algorithm for MLKEM512 {
-    const ALG_NAME: &'static str = ML_KEM_512_NAME;
-    const MAX_SECURITY_STRENGTH: SecurityStrength = SecurityStrength::_128bit;
-}
-/// Assigned by NIST in the Computer Security Objects Register: id-alg-ml-kem-512 { kems 1 }
-impl AlgorithmOID for MLKEM512 {
-    const OID: &'static [u32] = &[2, 16, 840, 1, 101, 3, 4, 4, 1];
-    const OID_DER: &'static [u8] =
-        &[0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x04, 0x01];
-}
 
 /// The ML-KEM-768 algorithm.
 pub type MLKEM768 = MLKEM<
+    MLKEM768Params,
+    MLKEM768PublicKey,
+    MLKEM768PrivateKey,
     MLKEM768_PK_LEN,
     MLKEM768_SK_LEN,
     MLKEM768_FULL_SK_LEN,
     MLKEM768_CT_LEN,
     MLKEM_SS_LEN,
-    MLKEM768PublicKey,
-    MLKEM768PrivateKey,
-    MLKEM768_k,
-    MLKEM768_ETA1,
-    MLKEM768_DU,
-    MLKEM768_DV,
-    MLKEM768_LAMBDA,
-    MLKEM768_T_PACKED_LEN,
 >;
-
-impl Algorithm for MLKEM768 {
-    const ALG_NAME: &'static str = ML_KEM_768_NAME;
-    const MAX_SECURITY_STRENGTH: SecurityStrength = SecurityStrength::_192bit;
-}
-/// Assigned by NIST in the Computer Security Objects Register: id-alg-ml-kem-768 { kems 2 }
-impl AlgorithmOID for MLKEM768 {
-    const OID: &'static [u32] = &[2, 16, 840, 1, 101, 3, 4, 4, 2];
-    const OID_DER: &'static [u8] =
-        &[0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x04, 0x02];
-}
 
 /// The ML-KEM-1024 algorithm.
 pub type MLKEM1024 = MLKEM<
+    MLKEM1024Params,
+    MLKEM1024PublicKey,
+    MLKEM1024PrivateKey,
     MLKEM1024_PK_LEN,
     MLKEM1024_SK_LEN,
     MLKEM1024_FULL_SK_LEN,
     MLKEM1024_CT_LEN,
     MLKEM_SS_LEN,
-    MLKEM1024PublicKey,
-    MLKEM1024PrivateKey,
-    MLKEM1024_k,
-    MLKEM1024_ETA1,
-    MLKEM1024_DU,
-    MLKEM1024_DV,
-    MLKEM1024_LAMBDA,
-    MLKEM1024_T_PACKED_LEN,
 >;
 
-impl Algorithm for MLKEM1024 {
-    const ALG_NAME: &'static str = ML_KEM_1024_NAME;
-    const MAX_SECURITY_STRENGTH: SecurityStrength = SecurityStrength::_256bit;
+impl<
+    P: MLKEMParams,
+    PK: MLKEMPublicKeyTrait<P, PK_LEN> + MLKEMPublicKeyInternalTrait<P, PK_LEN>,
+    SK: MLKEMPrivateKeyTrait<P, SK_LEN, FULL_SK_LEN, PK_LEN>
+        + MLKEMPrivateKeyInternalTrait<P, SK_LEN, PK_LEN>,
+    const PK_LEN: usize,
+    const SK_LEN: usize,
+    const FULL_SK_LEN: usize,
+    const CT_LEN: usize,
+    const SS_LEN: usize,
+> Algorithm for MLKEM<P, PK, SK, PK_LEN, SK_LEN, FULL_SK_LEN, CT_LEN, SS_LEN>
+{
+    const ALG_NAME: &'static str = P::ALG_NAME;
+    const MAX_SECURITY_STRENGTH: SecurityStrength = P::MAX_SECURITY_STRENGTH;
 }
-/// Assigned by NIST in the Computer Security Objects Register: id-alg-ml-kem-1024 { kems 3 }
-impl AlgorithmOID for MLKEM1024 {
-    const OID: &'static [u32] = &[2, 16, 840, 1, 101, 3, 4, 4, 3];
-    const OID_DER: &'static [u8] =
-        &[0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x04, 0x03];
+
+/// The OIDs NIST assigned in the Computer Security Objects Register: id-alg-ml-kem-512
+/// { kems 1 }, id-alg-ml-kem-768 { kems 2 } and id-alg-ml-kem-1024 { kems 3 }. As with
+/// [`Algorithm`], the values belong to the parameter set, so one impl covers all three.
+impl<
+    P: MLKEMParams,
+    PK: MLKEMPublicKeyTrait<P, PK_LEN> + MLKEMPublicKeyInternalTrait<P, PK_LEN>,
+    SK: MLKEMPrivateKeyTrait<P, SK_LEN, FULL_SK_LEN, PK_LEN>
+        + MLKEMPrivateKeyInternalTrait<P, SK_LEN, PK_LEN>,
+    const PK_LEN: usize,
+    const SK_LEN: usize,
+    const FULL_SK_LEN: usize,
+    const CT_LEN: usize,
+    const SS_LEN: usize,
+> AlgorithmOID for MLKEM<P, PK, SK, PK_LEN, SK_LEN, FULL_SK_LEN, CT_LEN, SS_LEN>
+{
+    const OID: &'static [u32] = P::OID;
+    const OID_DER: &'static [u8] = P::OID_DER;
 }
 
 /// The core internal implementation of the ML-KEM algorithm.
@@ -204,57 +170,30 @@ impl AlgorithmOID for MLKEM1024 {
 /// but is shouldn't ever need to be used directly.
 /// Please use the named public types.
 pub struct MLKEM<
+    P: MLKEMParams,
+    PK: MLKEMPublicKeyTrait<P, PK_LEN> + MLKEMPublicKeyInternalTrait<P, PK_LEN>,
+    SK: MLKEMPrivateKeyTrait<P, SK_LEN, FULL_SK_LEN, PK_LEN>
+        + MLKEMPrivateKeyInternalTrait<P, SK_LEN, PK_LEN>,
     const PK_LEN: usize,
     const SK_LEN: usize,
     const FULL_SK_LEN: usize,
     const CT_LEN: usize,
     const SS_LEN: usize,
-    PK: MLKEMPublicKeyTrait<k, PK_LEN, T_PACKED_LEN>
-        + MLKEMPublicKeyInternalTrait<k, T_PACKED_LEN, PK_LEN>,
-    SK: MLKEMPrivateKeyTrait<k, SK_LEN, FULL_SK_LEN, PK_LEN, T_PACKED_LEN>
-        + MLKEMPrivateKeyInternalTrait<k, SK_LEN, PK_LEN, T_PACKED_LEN>,
-    const k: usize,
-    const eta1: i16,
-    const du: i16,
-    const dv: i16,
-    const LAMBDA: i16,
-    const T_PACKED_LEN: usize,
 > {
-    _phantom: PhantomData<(PK, SK)>,
+    _phantom: PhantomData<(P, PK, SK)>,
 }
 
 impl<
+    P: MLKEMParams,
+    PK: MLKEMPublicKeyTrait<P, PK_LEN> + MLKEMPublicKeyInternalTrait<P, PK_LEN>,
+    SK: MLKEMPrivateKeyTrait<P, SK_LEN, FULL_SK_LEN, PK_LEN>
+        + MLKEMPrivateKeyInternalTrait<P, SK_LEN, PK_LEN>,
     const PK_LEN: usize,
     const SK_LEN: usize,
     const FULL_SK_LEN: usize,
     const CT_LEN: usize,
     const SS_LEN: usize,
-    PK: MLKEMPublicKeyTrait<k, PK_LEN, T_PACKED_LEN>
-        + MLKEMPublicKeyInternalTrait<k, T_PACKED_LEN, PK_LEN>,
-    SK: MLKEMPrivateKeyTrait<k, SK_LEN, FULL_SK_LEN, PK_LEN, T_PACKED_LEN>
-        + MLKEMPrivateKeyInternalTrait<k, SK_LEN, PK_LEN, T_PACKED_LEN>,
-    const k: usize,
-    const eta1: i16,
-    const du: i16,
-    const dv: i16,
-    const LAMBDA: i16,
-    const T_PACKED_LEN: usize,
->
-    MLKEM<
-        PK_LEN,
-        SK_LEN,
-        FULL_SK_LEN,
-        CT_LEN,
-        SS_LEN,
-        PK,
-        SK,
-        k,
-        eta1,
-        du,
-        dv,
-        LAMBDA,
-        T_PACKED_LEN,
-    >
+> MLKEM<P, PK, SK, PK_LEN, SK_LEN, FULL_SK_LEN, CT_LEN, SS_LEN>
 {
     /// Performs the first step of key generation to transform the single provided seed into a set of internal intermediate seeds.
     ///
@@ -278,7 +217,7 @@ impl<
     /// Input: randomness 𝑟 ∈ 𝔹32 .
     /// Output: ciphertext 𝑐 ∈ 𝔹32(𝑑𝑢𝑘+𝑑𝑣).
     fn pke_encrypt(
-        t_hat_packed: &[u8; T_PACKED_LEN],
+        t_hat_packed: &P::TPacked,
         rho: &[u8; 32],
         m: [u8; 32],
         r: &[u8; 32],
@@ -297,14 +236,14 @@ impl<
 
         // Note: y_hat is needed twice: once here at line 19, and again at line 21.
         // Here it is generated each time it is needed in order to save memory.
-        for i in 0..k {
-            let mut u_i = compute_A_hat_dot_y_hat::<k, eta1>(rho, &r, i);
+        for i in 0..P::k {
+            let mut u_i = compute_A_hat_dot_y_hat::<P>(rho, &r, i);
 
-            let e1_i = sample_poly_CBD::<ETA2>(&r, (k + i) as u8);
+            let e1_i = sample_poly_CBD(&r, (P::k + i) as u8, P::eta2);
             u_i.add(&e1_i);
             u_i.poly_reduce();
 
-            compress_u_row::<du, CT_LEN>(u_i, i, &mut ct);
+            compress_u_row::<P, CT_LEN>(u_i, i, &mut ct);
         }
 
         // 17: 𝑒2 ← SamplePolyCBD_𝜂2(PRF𝜂2 (𝑟, 𝑁))
@@ -313,23 +252,23 @@ impl<
         // 23: 𝑐2 ← ByteEncode_𝑑𝑣(Compress_𝑑𝑣(𝑣))
         {
             // compute v, which is a single polynomial, but requires iterating over the vectors t_hat and y_hat
-            let mut v = compute_t_hat_dot_y_hat_row::<k, eta1>(
+            let mut v = compute_t_hat_dot_y_hat_row::<P>(
                 &r,
-                &unpack_t_hat_row(t_hat_packed, 0),
+                &unpack_t_hat_row(t_hat_packed.as_ref(), 0),
                 /*row*/ 0,
             );
 
-            for i in 1..k {
-                let v_i = compute_t_hat_dot_y_hat_row::<k, eta1>(
+            for i in 1..P::k {
+                let v_i = compute_t_hat_dot_y_hat_row::<P>(
                     &r,
-                    &unpack_t_hat_row(t_hat_packed, i),
+                    &unpack_t_hat_row(t_hat_packed.as_ref(), i),
                     /*row*/ i,
                 );
                 v.add(&v_i);
             }
 
             // perform polynomial addition
-            let e2 = sample_poly_CBD::<ETA2>(&r, 2 * k as u8);
+            let e2 = sample_poly_CBD(&r, 2 * P::k as u8, P::eta2);
             v.add(&e2);
 
             let mu = Polynomial::from_msg(m);
@@ -337,7 +276,7 @@ impl<
 
             v.poly_reduce();
 
-            v.compress_poly::<dv>(&mut ct[CT_LEN - (N * (dv as usize) / 8)..]);
+            v.compress_poly::<P>(&mut ct[CT_LEN - (N * (P::dv as usize) / 8)..]);
         }
 
         ct
@@ -367,7 +306,7 @@ impl<
     /// Failing to use this properly will result in catastrophic vulnerabilities.
     /// Please don't do it.
     pub fn encaps_internal(ek: &PK, m: [u8; 32]) -> ([u8; 32], [u8; CT_LEN]) {
-        debug_assert_eq!(CT_LEN, 32 * ((du as usize) * k + (dv as usize)));
+        debug_assert_eq!(CT_LEN, 32 * ((P::du as usize) * P::k + (P::dv as usize)));
 
         // 1: (𝐾, 𝑟) ← G(𝑚‖H(ek))
         //  ▷ derive shared secret key 𝐾 and randomness 𝑟
@@ -411,7 +350,7 @@ impl<
             let mut v1 = {
                 let mut s_hat_i = dk.compute_s_hat_row(0);
                 {
-                    let mut u_prime_i = unpack_ciphertext_u_row::<du, CT_LEN>(0, &ct);
+                    let mut u_prime_i = unpack_ciphertext_u_row::<P, CT_LEN>(0, &ct);
                     u_prime_i.ntt();
                     s_hat_i.base_mult_montgomery(&u_prime_i);
                 }
@@ -420,10 +359,10 @@ impl<
                 s_hat_i
             };
 
-            for i in 1..k {
+            for i in 1..P::k {
                 let mut s_hat_i = dk.compute_s_hat_row(i);
                 {
-                    let mut u_prime_i = unpack_ciphertext_u_row::<du, CT_LEN>(i, &ct);
+                    let mut u_prime_i = unpack_ciphertext_u_row::<P, CT_LEN>(i, &ct);
                     u_prime_i.ntt();
                     s_hat_i.base_mult_montgomery(&u_prime_i);
                 }
@@ -439,7 +378,7 @@ impl<
         let w = {
             // second half of
             // 6: 𝑤 ← 𝑣′ − NTT−1(𝐬_hat^T ∘ NTT(𝐮′))
-            let mut v_prime = unpack_ciphertext_v::<k, CT_LEN, du, dv>(&ct);
+            let mut v_prime = unpack_ciphertext_v::<P, CT_LEN>(&ct);
 
             v_prime.sub(&v1);
             v_prime.poly_reduce();
@@ -532,52 +471,17 @@ impl<
 }
 
 impl<
+    P: MLKEMParams,
+    PK: MLKEMPublicKeyTrait<P, PK_LEN> + MLKEMPublicKeyInternalTrait<P, PK_LEN>,
+    SK: MLKEMPrivateKeyTrait<P, SK_LEN, FULL_SK_LEN, PK_LEN>
+        + MLKEMPrivateKeyInternalTrait<P, SK_LEN, PK_LEN>,
     const PK_LEN: usize,
     const SK_LEN: usize,
     const FULL_SK_LEN: usize,
     const CT_LEN: usize,
     const SS_LEN: usize,
-    PK: MLKEMPublicKeyTrait<k, PK_LEN, T_PACKED_LEN>
-        + MLKEMPublicKeyInternalTrait<k, T_PACKED_LEN, PK_LEN>,
-    SK: MLKEMPrivateKeyTrait<k, SK_LEN, FULL_SK_LEN, PK_LEN, T_PACKED_LEN>
-        + MLKEMPrivateKeyInternalTrait<k, SK_LEN, PK_LEN, T_PACKED_LEN>,
-    const k: usize,
-    const eta1: i16,
-    const du: i16,
-    const dv: i16,
-    const LAMBDA: i16,
-    const T_PACKED_LEN: usize,
->
-    MLKEMTrait<
-        PK_LEN,
-        SK_LEN,
-        FULL_SK_LEN,
-        CT_LEN,
-        SS_LEN,
-        PK,
-        SK,
-        k,
-        eta1,
-        du,
-        dv,
-        LAMBDA,
-        T_PACKED_LEN,
-    >
-    for MLKEM<
-        PK_LEN,
-        SK_LEN,
-        FULL_SK_LEN,
-        CT_LEN,
-        SS_LEN,
-        PK,
-        SK,
-        k,
-        eta1,
-        du,
-        dv,
-        LAMBDA,
-        T_PACKED_LEN,
-    >
+> MLKEMTrait<P, PK, SK, PK_LEN, SK_LEN, FULL_SK_LEN, CT_LEN, SS_LEN>
+    for MLKEM<P, PK, SK, PK_LEN, SK_LEN, FULL_SK_LEN, CT_LEN, SS_LEN>
 {
     /// Imports a secret key from a seed.
     fn keygen_from_seed(seed: &KeyMaterial<64>) -> Result<(PK, SK), KEMError> {
@@ -624,21 +528,15 @@ impl<
 
 /// Trait for all three of the ML-DSA algorithm variants.
 pub trait MLKEMTrait<
+    P: MLKEMParams,
+    PK: MLKEMPublicKeyTrait<P, PK_LEN> + MLKEMPublicKeyInternalTrait<P, PK_LEN>,
+    SK: MLKEMPrivateKeyTrait<P, SK_LEN, FULL_SK_LEN, PK_LEN>
+        + MLKEMPrivateKeyInternalTrait<P, SK_LEN, PK_LEN>,
     const PK_LEN: usize,
     const SK_LEN: usize,
     const FULL_SK_LEN: usize,
     const CT_LEN: usize,
     const SS_LEN: usize,
-    PK: MLKEMPublicKeyTrait<k, PK_LEN, T_PACKED_LEN>
-        + MLKEMPublicKeyInternalTrait<k, T_PACKED_LEN, PK_LEN>,
-    SK: MLKEMPrivateKeyTrait<k, SK_LEN, FULL_SK_LEN, PK_LEN, T_PACKED_LEN>
-        + MLKEMPrivateKeyInternalTrait<k, SK_LEN, PK_LEN, T_PACKED_LEN>,
-    const k: usize,
-    const eta: i16,
-    const du: i16,
-    const dv: i16,
-    const LAMBDA: i16,
-    const T_PACKED_LEN: usize,
 >: Sized
 {
     /// Generates a fresh key pair.
@@ -650,7 +548,7 @@ pub trait MLKEMTrait<
     // Should still be ok in FIPS mode, provided that you're using the FIPS-approved RNG.
     fn keygen_from_rng(rng: &mut dyn RNG) -> Result<(PK, SK), KEMError> {
         // Source the seed from the provided RNG
-        if rng.security_strength() < SecurityStrength::from_bits(LAMBDA as usize) {
+        if rng.security_strength() < P::MAX_SECURITY_STRENGTH {
             return Err(RNGError::SecurityStrengthInsufficientForAlgorithm)?;
         }
         let mut seed = KeyMaterial::<64>::new();
@@ -681,37 +579,17 @@ pub trait MLKEMTrait<
 }
 
 impl<
+    P: MLKEMParams,
+    PK: MLKEMPublicKeyTrait<P, PK_LEN> + MLKEMPublicKeyInternalTrait<P, PK_LEN>,
+    SK: MLKEMPrivateKeyTrait<P, SK_LEN, FULL_SK_LEN, PK_LEN>
+        + MLKEMPrivateKeyInternalTrait<P, SK_LEN, PK_LEN>,
     const PK_LEN: usize,
     const SK_LEN: usize,
     const FULL_SK_LEN: usize,
     const CT_LEN: usize,
     const SS_LEN: usize,
-    PK: MLKEMPublicKeyTrait<k, PK_LEN, T_PACKED_LEN>
-        + MLKEMPublicKeyInternalTrait<k, T_PACKED_LEN, PK_LEN>,
-    SK: MLKEMPrivateKeyTrait<k, SK_LEN, FULL_SK_LEN, PK_LEN, T_PACKED_LEN>
-        + MLKEMPrivateKeyInternalTrait<k, SK_LEN, PK_LEN, T_PACKED_LEN>,
-    const k: usize,
-    const eta: i16,
-    const du: i16,
-    const dv: i16,
-    const LAMBDA: i16,
-    const T_PACKED_LEN: usize,
 > KEMEncapsulator<PK, PK_LEN, CT_LEN, SS_LEN>
-    for MLKEM<
-        PK_LEN,
-        SK_LEN,
-        FULL_SK_LEN,
-        CT_LEN,
-        SS_LEN,
-        PK,
-        SK,
-        k,
-        eta,
-        du,
-        dv,
-        LAMBDA,
-        T_PACKED_LEN,
-    >
+    for MLKEM<P, PK, SK, PK_LEN, SK_LEN, FULL_SK_LEN, CT_LEN, SS_LEN>
 {
     fn encaps(pk: &PK) -> Result<(KeyMaterial<SS_LEN>, [u8; CT_LEN]), KEMError> {
         let mut os_rng = HashDRBG_SHA512::new_from_os();
@@ -723,7 +601,7 @@ impl<
         rng: &mut dyn RNG,
     ) -> Result<(KeyMaterial<SS_LEN>, [u8; CT_LEN]), KEMError> {
         // Source the random message m from the provided RNG
-        if rng.security_strength() < SecurityStrength::from_bits(LAMBDA as usize) {
+        if rng.security_strength() < P::MAX_SECURITY_STRENGTH {
             return Err(RNGError::SecurityStrengthInsufficientForAlgorithm)?;
         }
         let mut m = [0u8; 32];
@@ -734,7 +612,7 @@ impl<
         let mut ss_keymaterial =
             KeyMaterial::<SS_LEN>::from_bytes_as_type(&ss_bytes, KeyType::CryptographicRandom)?;
         do_hazardous_operations(&mut ss_keymaterial, |ss_keymaterial| {
-            ss_keymaterial.set_security_strength(SecurityStrength::from_bits(LAMBDA as usize))
+            ss_keymaterial.set_security_strength(P::MAX_SECURITY_STRENGTH)
         })?;
 
         Ok((ss_keymaterial, ct))
@@ -742,37 +620,17 @@ impl<
 }
 
 impl<
+    P: MLKEMParams,
+    PK: MLKEMPublicKeyTrait<P, PK_LEN> + MLKEMPublicKeyInternalTrait<P, PK_LEN>,
+    SK: MLKEMPrivateKeyTrait<P, SK_LEN, FULL_SK_LEN, PK_LEN>
+        + MLKEMPrivateKeyInternalTrait<P, SK_LEN, PK_LEN>,
     const PK_LEN: usize,
     const SK_LEN: usize,
     const FULL_SK_LEN: usize,
     const CT_LEN: usize,
     const SS_LEN: usize,
-    PK: MLKEMPublicKeyTrait<k, PK_LEN, T_PACKED_LEN>
-        + MLKEMPublicKeyInternalTrait<k, T_PACKED_LEN, PK_LEN>,
-    SK: MLKEMPrivateKeyTrait<k, SK_LEN, FULL_SK_LEN, PK_LEN, T_PACKED_LEN>
-        + MLKEMPrivateKeyInternalTrait<k, SK_LEN, PK_LEN, T_PACKED_LEN>,
-    const k: usize,
-    const eta: i16,
-    const du: i16,
-    const dv: i16,
-    const LAMBDA: i16,
-    const T_PACKED_LEN: usize,
 > KEMDecapsulator<SK, SK_LEN, CT_LEN, SS_LEN>
-    for MLKEM<
-        PK_LEN,
-        SK_LEN,
-        FULL_SK_LEN,
-        CT_LEN,
-        SS_LEN,
-        PK,
-        SK,
-        k,
-        eta,
-        du,
-        dv,
-        LAMBDA,
-        T_PACKED_LEN,
-    >
+    for MLKEM<P, PK, SK, PK_LEN, SK_LEN, FULL_SK_LEN, CT_LEN, SS_LEN>
 {
     /// Performs a decapsulation of the given ciphertext.
     /// Returns the shared secret key.
@@ -789,7 +647,7 @@ impl<
         let mut ss_keymaterial =
             KeyMaterial::<SS_LEN>::from_bytes_as_type(&ss_bytes, KeyType::CryptographicRandom)?;
         do_hazardous_operations(&mut ss_keymaterial, |ss_keymaterial| {
-            ss_keymaterial.set_security_strength(SecurityStrength::from_bits(LAMBDA as usize))
+            ss_keymaterial.set_security_strength(P::MAX_SECURITY_STRENGTH)
         })?;
 
         Ok(ss_keymaterial)

--- a/crypto/mlkem-lowmemory/src/mlkem.rs
+++ b/crypto/mlkem-lowmemory/src/mlkem.rs
@@ -302,8 +302,6 @@ impl<
     /// Failing to use this properly will result in catastrophic vulnerabilities.
     /// Please don't do it.
     pub fn encaps_internal(ek: &PK, m: [u8; 32]) -> ([u8; 32], [u8; CT_LEN]) {
-        debug_assert_eq!(CT_LEN, 32 * ((P::du as usize) * P::k + (P::dv as usize)));
-
         // 1: (𝐾, 𝑟) ← G(𝑚‖H(ek))
         //  ▷ derive shared secret key 𝐾 and randomness 𝑟
         let K: [u8; MLKEM_SS_LEN];

--- a/crypto/mlkem-lowmemory/src/mlkem_keys.rs
+++ b/crypto/mlkem-lowmemory/src/mlkem_keys.rs
@@ -139,7 +139,6 @@ impl<P: MLKEMParams, const PK_LEN: usize> KEMPublicKey<PK_LEN> for MLKEMPublicKe
     /// Input:𝜌 ∈ 𝔹32, 𝐭1 ∈ 𝑅𝑘 with coefficients in [0, 2bitlen (𝑞−1)−𝑑 − 1].
     /// Output: Public key 𝑝𝑘 ∈ 𝔹32+32𝑘(bitlen (𝑞−1)−𝑑).
     fn encode(&self) -> [u8; PK_LEN] {
-        debug_assert_eq!(PK_LEN, 32 + 12 * P::k * 32);
         let mut pk = [0u8; PK_LEN];
         self.encode_out(&mut pk);
 
@@ -413,7 +412,6 @@ impl<P: MLKEMParams, const SK_LEN: usize, const FULL_SK_LEN: usize, const PK_LEN
         FULL_SK_LEN
     }
     fn sk_decode(sk: &[u8; SK_LEN]) -> Self {
-        debug_assert_eq!(SK_LEN, /* seed*/ 64);
         Self::from_bytes(sk).unwrap()
     }
 }
@@ -491,8 +489,6 @@ impl<P: MLKEMParams, const SK_LEN: usize, const FULL_SK_LEN: usize, const PK_LEN
     }
 
     fn encode_out(&self, out: &mut [u8; SK_LEN]) -> usize {
-        debug_assert_eq!(SK_LEN, 64);
-
         out.fill(0);
 
         out[..32].copy_from_slice(&*self.seed_d);

--- a/crypto/mlkem-lowmemory/src/mlkem_keys.rs
+++ b/crypto/mlkem-lowmemory/src/mlkem_keys.rs
@@ -3,27 +3,18 @@ use crate::low_memory_helpers::{
     compute_A_hat_dot_s_hat, pack_s_hat_row, pack_t_hat_row, unpack_t_hat_row,
 };
 use crate::mlkem::{G, H, POLY_BYTES, q};
-use crate::mlkem::{
-    MLKEM512_ETA1, MLKEM512_FULL_SK_LEN, MLKEM512_LAMBDA, MLKEM512_PK_LEN, MLKEM512_SK_LEN,
-    MLKEM512_T_PACKED_LEN, MLKEM512_k,
-};
-use crate::mlkem::{
-    MLKEM768_ETA1, MLKEM768_FULL_SK_LEN, MLKEM768_LAMBDA, MLKEM768_PK_LEN, MLKEM768_SK_LEN,
-    MLKEM768_T_PACKED_LEN, MLKEM768_k,
-};
-use crate::mlkem::{
-    MLKEM1024_ETA1, MLKEM1024_FULL_SK_LEN, MLKEM1024_LAMBDA, MLKEM1024_PK_LEN, MLKEM1024_SK_LEN,
-    MLKEM1024_T_PACKED_LEN, MLKEM1024_k,
-};
+use crate::mlkem::{MLKEM512_FULL_SK_LEN, MLKEM512_PK_LEN, MLKEM512_SK_LEN};
+use crate::mlkem::{MLKEM768_FULL_SK_LEN, MLKEM768_PK_LEN, MLKEM768_SK_LEN};
+use crate::mlkem::{MLKEM1024_FULL_SK_LEN, MLKEM1024_PK_LEN, MLKEM1024_SK_LEN};
+use crate::params::{MLKEM512Params, MLKEM768Params, MLKEM1024Params, MLKEMParams};
 use crate::polynomial::Polynomial;
-use crate::{ML_KEM_512_NAME, ML_KEM_768_NAME, ML_KEM_1024_NAME};
 use bouncycastle_core::errors::KEMError;
 use bouncycastle_core::key_material::{
     KeyMaterial, KeyMaterialTrait, KeyType, do_hazardous_operations,
 };
 use bouncycastle_core::traits::{Hash, KEMPrivateKey, KEMPublicKey, SecurityStrength};
 use bouncycastle_sha3::SHA3_256;
-use bouncycastle_utils::secret::Secret;
+use bouncycastle_utils::secret::{Secret, ZeroizablePrimitive};
 use core::fmt;
 use core::fmt::{Debug, Display, Formatter};
 // imports just for docs
@@ -31,53 +22,37 @@ use core::fmt::{Debug, Display, Formatter};
 /* Pub Types */
 
 /// ML-KEM-512 Public Key
-pub type MLKEM512PublicKey = MLKEMPublicKey<MLKEM512_k, MLKEM512_PK_LEN, MLKEM512_T_PACKED_LEN>;
+pub type MLKEM512PublicKey = MLKEMPublicKey<MLKEM512Params, MLKEM512_PK_LEN>;
 /// ML-KEM-512 Private Key
-pub type MLKEM512PrivateKey = MLKEMSeedPrivateKey<
-    MLKEM512_k,
-    MLKEM512_ETA1,
-    MLKEM512_LAMBDA,
-    MLKEM512_SK_LEN,
-    MLKEM512_FULL_SK_LEN,
-    MLKEM512_PK_LEN,
-    MLKEM512_T_PACKED_LEN,
->;
+pub type MLKEM512PrivateKey =
+    MLKEMSeedPrivateKey<MLKEM512Params, MLKEM512_SK_LEN, MLKEM512_FULL_SK_LEN, MLKEM512_PK_LEN>;
 /// ML-KEM-768 Public Key
-pub type MLKEM768PublicKey = MLKEMPublicKey<MLKEM768_k, MLKEM768_PK_LEN, MLKEM768_T_PACKED_LEN>;
+pub type MLKEM768PublicKey = MLKEMPublicKey<MLKEM768Params, MLKEM768_PK_LEN>;
 /// ML-KEM-768 Private Key
-pub type MLKEM768PrivateKey = MLKEMSeedPrivateKey<
-    MLKEM768_k,
-    MLKEM768_ETA1,
-    MLKEM768_LAMBDA,
-    MLKEM768_SK_LEN,
-    MLKEM768_FULL_SK_LEN,
-    MLKEM768_PK_LEN,
-    MLKEM768_T_PACKED_LEN,
->;
+pub type MLKEM768PrivateKey =
+    MLKEMSeedPrivateKey<MLKEM768Params, MLKEM768_SK_LEN, MLKEM768_FULL_SK_LEN, MLKEM768_PK_LEN>;
 /// ML-KEM-1024 Public Key
-pub type MLKEM1024PublicKey = MLKEMPublicKey<MLKEM1024_k, MLKEM1024_PK_LEN, MLKEM1024_T_PACKED_LEN>;
+pub type MLKEM1024PublicKey = MLKEMPublicKey<MLKEM1024Params, MLKEM1024_PK_LEN>;
 /// ML-KEM-1024 Private Key
-pub type MLKEM1024PrivateKey = MLKEMSeedPrivateKey<
-    MLKEM1024_k,
-    MLKEM1024_ETA1,
-    MLKEM1024_LAMBDA,
-    MLKEM1024_SK_LEN,
-    MLKEM1024_FULL_SK_LEN,
-    MLKEM1024_PK_LEN,
-    MLKEM1024_T_PACKED_LEN,
->;
+pub type MLKEM1024PrivateKey =
+    MLKEMSeedPrivateKey<MLKEM1024Params, MLKEM1024_SK_LEN, MLKEM1024_FULL_SK_LEN, MLKEM1024_PK_LEN>;
 
 /// An ML-KEM public key.
-#[derive(Clone)]
-pub struct MLKEMPublicKey<const k: usize, const PK_LEN: usize, const T_PACKED_LEN: usize> {
-    pub(crate) t_hat_packed: [u8; T_PACKED_LEN],
+pub struct MLKEMPublicKey<P: MLKEMParams, const PK_LEN: usize> {
+    pub(crate) t_hat_packed: P::TPacked,
     pub(crate) rho: [u8; 32],
 }
 
+// Written out rather than derived: `#[derive(Clone)]` would demand `P: Clone`, and `P` is a
+// marker for the parameter set that is never stored, only used to name the field types.
+impl<P: MLKEMParams, const PK_LEN: usize> Clone for MLKEMPublicKey<P, PK_LEN> {
+    fn clone(&self) -> Self {
+        Self { t_hat_packed: self.t_hat_packed, rho: self.rho }
+    }
+}
+
 /// General trait for all ML-KEM public keys types.
-pub trait MLKEMPublicKeyTrait<const k: usize, const PK_LEN: usize, const T_PACKED_LEN: usize>:
-    KEMPublicKey<PK_LEN>
-{
+pub trait MLKEMPublicKeyTrait<P: MLKEMParams, const PK_LEN: usize>: KEMPublicKey<PK_LEN> {
     /// Algorithm 23 pkDecode(𝑝𝑘)
     /// Reverses the procedure pkEncode.
     /// Input: Public key 𝑝𝑘 ∈ 𝔹32+32𝑘(bitlen (𝑞−1)−𝑑).
@@ -86,7 +61,7 @@ pub trait MLKEMPublicKeyTrait<const k: usize, const PK_LEN: usize, const T_PACKE
     fn pk_decode(pk: &[u8; PK_LEN]) -> Result<Self, KEMError>;
 
     /// Get a ref to t_hat_packed byte array
-    fn t_hat_packed(&self) -> &[u8; T_PACKED_LEN];
+    fn t_hat_packed(&self) -> &P::TPacked;
 
     /// Get a ref to rho
     fn rho(&self) -> &[u8; 32];
@@ -95,29 +70,30 @@ pub trait MLKEMPublicKeyTrait<const k: usize, const PK_LEN: usize, const T_PACKE
     fn compute_hash(&self) -> [u8; 32];
 }
 
-pub(crate) trait MLKEMPublicKeyInternalTrait<
-    const k: usize,
-    const T_PACKED_LEN: usize,
-    const PK_LEN: usize,
->: MLKEMPublicKeyTrait<k, PK_LEN, T_PACKED_LEN>
+pub(crate) trait MLKEMPublicKeyInternalTrait<P: MLKEMParams, const PK_LEN: usize>:
+    MLKEMPublicKeyTrait<P, PK_LEN>
 {
     /// Not exposing a constructor publicly because you should have to get an instance either by
     /// running a keygen, or by decoding an existing key.
-    fn new(t_hat: [u8; T_PACKED_LEN], rho: [u8; 32]) -> Self;
+    fn new(t_hat: P::TPacked, rho: [u8; 32]) -> Self;
 }
 
-impl<const k: usize, const PK_LEN: usize, const T_PACKED_LEN: usize>
-    MLKEMPublicKeyTrait<k, PK_LEN, T_PACKED_LEN> for MLKEMPublicKey<k, PK_LEN, T_PACKED_LEN>
+impl<P: MLKEMParams, const PK_LEN: usize> MLKEMPublicKeyTrait<P, PK_LEN>
+    for MLKEMPublicKey<P, PK_LEN>
 {
     fn pk_decode(pk: &[u8; PK_LEN]) -> Result<Self, KEMError> {
         let pk = Self::new(
-            pk[..T_PACKED_LEN].try_into().unwrap(),
-            pk[T_PACKED_LEN..].try_into().unwrap(),
+            {
+                let mut t = <P::TPacked as ZeroizablePrimitive>::ZEROED;
+                t.as_mut().copy_from_slice(&pk[..P::T_PACKED_LEN]);
+                t
+            },
+            pk[P::T_PACKED_LEN..].try_into().unwrap(),
         );
 
         // check that all entries are in range
-        for i in 0..k {
-            let p = unpack_t_hat_row(&pk.t_hat_packed, i);
+        for i in 0..P::k {
+            let p = unpack_t_hat_row(pk.t_hat_packed.as_ref(), i);
             for w in p.coeffs.iter() {
                 if *w >= q {
                     return Err(KEMError::DecodingError("Invalid public key"));
@@ -128,7 +104,7 @@ impl<const k: usize, const PK_LEN: usize, const T_PACKED_LEN: usize>
         Ok(pk)
     }
 
-    fn t_hat_packed(&self) -> &[u8; T_PACKED_LEN] {
+    fn t_hat_packed(&self) -> &P::TPacked {
         &self.t_hat_packed
     }
 
@@ -141,7 +117,7 @@ impl<const k: usize, const PK_LEN: usize, const T_PACKED_LEN: usize>
 
         let mut out = [0u8; 32];
         let mut h = H::default();
-        h.do_update(&self.t_hat_packed);
+        h.do_update(self.t_hat_packed.as_ref());
         h.do_update(&self.rho);
         let bytes_written = h.do_final_out(&mut out);
         debug_assert_eq!(bytes_written, 32);
@@ -149,24 +125,21 @@ impl<const k: usize, const PK_LEN: usize, const T_PACKED_LEN: usize>
     }
 }
 
-impl<const k: usize, const T_PACKED_LEN: usize, const PK_LEN: usize>
-    MLKEMPublicKeyInternalTrait<k, T_PACKED_LEN, PK_LEN>
-    for MLKEMPublicKey<k, PK_LEN, T_PACKED_LEN>
+impl<P: MLKEMParams, const PK_LEN: usize> MLKEMPublicKeyInternalTrait<P, PK_LEN>
+    for MLKEMPublicKey<P, PK_LEN>
 {
-    fn new(t_hat_packed: [u8; T_PACKED_LEN], rho: [u8; 32]) -> Self {
+    fn new(t_hat_packed: P::TPacked, rho: [u8; 32]) -> Self {
         Self { rho, t_hat_packed }
     }
 }
 
-impl<const k: usize, const PK_LEN: usize, const T_PACKED_LEN: usize> KEMPublicKey<PK_LEN>
-    for MLKEMPublicKey<k, PK_LEN, T_PACKED_LEN>
-{
+impl<P: MLKEMParams, const PK_LEN: usize> KEMPublicKey<PK_LEN> for MLKEMPublicKey<P, PK_LEN> {
     /// Algorithm 22 pkEncode(𝜌, 𝐭1)
     /// Encodes a public key for ML-DSA into a byte string.
     /// Input:𝜌 ∈ 𝔹32, 𝐭1 ∈ 𝑅𝑘 with coefficients in [0, 2bitlen (𝑞−1)−𝑑 − 1].
     /// Output: Public key 𝑝𝑘 ∈ 𝔹32+32𝑘(bitlen (𝑞−1)−𝑑).
     fn encode(&self) -> [u8; PK_LEN] {
-        debug_assert_eq!(PK_LEN, 32 + 12 * k * 32);
+        debug_assert_eq!(PK_LEN, 32 + 12 * P::k * 32);
         let mut pk = [0u8; PK_LEN];
         self.encode_out(&mut pk);
 
@@ -174,13 +147,14 @@ impl<const k: usize, const PK_LEN: usize, const T_PACKED_LEN: usize> KEMPublicKe
     }
 
     fn encode_out(&self, out: &mut [u8; PK_LEN]) -> usize {
-        debug_assert_eq!(self.t_hat_packed.len(), T_PACKED_LEN);
+        // Check length
+        debug_assert_eq!(self.t_hat_packed.as_ref().len(), P::T_PACKED_LEN);
 
         out.fill(0);
 
-        out[..T_PACKED_LEN].copy_from_slice(&self.t_hat_packed);
-        debug_assert_eq!(out[T_PACKED_LEN..].len(), 32);
-        out[T_PACKED_LEN..].copy_from_slice(&self.rho);
+        out[..P::T_PACKED_LEN].copy_from_slice(self.t_hat_packed.as_ref());
+        debug_assert_eq!(out[P::T_PACKED_LEN..].len(), 32);
+        out[P::T_PACKED_LEN..].copy_from_slice(&self.rho);
 
         PK_LEN
     }
@@ -194,60 +168,36 @@ impl<const k: usize, const PK_LEN: usize, const T_PACKED_LEN: usize> KEMPublicKe
     }
 }
 
-impl<const k: usize, const PK_LEN: usize, const T_PACKED_LEN: usize> Eq
-    for MLKEMPublicKey<k, PK_LEN, T_PACKED_LEN>
-{
-}
+impl<P: MLKEMParams, const PK_LEN: usize> Eq for MLKEMPublicKey<P, PK_LEN> {}
 
-impl<const k: usize, const PK_LEN: usize, const T_PACKED_LEN: usize> PartialEq
-    for MLKEMPublicKey<k, PK_LEN, T_PACKED_LEN>
-{
+impl<P: MLKEMParams, const PK_LEN: usize> PartialEq for MLKEMPublicKey<P, PK_LEN> {
     fn eq(&self, other: &Self) -> bool {
         bouncycastle_utils::ct::ct_eq_bytes(&self.encode(), &other.encode())
     }
 }
 
-impl<const k: usize, const PK_LEN: usize, const T_PACKED_LEN: usize> Debug
-    for MLKEMPublicKey<k, PK_LEN, T_PACKED_LEN>
-{
+impl<P: MLKEMParams, const PK_LEN: usize> Debug for MLKEMPublicKey<P, PK_LEN> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        let alg = match k {
-            2 => ML_KEM_512_NAME,
-            3 => ML_KEM_768_NAME,
-            4 => ML_KEM_1024_NAME,
-            _ => panic!("Unsupported key length"),
-        };
         let hash = SHA3_256::new().hash(&self.encode());
-        write!(f, "MLKEMPublicKey {{ alg: {}, pub_key_hash: {:x?} }}", alg, hash)
+        write!(f, "MLKEMPublicKey {{ alg: {}, pub_key_hash: {:x?} }}", P::ALG_NAME, hash)
     }
 }
 
-impl<const k: usize, const PK_LEN: usize, const T_PACKED_LEN: usize> Display
-    for MLKEMPublicKey<k, PK_LEN, T_PACKED_LEN>
-{
+impl<P: MLKEMParams, const PK_LEN: usize> Display for MLKEMPublicKey<P, PK_LEN> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        let alg = match k {
-            2 => ML_KEM_512_NAME,
-            3 => ML_KEM_768_NAME,
-            4 => ML_KEM_1024_NAME,
-            _ => panic!("Unsupported key length"),
-        };
         let hash = SHA3_256::new().hash(&self.encode());
-        write!(f, "MLKEMPublicKey {{ alg: {}, pub_key_hash: {:x?} }}", alg, hash)
+        write!(f, "MLKEMPublicKey {{ alg: {}, pub_key_hash: {:x?} }}", P::ALG_NAME, hash)
     }
 }
 
 /// An ML-KEM private key.
-#[derive(Clone)]
 pub struct MLKEMSeedPrivateKey<
-    const k: usize,
-    const eta1: i16,
-    const LAMBDA: i16,
+    P: MLKEMParams,
     const SK_LEN: usize,
     const FULL_SK_LEN: usize,
     const PK_LEN: usize,
-    const T_PACKED_LEN: usize,
 > {
+    _phantom: core::marker::PhantomData<P>,
     rho: [u8; 32],
     sigma: Secret<[u8; 32]>,
     pk_hash: Option<[u8; 32]>,
@@ -255,15 +205,24 @@ pub struct MLKEMSeedPrivateKey<
     seed_d: Secret<[u8; 32]>,
 }
 
-impl<
-    const k: usize,
-    const eta1: i16,
-    const LAMBDA: i16,
-    const SK_LEN: usize,
-    const FULL_SK_LEN: usize,
-    const PK_LEN: usize,
-    const T_PACKED_LEN: usize,
-> MLKEMSeedPrivateKey<k, eta1, LAMBDA, SK_LEN, FULL_SK_LEN, PK_LEN, T_PACKED_LEN>
+/// See the note on [`MLKEMPublicKey`]'s `Clone` for why this is not derived.
+impl<P: MLKEMParams, const SK_LEN: usize, const FULL_SK_LEN: usize, const PK_LEN: usize> Clone
+    for MLKEMSeedPrivateKey<P, SK_LEN, FULL_SK_LEN, PK_LEN>
+{
+    fn clone(&self) -> Self {
+        Self {
+            _phantom: core::marker::PhantomData,
+            rho: self.rho,
+            sigma: self.sigma.clone(),
+            pk_hash: self.pk_hash,
+            z: self.z.clone(),
+            seed_d: self.seed_d.clone(),
+        }
+    }
+}
+
+impl<P: MLKEMParams, const SK_LEN: usize, const FULL_SK_LEN: usize, const PK_LEN: usize>
+    MLKEMSeedPrivateKey<P, SK_LEN, FULL_SK_LEN, PK_LEN>
 {
     /// Create a new MLKEMSeedPrivateKey from a 64-byte KeyMaterial.
     /// Seed SecurityStrength must match algorithm security strength: 128-bit (ML-KEM-512), 192-bit (ML-KEM-768), or 256-bit (ML-KEM-1024).
@@ -276,7 +235,7 @@ impl<
             ));
         }
 
-        if seed.security_strength() < SecurityStrength::from_bits(LAMBDA as usize) {
+        if seed.security_strength() < P::MAX_SECURITY_STRENGTH {
             return Err(KEMError::KeyGenError("SecurityStrength"));
         }
 
@@ -291,7 +250,7 @@ impl<
 
         // Deviation from the FIPS: The implementation does not persist the hash of the public key H(ek) in the
         // in-memory representation because it can be re-computed as needed.
-        Ok(Self { rho, sigma, pk_hash: None, z, seed_d })
+        Ok(Self { _phantom: core::marker::PhantomData, rho, sigma, pk_hash: None, z, seed_d })
     }
     /// Algorithm 13 K-PKE.KeyGen(𝑑)
     /// 1: (𝜌, 𝜎) ← G(𝑑‖𝑘)
@@ -305,7 +264,7 @@ impl<
 
         let mut g = G::new();
         g.do_update(seed_d);
-        g.do_update(&[k as u8]);
+        g.do_update(&[P::k as u8]);
         let bytes_written = g.do_final_out(buf.as_mut());
         debug_assert_eq!(bytes_written, 64);
 
@@ -318,11 +277,10 @@ impl<
 
 /// General trait for all ML-KEM private keys types.
 pub trait MLKEMPrivateKeyTrait<
-    const k: usize,
+    P: MLKEMParams,
     const SK_LEN: usize,
     const FULL_SK_LEN: usize,
     const PK_LEN: usize,
-    const T_PACKED_LEN: usize,
 >: KEMPrivateKey<SK_LEN>
 {
     /// New from KeyMaterial. Can throw a KEMError if the KeyMaterial does not contain sufficient entropy.
@@ -332,7 +290,7 @@ pub trait MLKEMPrivateKeyTrait<
     fn seed(&self) -> Option<KeyMaterial<64>>;
     /// Runs essentially a full keygen according to Algorithm 13.
     // Dev note: This is a partial implementation of keygen_internal(), and probably not allowed in FIPS mode.
-    fn pk(&self) -> MLKEMPublicKey<k, PK_LEN, T_PACKED_LEN>;
+    fn pk(&self) -> MLKEMPublicKey<P, PK_LEN>;
     /// Get a ref to the stored public key hash.
     /// Since in this implementation, this requires running the full keygen, this is a lazy evaluation and
     /// will only be computationally heavy the first time it is called for a given key.
@@ -362,10 +320,9 @@ pub trait MLKEMPrivateKeyTrait<
 }
 
 pub(crate) trait MLKEMPrivateKeyInternalTrait<
-    const k: usize,
+    P: MLKEMParams,
     const SK_LEN: usize,
     const PK_LEN: usize,
-    const T_PACKED_LEN: usize,
 >
 {
     fn z(&self) -> &[u8; 32];
@@ -375,19 +332,12 @@ pub(crate) trait MLKEMPrivateKeyInternalTrait<
     fn rho(&self) -> &[u8; 32];
 
     /// Note: this one is not a ref because the data does not exist in the private key.
-    fn t_hat_packed(&self) -> [u8; T_PACKED_LEN];
+    fn t_hat_packed(&self) -> P::TPacked;
 }
 
-impl<
-    const k: usize,
-    const eta1: i16,
-    const LAMBDA: i16,
-    const SK_LEN: usize,
-    const FULL_SK_LEN: usize,
-    const PK_LEN: usize,
-    const T_PACKED_LEN: usize,
-> MLKEMPrivateKeyTrait<k, SK_LEN, FULL_SK_LEN, PK_LEN, T_PACKED_LEN>
-    for MLKEMSeedPrivateKey<k, eta1, LAMBDA, SK_LEN, FULL_SK_LEN, PK_LEN, T_PACKED_LEN>
+impl<P: MLKEMParams, const SK_LEN: usize, const FULL_SK_LEN: usize, const PK_LEN: usize>
+    MLKEMPrivateKeyTrait<P, SK_LEN, FULL_SK_LEN, PK_LEN>
+    for MLKEMSeedPrivateKey<P, SK_LEN, FULL_SK_LEN, PK_LEN>
 {
     fn from_keymaterial(seed: &KeyMaterial<64>) -> Result<Self, KEMError> {
         Self::new(seed)
@@ -398,19 +348,14 @@ impl<
         tmp[32..].as_mut().copy_from_slice(&*self.z);
         let mut seed = KeyMaterial::<64>::from_bytes_as_type(&*tmp, KeyType::Seed).unwrap();
         do_hazardous_operations(&mut seed, |seed| {
-            seed.set_security_strength(match k {
-                2 => SecurityStrength::_128bit,
-                3 => SecurityStrength::_192bit,
-                4 => SecurityStrength::_256bit,
-                _ => unreachable!("Invalid mlkem param set"),
-            })
+            seed.set_security_strength(P::MAX_SECURITY_STRENGTH)
         })
         .unwrap();
 
         Some(seed)
     }
-    fn pk(&self) -> MLKEMPublicKey<k, PK_LEN, T_PACKED_LEN> {
-        MLKEMPublicKey::<k, PK_LEN, T_PACKED_LEN>::new(self.t_hat_packed(), self.rho)
+    fn pk(&self) -> MLKEMPublicKey<P, PK_LEN> {
+        MLKEMPublicKey::<P, PK_LEN>::new(self.t_hat_packed(), self.rho)
     }
     fn pk_hash(&mut self) -> &[u8; 32] {
         if self.pk_hash.is_none() {
@@ -447,10 +392,10 @@ impl<
 
         /* dk_pke */
         // Alg 13; line 20: dkPKE ← ByteEncode12(𝐬)
-        for i in 0..k {
-            pack_s_hat_row::<k>(&self.compute_s_hat_row(i), i, out);
+        for i in 0..P::k {
+            pack_s_hat_row::<P>(&self.compute_s_hat_row(i), i, out);
         }
-        pos += k * POLY_BYTES;
+        pos += P::k * POLY_BYTES;
 
         /* ek */
         // Alg 13; line 19: ekPKE ← ByteEncode12(𝐭)‖𝜌
@@ -473,32 +418,25 @@ impl<
     }
 }
 
-impl<
-    const k: usize,
-    const eta1: i16,
-    const LAMBDA: i16,
-    const SK_LEN: usize,
-    const FULL_SK_LEN: usize,
-    const PK_LEN: usize,
-    const T_PACKED_LEN: usize,
-> MLKEMPrivateKeyInternalTrait<k, SK_LEN, PK_LEN, T_PACKED_LEN>
-    for MLKEMSeedPrivateKey<k, eta1, LAMBDA, SK_LEN, FULL_SK_LEN, PK_LEN, T_PACKED_LEN>
+impl<P: MLKEMParams, const SK_LEN: usize, const FULL_SK_LEN: usize, const PK_LEN: usize>
+    MLKEMPrivateKeyInternalTrait<P, SK_LEN, PK_LEN>
+    for MLKEMSeedPrivateKey<P, SK_LEN, FULL_SK_LEN, PK_LEN>
 {
     fn z(&self) -> &[u8; 32] {
         &self.z
     }
 
     fn compute_s_hat_row(&self, idx: usize) -> Polynomial {
-        debug_assert!(idx < k);
+        debug_assert!(idx < P::k);
 
         // We're doing just one row of this:
         // 8: for (𝑖 ← 0; 𝑖 < 𝑘; 𝑖++)
-        //  ▷ generate 𝐬 ∈ (ℤ256)^k
+        //  ▷ generate 𝐬 ∈ (ℤ256)^P::k
         // 9: 𝐬[𝑖] ← SamplePolyCBD𝜂1(PRF𝜂1 (𝜎, 𝑁 ))
         //   ▷ 𝐬[𝑖] ∈ ℤ256 sampled from CBD
         // 10: 𝑁 ← 𝑁 + 1
         // Note: here n = 0
-        let mut s_i = sample_poly_CBD::<eta1>(&self.sigma, idx as u8);
+        let mut s_i = sample_poly_CBD(&self.sigma, idx as u8, P::eta1);
 
         // 16: 𝐬_hat ← NTT(𝐬)̂
         s_i.ntt();
@@ -510,47 +448,39 @@ impl<
     }
     /// Runs essentially a full keygen according to Algorithm 13
     /// Outputs t_hat in the packed encoding specified in FIPS 203
-    fn t_hat_packed(&self) -> [u8; T_PACKED_LEN] {
-        let mut t_hat_packed = [0u8; T_PACKED_LEN];
+    fn t_hat_packed(&self) -> P::TPacked {
+        let mut t_hat_packed = <P::TPacked as ZeroizablePrimitive>::ZEROED;
 
-        for i in 0..k {
+        for i in 0..P::k {
             // first half of
             // 18: 𝐭_hat ← 𝐀_hat ∘ 𝐬_hat + 𝐞_hat
-            let mut t_hat_i = compute_A_hat_dot_s_hat::<k, eta1>(&self.rho, &self.sigma, i);
+            let mut t_hat_i = compute_A_hat_dot_s_hat::<P>(&self.rho, &self.sigma, i);
 
             // second half of
             // 18: 𝐭_hat ← 𝐀_hat ∘ 𝐬_hat + 𝐞_hat
             {
                 // 12: for (𝑖 ← 0; 𝑖 < 𝑘; 𝑖++)
-                //  ▷ generate 𝐞 ∈ (ℤ256)^k
+                //  ▷ generate 𝐞 ∈ (ℤ256)^P::k
                 // 13: 𝐞[𝑖] ← SamplePolyCBD𝜂1(PRF𝜂1 (𝜎, 𝑁))
                 //   ▷ 𝐞[𝑖] ∈ ℤ256 sampled from CBD
                 // 14: 𝑁 ← 𝑁 + 1
-                // Note: here n = k
-                let mut e_i = sample_poly_CBD::<eta1>(&self.sigma, (k + i) as u8);
+                // Note: here n = P::k
+                let mut e_i = sample_poly_CBD(&self.sigma, (P::k + i) as u8, P::eta1);
 
                 e_i.ntt(); // technically now e_hat_i
                 t_hat_i.add(&e_i);
             }
             t_hat_i.poly_reduce();
 
-            pack_t_hat_row::<T_PACKED_LEN>(&t_hat_i, i, &mut t_hat_packed);
+            pack_t_hat_row::<P>(&t_hat_i, i, &mut t_hat_packed);
         }
 
         t_hat_packed
     }
 }
 
-impl<
-    const k: usize,
-    const eta1: i16,
-    const LAMBDA: i16,
-    const SK_LEN: usize,
-    const FULL_SK_LEN: usize,
-    const PK_LEN: usize,
-    const T_PACKED_LEN: usize,
-> KEMPrivateKey<SK_LEN>
-    for MLKEMSeedPrivateKey<k, eta1, LAMBDA, SK_LEN, FULL_SK_LEN, PK_LEN, T_PACKED_LEN>
+impl<P: MLKEMParams, const SK_LEN: usize, const FULL_SK_LEN: usize, const PK_LEN: usize>
+    KEMPrivateKey<SK_LEN> for MLKEMSeedPrivateKey<P, SK_LEN, FULL_SK_LEN, PK_LEN>
 {
     /// Encode the private key as a 64-byte seed (d || z)
     fn encode(&self) -> [u8; SK_LEN] {
@@ -585,27 +515,13 @@ impl<
     }
 }
 
-impl<
-    const k: usize,
-    const eta1: i16,
-    const LAMBDA: i16,
-    const SK_LEN: usize,
-    const FULL_SK_LEN: usize,
-    const PK_LEN: usize,
-    const T_PACKED_LEN: usize,
-> Eq for MLKEMSeedPrivateKey<k, eta1, LAMBDA, SK_LEN, FULL_SK_LEN, PK_LEN, T_PACKED_LEN>
+impl<P: MLKEMParams, const SK_LEN: usize, const FULL_SK_LEN: usize, const PK_LEN: usize> Eq
+    for MLKEMSeedPrivateKey<P, SK_LEN, FULL_SK_LEN, PK_LEN>
 {
 }
 
-impl<
-    const k: usize,
-    const eta1: i16,
-    const LAMBDA: i16,
-    const SK_LEN: usize,
-    const FULL_SK_LEN: usize,
-    const PK_LEN: usize,
-    const T_PACKED_LEN: usize,
-> PartialEq for MLKEMSeedPrivateKey<k, eta1, LAMBDA, SK_LEN, FULL_SK_LEN, PK_LEN, T_PACKED_LEN>
+impl<P: MLKEMParams, const SK_LEN: usize, const FULL_SK_LEN: usize, const PK_LEN: usize> PartialEq
+    for MLKEMSeedPrivateKey<P, SK_LEN, FULL_SK_LEN, PK_LEN>
 {
     fn eq(&self, other: &Self) -> bool {
         let self_encoded = self.encode();
@@ -615,47 +531,21 @@ impl<
 }
 
 /// Debug impl mainly to prevent the secret key from being printed in logs.
-impl<
-    const k: usize,
-    const eta1: i16,
-    const LAMBDA: i16,
-    const SK_LEN: usize,
-    const FULL_SK_LEN: usize,
-    const PK_LEN: usize,
-    const T_PACKED_LEN: usize,
-> fmt::Debug for MLKEMSeedPrivateKey<k, eta1, LAMBDA, SK_LEN, FULL_SK_LEN, PK_LEN, T_PACKED_LEN>
+impl<P: MLKEMParams, const SK_LEN: usize, const FULL_SK_LEN: usize, const PK_LEN: usize> fmt::Debug
+    for MLKEMSeedPrivateKey<P, SK_LEN, FULL_SK_LEN, PK_LEN>
 {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        let alg = match k {
-            2 => ML_KEM_512_NAME,
-            3 => ML_KEM_768_NAME,
-            4 => ML_KEM_1024_NAME,
-            _ => panic!("Unsupported key length"),
-        };
         let pk_hash = self.pk().compute_hash();
-        write!(f, "MLKEMSeedPrivateKey {{ alg: {}, pub_key_hash: {:x?} }}", alg, &pk_hash,)
+        write!(f, "MLKEMSeedPrivateKey {{ alg: {}, pub_key_hash: {:x?} }}", P::ALG_NAME, &pk_hash,)
     }
 }
 
 /// Display impl mainly to prevent the secret key from being printed in logs.
-impl<
-    const k: usize,
-    const eta1: i16,
-    const LAMBDA: i16,
-    const SK_LEN: usize,
-    const FULL_SK_LEN: usize,
-    const PK_LEN: usize,
-    const T_PACKED_LEN: usize,
-> Display for MLKEMSeedPrivateKey<k, eta1, LAMBDA, SK_LEN, FULL_SK_LEN, PK_LEN, T_PACKED_LEN>
+impl<P: MLKEMParams, const SK_LEN: usize, const FULL_SK_LEN: usize, const PK_LEN: usize> Display
+    for MLKEMSeedPrivateKey<P, SK_LEN, FULL_SK_LEN, PK_LEN>
 {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        let alg = match k {
-            2 => ML_KEM_512_NAME,
-            3 => ML_KEM_768_NAME,
-            4 => ML_KEM_1024_NAME,
-            _ => panic!("Unsupported key length"),
-        };
         let pk_hash = self.pk().compute_hash();
-        write!(f, "MLKEMSeedPrivateKey {{ alg: {}, pub_key_hash: {:x?} }}", alg, &pk_hash,)
+        write!(f, "MLKEMSeedPrivateKey {{ alg: {}, pub_key_hash: {:x?} }}", P::ALG_NAME, &pk_hash,)
     }
 }

--- a/crypto/mlkem-lowmemory/src/params.rs
+++ b/crypto/mlkem-lowmemory/src/params.rs
@@ -1,0 +1,249 @@
+//! The three ML-KEM parameter sets of FIPS 203, Section 8, as a sealed trait with one type per set.
+//!
+//! This mirrors `bouncycastle_mlkem::params`, minus the vector and matrix types: this crate never
+//! materializes 𝐀̂ or a whole polynomial vector, so the only parameter-sized type it needs is a
+//! byte buffer for the packed 𝐭̂.
+//!
+//! # Derived parameters
+//!
+//! FIPS 203, Table 2 assigns five values per set (𝑘, 𝜂1, 𝜂2, 𝑑𝑢, 𝑑𝑣); its last column, the
+//! required RBG strength, is carried by `MAX_SECURITY_STRENGTH`.
+//! The sizes of Table 3 are each a function of those, so they are written once as defaulted
+//! associated consts rather than three times as a hand-computed number. `params::tests` checks every
+//! derivation against the values tabulated in FIPS 203.
+
+use crate::mlkem::{
+    ML_KEM_512_NAME, ML_KEM_768_NAME, ML_KEM_1024_NAME, MLKEM_SEED_LEN, MLKEM_SS_LEN,
+};
+use bouncycastle_core::traits::SecurityStrength;
+use bouncycastle_utils::secret::ZeroizablePrimitive;
+
+/// A fixed-size byte buffer whose length depends on the parameter set.
+///
+/// [`ZeroizablePrimitive`] rather than [`Default`] supplies the all-zero value, because `Default`
+/// for arrays stops at 32 elements and every buffer here is longer than that.
+trait ByteBuffer: ZeroizablePrimitive + AsRef<[u8]> + AsMut<[u8]> {}
+impl<const N: usize> ByteBuffer for [u8; N] {}
+
+/// A crate-private (aka "sealed") trait that prevents a new ML-KEM parameter set from being defined
+/// outside this crate.
+trait MLKEMParamsInternalTrait {}
+
+/// One ML-KEM parameter set: the values of FIPS 203, Table 2 and Table 3, and the types whose size
+/// they determine.
+///
+/// Sealed via a private supertrait, so [`MLKEM512Params`], [`MLKEM768Params`] and
+/// [`MLKEM1024Params`] are the only implementations.
+pub trait MLKEMParams: MLKEMParamsInternalTrait {
+    /* FIPS 203, Table 2: the values assigned by each parameter set. */
+
+    /// 𝑘, the rank of the module.
+    const k: usize;
+    /// 𝜂1, the CBD parameter used for the secret vector 𝐬 and the keygen error vector 𝐞.
+    const eta1: i16;
+    /// 𝜂2, the CBD parameter used for the encaps error terms 𝐞1 and 𝑒2.
+    ///
+    /// FIPS 203, Table 2 lists this per parameter set even though all three assign it 2.
+    const eta2: i16;
+    /// 𝑑𝑢, the compression parameter for 𝐮.
+    const du: i16;
+    /// 𝑑𝑣, the compression parameter for 𝑣.
+    const dv: i16;
+
+    /* Algorithm meta-data */
+
+    /// The algorithm name, as reported by `Algorithm::ALG_NAME`.
+    const ALG_NAME: &'static str;
+    /// The strength claimed for this parameter set, as reported by `Algorithm::MAX_SECURITY_STRENGTH`.
+    const MAX_SECURITY_STRENGTH: SecurityStrength;
+    /// The OID in component form, as reported by `AlgorithmOID::OID`.
+    const OID: &'static [u32];
+    /// The DER encoding of [`MLKEMParams::OID`], as reported by `AlgorithmOID::OID_DER`.
+    const OID_DER: &'static [u8];
+
+    /* Derived. Never written out per parameter set -- see the module docs. */
+
+    /// The length of an encapsulation key: FIPS 203, Algorithm 16 (ML-KEM.KeyGen) gives
+    /// ek ∈ 𝔹^(384𝑘+32).
+    const PK_LEN: usize = 384 * Self::k + 32;
+
+    /// The length of the FIPS 203 encoding of a decapsulation key: Algorithm 16 gives
+    /// dk ∈ 𝔹^(768𝑘+96).
+    ///
+    /// Named `FULL_SK_LEN` rather than `SK_LEN` because this crate's private keys are held as the
+    /// 64-byte seed and expanded on demand; see [`MLKEMParams::SK_LEN`].
+    const FULL_SK_LEN: usize = 768 * Self::k + 96;
+
+    /// The length of a ciphertext: FIPS 203, Algorithm 17 (ML-KEM.Encaps) gives
+    /// 𝑐 ∈ 𝔹^(32(𝑑𝑢𝑘+𝑑𝑣)).
+    const CT_LEN: usize = 32 * (Self::du as usize * Self::k + Self::dv as usize);
+
+    /// The length of a private key as this crate stores it: the 64-byte seed (𝑑, 𝑧), for every
+    /// parameter set.
+    const SK_LEN: usize = MLKEM_SEED_LEN;
+
+    /// The length of a shared secret. 32 bytes for every parameter set (FIPS 203, Table 3).
+    const SS_LEN: usize = MLKEM_SS_LEN;
+
+    /// The packed length of 𝐭̂: 𝑘 polynomials of 12-bit coefficients, i.e. 384𝑘 bytes. This is the
+    /// encapsulation key without its trailing 32-byte 𝜌.
+    const T_PACKED_LEN: usize = 12 * Self::k * 32;
+
+    /* Types whose size depends on the parameter set. */
+
+    /// The packed 𝐭̂, of [`MLKEMParams::T_PACKED_LEN`] bytes.
+    type TPacked: ByteBuffer;
+}
+
+/// The ML-KEM-512 parameter set (FIPS 203, Table 2).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MLKEM512Params;
+/// The ML-KEM-768 parameter set (FIPS 203, Table 2).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MLKEM768Params;
+/// The ML-KEM-1024 parameter set (FIPS 203, Table 2).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MLKEM1024Params;
+
+impl MLKEMParamsInternalTrait for MLKEM512Params {}
+impl MLKEMParamsInternalTrait for MLKEM768Params {}
+impl MLKEMParamsInternalTrait for MLKEM1024Params {}
+
+impl MLKEMParams for MLKEM512Params {
+    const k: usize = 2;
+    const eta1: i16 = 3;
+    const eta2: i16 = 2;
+    const du: i16 = 10;
+    const dv: i16 = 4;
+
+    const ALG_NAME: &'static str = ML_KEM_512_NAME;
+    const MAX_SECURITY_STRENGTH: SecurityStrength = SecurityStrength::_128bit;
+    /// Assigned by NIST in the Computer Security Objects Register: id-alg-ml-kem-512 { kems 1 }
+    const OID: &'static [u32] = &[2, 16, 840, 1, 101, 3, 4, 4, 1];
+    const OID_DER: &'static [u8] =
+        &[0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x04, 0x01];
+
+    type TPacked = [u8; 768]; // 384 * 2
+}
+
+impl MLKEMParams for MLKEM768Params {
+    const k: usize = 3;
+    const eta1: i16 = 2;
+    const eta2: i16 = 2;
+    const du: i16 = 10;
+    const dv: i16 = 4;
+
+    const ALG_NAME: &'static str = ML_KEM_768_NAME;
+    const MAX_SECURITY_STRENGTH: SecurityStrength = SecurityStrength::_192bit;
+    /// Assigned by NIST in the Computer Security Objects Register: id-alg-ml-kem-768 { kems 2 }
+    const OID: &'static [u32] = &[2, 16, 840, 1, 101, 3, 4, 4, 2];
+    const OID_DER: &'static [u8] =
+        &[0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x04, 0x02];
+
+    type TPacked = [u8; 1152]; // 384 * 3
+}
+
+impl MLKEMParams for MLKEM1024Params {
+    const k: usize = 4;
+    const eta1: i16 = 2;
+    const eta2: i16 = 2;
+    const du: i16 = 11;
+    const dv: i16 = 5;
+
+    const ALG_NAME: &'static str = ML_KEM_1024_NAME;
+    const MAX_SECURITY_STRENGTH: SecurityStrength = SecurityStrength::_256bit;
+    /// Assigned by NIST in the Computer Security Objects Register: id-alg-ml-kem-1024 { kems 3 }
+    const OID: &'static [u32] = &[2, 16, 840, 1, 101, 3, 4, 4, 3];
+    const OID_DER: &'static [u8] =
+        &[0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x04, 0x03];
+
+    type TPacked = [u8; 1536]; // 384 * 4
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// FIPS 203, Table 2, transcribed row by row: the five values each parameter set
+    /// assigns, plus its last column. `(k, eta1, eta2, du, dv, rbg_strength)`.
+    const TABLE_2: [(usize, i16, i16, i16, i16, i16); 3] =
+        [(2, 3, 2, 10, 4, 128), (3, 2, 2, 10, 4, 192), (4, 2, 2, 11, 5, 256)];
+
+    /// FIPS 203, Table 3, transcribed row by row, in bytes:
+    /// `(encapsulation key, decapsulation key, ciphertext, shared secret key)`. The decapsulation
+    /// key column is the full FIPS encoding, which this crate calls `FULL_SK_LEN`.
+    const TABLE_3: [(usize, usize, usize, usize); 3] =
+        [(800, 1632, 768, 32), (1184, 2400, 1088, 32), (1568, 3168, 1568, 32)];
+
+    fn check_table_2<P: MLKEMParams>(i: usize) {
+        let (k, eta1, eta2, du, dv, rbg_strength) = TABLE_2[i];
+        assert_eq!(P::k, k, "{}: 𝑘", P::ALG_NAME);
+        assert_eq!(P::eta1, eta1, "{}: 𝜂1", P::ALG_NAME);
+        assert_eq!(P::eta2, eta2, "{}: 𝜂2", P::ALG_NAME);
+        assert_eq!(P::du, du, "{}: 𝑑𝑢", P::ALG_NAME);
+        assert_eq!(P::dv, dv, "{}: 𝑑𝑣", P::ALG_NAME);
+        assert_eq!(
+            P::MAX_SECURITY_STRENGTH,
+            SecurityStrength::from_bits(rbg_strength as usize),
+            "{}: required RBG strength",
+            P::ALG_NAME
+        );
+    }
+
+    fn check_table_3<P: MLKEMParams>(i: usize) {
+        let (pk_len, full_sk_len, ct_len, ss_len) = TABLE_3[i];
+        assert_eq!(P::PK_LEN, pk_len, "{}: encapsulation key size", P::ALG_NAME);
+        assert_eq!(P::FULL_SK_LEN, full_sk_len, "{}: decapsulation key size", P::ALG_NAME);
+        assert_eq!(P::CT_LEN, ct_len, "{}: ciphertext size", P::ALG_NAME);
+        assert_eq!(P::SS_LEN, ss_len, "{}: shared secret size", P::ALG_NAME);
+        // This crate stores the seed, not the expanded key, for every parameter set.
+        assert_eq!(P::SK_LEN, 64, "{}: stored private key size", P::ALG_NAME);
+    }
+
+    fn check_associated_type_sizes<P: MLKEMParams>() {
+        assert_eq!(
+            size_of::<P::TPacked>(),
+            P::T_PACKED_LEN,
+            "{}: TPacked vs T_PACKED_LEN",
+            P::ALG_NAME
+        );
+        // The encapsulation key is the packed 𝐭̂ followed by the 32-byte 𝜌.
+        assert_eq!(P::T_PACKED_LEN + 32, P::PK_LEN, "{}: 384𝑘 + 32 = PK_LEN", P::ALG_NAME);
+    }
+
+    #[test]
+    fn test_parameter_sets_match_fips203_table_2() {
+        check_table_2::<MLKEM512Params>(0);
+        check_table_2::<MLKEM768Params>(1);
+        check_table_2::<MLKEM1024Params>(2);
+    }
+
+    #[test]
+    fn test_sizes_match_fips203_table_3() {
+        check_table_3::<MLKEM512Params>(0);
+        check_table_3::<MLKEM768Params>(1);
+        check_table_3::<MLKEM1024Params>(2);
+    }
+
+    #[test]
+    fn test_associated_types_are_the_length_their_consts_claim() {
+        check_associated_type_sizes::<MLKEM512Params>();
+        check_associated_type_sizes::<MLKEM768Params>();
+        check_associated_type_sizes::<MLKEM1024Params>();
+    }
+
+    /// Each of the sizes of Table 3 also has a formula in FIPS 203, and the two must agree.
+    /// Table 3 is what is written down above; this is what re-derives it.
+    #[test]
+    fn test_table_3_sizes_agree_with_the_encoding_formulas() {
+        for (k, du, dv, pk, sk, ct) in [
+            (2usize, 10usize, 4usize, 800usize, 1632usize, 768usize),
+            (3, 10, 4, 1184, 2400, 1088),
+            (4, 11, 5, 1568, 3168, 1568),
+        ] {
+            assert_eq!(384 * k + 32, pk, "Algorithm 16: ek ∈ 𝔹^(384𝑘+32)");
+            assert_eq!(768 * k + 96, sk, "Algorithm 16: dk ∈ 𝔹^(768𝑘+96)");
+            assert_eq!(32 * (du * k + dv), ct, "Algorithm 17: 𝑐 ∈ 𝔹^(32(𝑑𝑢𝑘+𝑑𝑣))");
+        }
+    }
+}

--- a/crypto/mlkem-lowmemory/src/params.rs
+++ b/crypto/mlkem-lowmemory/src/params.rs
@@ -63,7 +63,7 @@ pub trait MLKEMParams: MLKEMParamsInternalTrait {
 
     /* Derived. Never written out per parameter set -- see the module docs. */
 
-    /// The length of an encapsulation key: FIPS 203, Algorithm 16 (ML-KEM.KeyGen) gives
+    /// The length of an encapsulation key: FIPS 203, Algorithm 16 (ML-KEM.KeyGen_internal) gives
     /// ek ∈ 𝔹^(384𝑘+32).
     const PK_LEN: usize = 384 * Self::k + 32;
 
@@ -74,7 +74,7 @@ pub trait MLKEMParams: MLKEMParamsInternalTrait {
     /// 64-byte seed and expanded on demand; see [`MLKEMParams::SK_LEN`].
     const FULL_SK_LEN: usize = 768 * Self::k + 96;
 
-    /// The length of a ciphertext: FIPS 203, Algorithm 17 (ML-KEM.Encaps) gives
+    /// The length of a ciphertext: FIPS 203, Algorithm 17 (ML-KEM.Encaps_internal) gives
     /// 𝑐 ∈ 𝔹^(32(𝑑𝑢𝑘+𝑑𝑣)).
     const CT_LEN: usize = 32 * (Self::du as usize * Self::k + Self::dv as usize);
 

--- a/crypto/mlkem-lowmemory/src/params.rs
+++ b/crypto/mlkem-lowmemory/src/params.rs
@@ -231,19 +231,4 @@ mod tests {
         check_associated_type_sizes::<MLKEM768Params>();
         check_associated_type_sizes::<MLKEM1024Params>();
     }
-
-    /// Each of the sizes of Table 3 also has a formula in FIPS 203, and the two must agree.
-    /// Table 3 is what is written down above; this is what re-derives it.
-    #[test]
-    fn test_table_3_sizes_agree_with_the_encoding_formulas() {
-        for (k, du, dv, pk, sk, ct) in [
-            (2usize, 10usize, 4usize, 800usize, 1632usize, 768usize),
-            (3, 10, 4, 1184, 2400, 1088),
-            (4, 11, 5, 1568, 3168, 1568),
-        ] {
-            assert_eq!(384 * k + 32, pk, "Algorithm 16: ek ∈ 𝔹^(384𝑘+32)");
-            assert_eq!(768 * k + 96, sk, "Algorithm 16: dk ∈ 𝔹^(768𝑘+96)");
-            assert_eq!(32 * (du * k + dv), ct, "Algorithm 17: 𝑐 ∈ 𝔹^(32(𝑑𝑢𝑘+𝑑𝑣))");
-        }
-    }
 }

--- a/crypto/mlkem-lowmemory/src/polynomial.rs
+++ b/crypto/mlkem-lowmemory/src/polynomial.rs
@@ -4,6 +4,7 @@ use crate::aux_functions::{
     ZETAS, ZETAS_INV, barrett_reduce, montgomery_reduce, mul_mont, ntt_base_mult,
 };
 use crate::mlkem::{N, q};
+use crate::params::MLKEMParams;
 use core::ops::{Index, IndexMut};
 
 /// A polynomial over the ML-KEM ring.
@@ -168,13 +169,13 @@ impl Polynomial {
     /// This is an optimized version of
     ///   ByteEncode_𝑑𝑣( Compress_𝑑𝑣(𝑣) )
     /// which packs a single polynomial according to the packing coefficient dv
-    pub(crate) fn compress_poly<const dv: i16>(&self, out: &mut [u8]) {
-        // make sure to received a dv
-        debug_assert!(dv == 4 || dv == 5);
+    pub(crate) fn compress_poly<P: MLKEMParams>(&self, out: &mut [u8]) {
+        // make sure to received a P::dv
+        debug_assert!(P::dv == 4 || P::dv == 5);
 
         // make sure the right size output buffer is given
-        // each of the N i16's will take dv bits
-        debug_assert_eq!(out.len(), N * (dv as usize) / 8);
+        // each of the N i16's will take P::dv bits
+        debug_assert_eq!(out.len(), N * (P::dv as usize) / 8);
 
         let mut t = [0u8; 8];
         let mut idx = 0;
@@ -186,7 +187,7 @@ impl Polynomial {
         // let mut s = self.clone();
         // s.cond_sub_q();
 
-        match dv {
+        match P::dv {
             4 => {
                 // MLKEM512 and MLKEM768
                 for i in 0..N / 8 {
@@ -227,20 +228,20 @@ impl Polynomial {
     /// This is an optimized version of
     ///   Decompress_𝑑𝑣( ByteDecode_𝑑𝑣(𝑐2) )
     /// which unpacks a single polynomial according to the packing coefficient dv
-    pub(crate) fn decompress_poly<const dv: i16>(compressed_v: &[u8]) -> Polynomial {
-        // make sure we have received a dv
-        debug_assert!(dv == 4 || dv == 5);
+    pub(crate) fn decompress_poly<P: MLKEMParams>(compressed_v: &[u8]) -> Polynomial {
+        // make sure we have received a P::dv
+        debug_assert!(P::dv == 4 || P::dv == 5);
 
         // make sure we were given the right size output buffer
-        // each of the N i16's will take dv bits
-        debug_assert_eq!(compressed_v.len(), N * (dv as usize) / 8);
+        // each of the N i16's will take P::dv bits
+        debug_assert_eq!(compressed_v.len(), N * (P::dv as usize) / 8);
 
         let mut v = Polynomial::new();
 
         let mut idx = 0usize;
 
         // if self.m_engine.poly_compressed_bytes() == 128 {
-        match dv {
+        match P::dv {
             4 => {
                 // MLKEM512 and MLKEM768
                 for i in 0..N / 2 {

--- a/crypto/mlkem-lowmemory/tests/mlkem_tests.rs
+++ b/crypto/mlkem-lowmemory/tests/mlkem_tests.rs
@@ -722,6 +722,42 @@ mod mlkem_tests {
         fake_rng.set_security_strength(SecurityStrength::_256bit);
         _ = MLKEM1024::encaps_rng(&pk1024, &mut fake_rng).unwrap();
     }
+
+    #[test]
+    fn algorithm_names_and_oids() {
+        use bouncycastle_core::traits::{Algorithm, AlgorithmOID, SecurityStrength};
+
+        // `Algorithm` and `AlgorithmOID` are implemented once, generically over the parameter set,
+        // so nothing else states these per algorithm. Pinned here so that a wrong wiring of the
+        // blanket impls, or a typo in a parameter set, is a test failure rather than a silently
+        // mislabelled algorithm or an unparseable OID.
+        assert_eq!(MLKEM512::ALG_NAME, "ML-KEM-512");
+        assert_eq!(MLKEM768::ALG_NAME, "ML-KEM-768");
+        assert_eq!(MLKEM1024::ALG_NAME, "ML-KEM-1024");
+
+        assert_eq!(MLKEM512::MAX_SECURITY_STRENGTH, SecurityStrength::_128bit);
+        assert_eq!(MLKEM768::MAX_SECURITY_STRENGTH, SecurityStrength::_192bit);
+        assert_eq!(MLKEM1024::MAX_SECURITY_STRENGTH, SecurityStrength::_256bit);
+
+        // NIST's Computer Security Objects Register: id-alg-ml-kem-512 { kems 1 },
+        // id-alg-ml-kem-768 { kems 2 }, id-alg-ml-kem-1024 { kems 3 }.
+        assert_eq!(MLKEM512::OID, &[2, 16, 840, 1, 101, 3, 4, 4, 1]);
+        assert_eq!(MLKEM768::OID, &[2, 16, 840, 1, 101, 3, 4, 4, 2]);
+        assert_eq!(MLKEM1024::OID, &[2, 16, 840, 1, 101, 3, 4, 4, 3]);
+
+        for (oid, der) in [
+            (MLKEM512::OID, MLKEM512::OID_DER),
+            (MLKEM768::OID, MLKEM768::OID_DER),
+            (MLKEM1024::OID, MLKEM1024::OID_DER),
+        ] {
+            assert_eq!(der[0], 0x06, "DER tag must be OBJECT IDENTIFIER");
+            assert_eq!(der[1] as usize, der.len() - 2, "DER length must match the content");
+            assert_eq!(
+                &der[2..],
+                &[0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x04, *oid.last().unwrap() as u8]
+            );
+        }
+    }
 }
 
 // struct Kat {

--- a/crypto/mlkem/src/aux_functions.rs
+++ b/crypto/mlkem/src/aux_functions.rs
@@ -1,19 +1,20 @@
 //! Implements auxiliary functions for ML-DSA as defined in Section 7 of FIPS 204.
 
-use crate::matrix::{Matrix, Vector};
+use crate::matrix::{MatrixTrait, VectorTrait};
 use crate::mlkem::{N, q, q_inv};
+use crate::params::MLKEMParams;
 use crate::polynomial::Polynomial;
 use bouncycastle_core::traits::XOF;
 use bouncycastle_sha3::{SHAKE128, SHAKE256};
 
-pub(crate) fn expandA<const k: usize>(rho: &[u8; 32]) -> Matrix<k, k> {
-    let mut A_hat = Matrix::<k, k>::new();
-    for i in 0..k {
+pub(crate) fn expandA<P: MLKEMParams>(rho: &[u8; 32]) -> P::MatrixA {
+    let mut A_hat = P::MatrixA::new();
+    for i in 0..P::k {
         // 5: for (𝑗 ← 0; 𝑗 < 𝑘; 𝑗++)
-        for j in 0..k {
+        for j in 0..P::k {
             // 6: 𝐀[𝑖, 𝑗] ← SampleNTT(𝜌‖𝑗‖𝑖)
             //  ▷ 𝑗 and 𝑖 are bytes 33 and 34 of the input
-            A_hat.elems[i][j] = sample_ntt(rho, &[j as u8, i as u8]);
+            A_hat.set_elem(i, j, sample_ntt(rho, &[j as u8, i as u8]));
         }
     }
 
@@ -158,7 +159,7 @@ pub fn sample_ntt(rho: &[u8; 32], nonce: &[u8; 2]) -> Polynomial {
 /// Input: byte array 𝐵 ∈ 𝔹64𝜂 .
 /// Output: array 𝑓 ∈ ℤ256  ▷ the coefficients of the sampled polynomial
 /// Note: this is exposed publicly only for testing purposes and there is no good reason to use it in production code.
-pub fn sample_poly_cbd<const eta: i16>(bytes: &[u8]) -> Polynomial {
+pub(crate) fn sample_poly_cbd(bytes: &[u8], eta: i16) -> Polynomial {
     debug_assert_eq!(bytes.len(), 64 * eta as usize);
 
     let mut f = Polynomial::new();
@@ -205,7 +206,7 @@ pub fn sample_poly_cbd<const eta: i16>(bytes: &[u8]) -> Polynomial {
 
 /// SamplePolyCBD𝜂1(PRF𝜂1 (𝜎, 𝑁 ))
 /// Performs both the PRF and SamplePolyCBD steps
-pub(crate) fn sample_poly_CBD<const eta: i16>(b: &[u8; 32], n: u8) -> Polynomial {
+pub(crate) fn sample_poly_CBD(b: &[u8; 32], n: u8, eta: i16) -> Polynomial {
     // Alg 13: 9: 𝐬[𝑖] ← SamplePolyCBD𝜂1(PRF𝜂1 (𝜎, 𝑁 ))
     //  ▷ 𝐬[𝑖] ∈ ℤ256 sampled from CBD
     match eta {
@@ -220,7 +221,7 @@ pub(crate) fn sample_poly_CBD<const eta: i16>(b: &[u8; 32], n: u8) -> Polynomial
                 buf
             };
 
-            sample_poly_cbd::<eta>(&buf)
+            sample_poly_cbd(&buf, eta)
         }
         3 => {
             let buf = {
@@ -232,21 +233,18 @@ pub(crate) fn sample_poly_CBD<const eta: i16>(b: &[u8; 32], n: u8) -> Polynomial
                 buf
             };
 
-            sample_poly_cbd::<eta>(&buf)
+            sample_poly_cbd(&buf, eta)
         }
         _ => unreachable!(),
     }
 }
 
 /// Internal helper for keygen since both s_hat and e_hat have identical sampling code
-pub(crate) fn sample_vector_CBD<const k: usize, const eta: i16>(
-    b: &[u8; 32],
-    mut n: u8,
-) -> Vector<k> {
-    let mut v = Vector::<k>::new();
+pub(crate) fn sample_vector_CBD<P: MLKEMParams>(b: &[u8; 32], mut n: u8, eta: i16) -> P::VecK {
+    let mut v = P::VecK::new();
 
-    for i in 0..k {
-        v[i] = sample_poly_CBD::<eta>(b, n);
+    for i in 0..P::k {
+        v[i] = sample_poly_CBD(b, n, eta);
 
         // Alg 13: 10: 𝑁 ← 𝑁 + 1
         n += 1;
@@ -333,48 +331,36 @@ pub(crate) fn ntt_base_mult(
     r[off + 1] = out_val1;
 }
 
-pub(crate) fn pack_ciphertext<const k: usize, const CT_LEN: usize, const du: i16, const dv: i16>(
-    u: &Vector<k>,
+pub(crate) fn pack_ciphertext<P: MLKEMParams, const CT_LEN: usize>(
+    u: &P::VecK,
     v: &Polynomial,
 ) -> [u8; CT_LEN] {
     let mut out = [0u8; CT_LEN];
 
     // each of the N i16's will take du bits, so a polynomial takes N * du bits, then we have k of them
-    let lim: usize = k * (N * (du as usize) / 8);
+    let lim: usize = P::k * (N * (P::du as usize) / 8);
 
-    u.compress_pol_vec::<du>(&mut out[..lim]);
-    v.compress_poly::<dv>(&mut out[lim..]);
+    u.compress_pol_vec::<P>(&mut out[..lim]);
+    v.compress_poly::<P>(&mut out[lim..]);
     out
 }
 
-pub(crate) fn unpack_ciphertext_u<
-    const k: usize,
-    const CT_LEN: usize,
-    const du: i16,
-    const dv: i16,
->(
+pub(crate) fn unpack_ciphertext_u<P: MLKEMParams, const CT_LEN: usize>(
     c: &[u8; CT_LEN],
-) -> Vector<k> {
+) -> P::VecK {
     // each of the N i16's will take du bits, so a polynomial takes N * du bits, then we have k of them
-    let lim: usize = k * (N * (du as usize) / 8);
+    let lim: usize = P::k * (N * (P::du as usize) / 8);
 
-    let u = Vector::<k>::decompress_pol_vec::<du>(&c[..lim]);
-
-    u
+    P::VecK::decompress_pol_vec::<P>(&c[..lim])
 }
 
-pub(crate) fn unpack_ciphertext_v<
-    const k: usize,
-    const CT_LEN: usize,
-    const du: i16,
-    const dv: i16,
->(
+pub(crate) fn unpack_ciphertext_v<P: MLKEMParams, const CT_LEN: usize>(
     c: &[u8; CT_LEN],
 ) -> Polynomial {
     // each of the N i16's will take du bits, so a polynomial takes N * du bits, then we have k of them
-    let lim: usize = k * (N * (du as usize) / 8);
+    let lim: usize = P::k * (N * (P::du as usize) / 8);
 
-    let v = Polynomial::decompress_poly::<dv>(&c[lim..]);
+    let v = Polynomial::decompress_poly::<P>(&c[lim..]);
 
     v
 }

--- a/crypto/mlkem/src/aux_functions.rs
+++ b/crypto/mlkem/src/aux_functions.rs
@@ -25,7 +25,6 @@ pub(crate) fn expandA<P: MLKEMParams>(rho: &[u8; 32]) -> P::MatrixA {
 /// Encodes an array of 𝑑-bit integers into a byte array for 1 ≤ 𝑑 ≤ 12.
 /// Input: integer array 𝐹 ∈ ℤ_M^256, where 𝑚 = 2^𝑑 if 𝑑 < 12, and 𝑚 = 𝑞 if 𝑑 = 12.
 /// Output: byte array 𝐵 ∈ 𝔹32𝑑.
-/// Note: this is exposed publicly only for testing purposes and there is no good reason to use it in production code.
 pub fn byte_encode<const d: usize, const PACK_LEN: usize>(F: &Polynomial) -> [u8; PACK_LEN] {
     debug_assert_eq!(PACK_LEN, 32 * d);
 
@@ -67,7 +66,6 @@ pub fn byte_encode<const d: usize, const PACK_LEN: usize>(F: &Polynomial) -> [u8
 /// Decodes a byte array into an array of 𝑑-bit integers for 1 ≤ 𝑑 ≤ 12.
 /// Input: byte array 𝐵 ∈ 𝔹32𝑑 .
 /// Output: integer array 𝐹 ∈ ℤ256 , where 𝑚 = 2𝑑 if 𝑑 < 12 and 𝑚 = 𝑞 if 𝑑 = 12.
-/// Note: this is exposed publicly only for testing purposes and there is no good reason to use it in production code.
 pub fn byte_decode<const d: usize, const PACK_LEN: usize>(B: &[u8; PACK_LEN]) -> Polynomial {
     debug_assert_eq!(PACK_LEN, 32 * d);
 
@@ -88,7 +86,6 @@ pub fn byte_decode<const d: usize, const PACK_LEN: usize>(B: &[u8; PACK_LEN]) ->
 /// Takes a 32-byte seed and two indices as input and outputs a pseudorandom element of 𝑇𝑞.
 /// Input: byte array 𝐵 ∈ 𝔹34 . ▷ a 32-byte seed along with two indices
 /// Output: array 𝑎_hat ∈ ℤ256 ▷ the coefficients of the NTT of a polynomial
-/// Note: this is exposed publicly only for testing purposes and there is no good reason to use it in production code.
 pub fn sample_ntt(rho: &[u8; 32], nonce: &[u8; 2]) -> Polynomial {
     let mut a_hat = Polynomial::new();
 
@@ -158,7 +155,6 @@ pub fn sample_ntt(rho: &[u8; 32], nonce: &[u8; 2]) -> Polynomial {
 /// Takes a seed as input and outputs a pseudorandom sample from the distribution D𝜂(𝑅𝑞).
 /// Input: byte array 𝐵 ∈ 𝔹64𝜂 .
 /// Output: array 𝑓 ∈ ℤ256  ▷ the coefficients of the sampled polynomial
-/// Note: this is exposed publicly only for testing purposes and there is no good reason to use it in production code.
 pub(crate) fn sample_poly_cbd(bytes: &[u8], eta: i16) -> Polynomial {
     debug_assert_eq!(bytes.len(), 64 * eta as usize);
 

--- a/crypto/mlkem/src/lib.rs
+++ b/crypto/mlkem/src/lib.rs
@@ -157,6 +157,7 @@ mod aux_functions;
 mod matrix;
 pub mod mlkem;
 mod mlkem_keys;
+mod params;
 mod polynomial;
 
 /*** Exported types ***/
@@ -181,9 +182,10 @@ pub use mlkem::ML_KEM_768_NAME;
 pub use mlkem::ML_KEM_1024_NAME;
 
 pub use mlkem::{MLKEM_RND_LEN, MLKEM_SEED_LEN, MLKEM_SS_LEN};
-
 pub use mlkem::{MLKEM512_CT_LEN, MLKEM512_PK_LEN, MLKEM512_SK_LEN};
 pub use mlkem::{MLKEM768_CT_LEN, MLKEM768_PK_LEN, MLKEM768_SK_LEN};
 pub use mlkem::{MLKEM1024_CT_LEN, MLKEM1024_PK_LEN, MLKEM1024_SK_LEN};
+pub use params::{MLKEM512Params, MLKEM768Params, MLKEM1024Params};
 
-pub use matrix::Matrix;
+pub use matrix::{Matrix, MatrixTrait, Vector, VectorTrait};
+pub use polynomial::Polynomial;

--- a/crypto/mlkem/src/lib.rs
+++ b/crypto/mlkem/src/lib.rs
@@ -185,7 +185,3 @@ pub use mlkem::{MLKEM_RND_LEN, MLKEM_SEED_LEN, MLKEM_SS_LEN};
 pub use mlkem::{MLKEM512_CT_LEN, MLKEM512_PK_LEN, MLKEM512_SK_LEN};
 pub use mlkem::{MLKEM768_CT_LEN, MLKEM768_PK_LEN, MLKEM768_SK_LEN};
 pub use mlkem::{MLKEM1024_CT_LEN, MLKEM1024_PK_LEN, MLKEM1024_SK_LEN};
-pub use params::{MLKEM512Params, MLKEM768Params, MLKEM1024Params};
-
-pub use matrix::{Matrix, MatrixTrait, Vector, VectorTrait};
-pub use polynomial::Polynomial;

--- a/crypto/mlkem/src/matrix.rs
+++ b/crypto/mlkem/src/matrix.rs
@@ -16,9 +16,6 @@ use bouncycastle_utils::secret::ZeroizablePrimitive;
 pub trait VectorTrait:
     Sized + Copy + ZeroizablePrimitive + Index<usize, Output = Polynomial> + IndexMut<usize>
 {
-    /// The number of polynomial coordinates, i.e. 𝑘.
-    const LEN: usize;
-
     /// A vector with every coefficient set to zero.
     fn new() -> Self;
 
@@ -49,11 +46,6 @@ pub trait VectorTrait:
 ///
 /// [`Matrix`] is the only implementation; see [`VectorTrait`] for why the trait exists.
 pub trait MatrixTrait: Sized + Clone {
-    /// 𝑘, the number of rows.
-    const ROWS: usize;
-    /// 𝑘, the number of columns. ML-KEM's 𝐀̂ is square.
-    const COLS: usize;
-
     /// The vector this matrix maps between: an element of 𝑅^𝑘.
     type Vec: VectorTrait;
 
@@ -124,9 +116,6 @@ impl<const k: usize, const l: usize> Matrix<k, l> {
 /// ML-KEM's 𝐀̂ is always 𝑘 × 𝑘, so the trait is implemented only for the square case; that is what
 /// lets [`MatrixTrait::Vec`] be one vector type rather than an input and an output type.
 impl<const k: usize> MatrixTrait for Matrix<k, k> {
-    const ROWS: usize = k;
-    const COLS: usize = k;
-
     type Vec = Vector<k>;
 
     fn new() -> Self {
@@ -177,8 +166,6 @@ impl<const k: usize> Vector<k> {
 }
 
 impl<const k: usize> VectorTrait for Vector<k> {
-    const LEN: usize = k;
-
     fn new() -> Self {
         Vector::new()
     }

--- a/crypto/mlkem/src/matrix.rs
+++ b/crypto/mlkem/src/matrix.rs
@@ -4,9 +4,66 @@
 use core::ops::{Index, IndexMut};
 
 use crate::mlkem::{N, q};
+use crate::params::MLKEMParams;
 use crate::polynomial;
 use crate::polynomial::Polynomial;
 use bouncycastle_utils::secret::ZeroizablePrimitive;
+
+/// The operations this crate performs on a vector of polynomials, i.e. on an element of 𝑅^LEN.
+///
+/// [`Vector`] is the only implementation; the trait exists so that code generic over a parameter
+/// set can operate on `MLKEMParams::VecK` without knowing its length.
+pub trait VectorTrait:
+    Sized + Copy + ZeroizablePrimitive + Index<usize, Output = Polynomial> + IndexMut<usize>
+{
+    /// The number of polynomial coordinates, i.e. 𝑘.
+    const LEN: usize;
+
+    /// A vector with every coefficient set to zero.
+    fn new() -> Self;
+
+    /// The coordinates, for iteration and chunking.
+    fn elems(&self) -> &[Polynomial];
+    /// The coordinates, for iteration and chunking.
+    fn elems_mut(&mut self) -> &mut [Polynomial];
+
+    /// Adds another vector to this one, coordinatewise, in the NTT domain.
+    fn add_vector_ntt(&mut self, s: &Self);
+    /// The dot product of two vectors in the NTT domain.
+    fn dot_product(&self, v: &Self) -> Polynomial;
+    /// Barrett-reduces every coefficient.
+    fn reduce(&mut self);
+    /// Applies the NTT to every coordinate.
+    fn ntt(&mut self);
+    /// Applies the inverse NTT to every coordinate.
+    fn inv_ntt(&mut self);
+    /// Converts every coefficient into the Montgomery domain.
+    fn convert_to_mont(&mut self);
+    /// FIPS 203, Algorithm 5 (ByteEncode) applied to the compressed vector.
+    fn compress_pol_vec<P: MLKEMParams>(&self, out: &mut [u8]);
+    /// The inverse of [`VectorTrait::compress_pol_vec`].
+    fn decompress_pol_vec<P: MLKEMParams>(compressed_u: &[u8]) -> Self;
+}
+
+/// The operations this crate performs on the public matrix 𝐀̂.
+///
+/// [`Matrix`] is the only implementation; see [`VectorTrait`] for why the trait exists.
+pub trait MatrixTrait: Sized + Clone {
+    /// 𝑘, the number of rows.
+    const ROWS: usize;
+    /// 𝑘, the number of columns. ML-KEM's 𝐀̂ is square.
+    const COLS: usize;
+
+    /// The vector this matrix maps between: an element of 𝑅^𝑘.
+    type Vec: VectorTrait;
+
+    /// A matrix with every coefficient set to zero.
+    fn new() -> Self;
+    /// Overwrites the polynomial at `elems[row][col]`.
+    fn set_elem(&mut self, row: usize, col: usize, p: Polynomial);
+    /// Computes 𝐀̂ ∘ 𝐯̂, transposing 𝐀̂ first when `transpose` is set.
+    fn matrix_vector_ntt<const transpose: bool>(&self, v: &Self::Vec) -> Self::Vec;
+}
 
 #[derive(Clone)]
 /// A matrix over the ML-KEM ring.
@@ -64,8 +121,33 @@ impl<const k: usize, const l: usize> Matrix<k, l> {
     }
 }
 
+/// ML-KEM's 𝐀̂ is always 𝑘 × 𝑘, so the trait is implemented only for the square case; that is what
+/// lets [`MatrixTrait::Vec`] be one vector type rather than an input and an output type.
+impl<const k: usize> MatrixTrait for Matrix<k, k> {
+    const ROWS: usize = k;
+    const COLS: usize = k;
+
+    type Vec = Vector<k>;
+
+    fn new() -> Self {
+        Matrix::new()
+    }
+
+    fn set_elem(&mut self, row: usize, col: usize, p: Polynomial) {
+        self.elems[row][col] = p;
+    }
+
+    fn matrix_vector_ntt<const transpose: bool>(&self, v: &Vector<k>) -> Vector<k> {
+        Matrix::matrix_vector_ntt::<transpose>(self, v)
+    }
+}
+
 #[derive(Clone, Copy)]
-pub(crate) struct Vector<const k: usize> {
+/// A vector of `k` polynomials, i.e. an element of 𝑅^𝑘.
+///
+/// Public only because it is the value of `MLKEMParams::VecK`; its fields and operations are
+/// crate-private, so from outside it is an opaque handle. Reach it through [`VectorTrait`].
+pub struct Vector<const k: usize> {
     pub(crate) elems: [Polynomial; k],
 }
 
@@ -92,20 +174,30 @@ impl<const k: usize> Vector<k> {
     pub(crate) const fn new() -> Self {
         Self { elems: [Polynomial::new(); k] }
     }
+}
 
-    /// Algorithm 46 AddVectorNTT(𝐯, 𝐰)̂
-    /// Computes the sum 𝐯_hat + 𝐰_hat of two vectors 𝐯_hat, 𝐰_hat over 𝑇𝑞.
-    /// Input: ℓ ∈ ℕ, v_hat ∈ T^ℓ, w_hat ∈ 𝑇^ℓ
-    /// Output: u_hat ∈ T^ℓ_𝑞.
-    /// Add another vector to this vector
-    pub(crate) fn add_vector_ntt(&mut self, s: &Self) {
+impl<const k: usize> VectorTrait for Vector<k> {
+    const LEN: usize = k;
+
+    fn new() -> Self {
+        Vector::new()
+    }
+
+    fn elems(&self) -> &[Polynomial] {
+        &self.elems
+    }
+
+    fn elems_mut(&mut self) -> &mut [Polynomial] {
+        &mut self.elems
+    }
+    fn add_vector_ntt(&mut self, s: &Self) {
         for i in 0..k {
             // perform Montgomery addition of each polynomial in the vector
             self[i].add(&s[i]);
         }
     }
 
-    pub(crate) fn dot_product(&self, v: &Self) -> Polynomial {
+    fn dot_product(&self, v: &Self) -> Polynomial {
         // split out the 0 case to skip a no-op add_ntt()
         let mut w = polynomial::base_mult_montgomery(&self[0], &v[0]);
 
@@ -120,25 +212,25 @@ impl<const k: usize> Vector<k> {
         w
     }
 
-    pub(crate) fn reduce(&mut self) {
+    fn reduce(&mut self) {
         for i in 0..k {
             self[i].poly_reduce();
         }
     }
 
-    pub(crate) fn ntt(&mut self) {
+    fn ntt(&mut self) {
         for i in 0..k {
             self[i].ntt();
         }
     }
 
-    pub(crate) fn inv_ntt(&mut self) {
+    fn inv_ntt(&mut self) {
         for i in 0..k {
             self[i].inv_ntt();
         }
     }
 
-    pub(crate) fn convert_to_mont(&mut self) {
+    fn convert_to_mont(&mut self) {
         for i in 0..k {
             self[i].convert_to_mont();
         }
@@ -147,13 +239,13 @@ impl<const k: usize> Vector<k> {
     /// This is an optimized version of
     ///   ByteEncode_𝑑𝑢( Compress_𝑑𝑢(𝐮) )
     /// which packs a polynomial vector according to the packing coefficient dv
-    pub(crate) fn compress_pol_vec<const du: i16>(&self, out: &mut [u8]) {
+    fn compress_pol_vec<P: MLKEMParams>(&self, out: &mut [u8]) {
         // make sure we have received a dv
-        assert!(du == 10 || du == 11);
+        assert!(P::du == 10 || P::du == 11);
 
         // make sure we were given the right size output buffer
         // each of the N i16's will take dv bits
-        debug_assert_eq!(out.len(), k * (N * (du as usize) / 8));
+        debug_assert_eq!(out.len(), k * (N * (P::du as usize) / 8));
 
         // No conditional_sub_q needed (as done in bc-java): callers must reduce() first,
         // so coefficients are in [0, q) (barrett_reduce, floor variant). The Compress mask `& (2^du - 1)` folds
@@ -165,7 +257,7 @@ impl<const k: usize> Vector<k> {
         // s.conditional_sub_q();
 
         let mut idx = 0;
-        match du {
+        match P::du {
             10 => {
                 // MLKEM512 and MLKEM 768
                 let mut t = [0i16; 4];
@@ -218,19 +310,19 @@ impl<const k: usize> Vector<k> {
         }
     }
 
-    pub(crate) fn decompress_pol_vec<const du: i16>(compressed_u: &[u8]) -> Vector<k> {
+    fn decompress_pol_vec<P: MLKEMParams>(compressed_u: &[u8]) -> Self {
         let mut u = Vector::<k>::new();
 
         // make sure we have received a dv
-        assert!(du == 10 || du == 11);
+        assert!(P::du == 10 || P::du == 11);
 
         // make sure we were given the right size output buffer
         // each of the N i16's will take dv bits
-        debug_assert_eq!(compressed_u.len(), k * (N * (du as usize) / 8));
+        debug_assert_eq!(compressed_u.len(), k * (N * (P::du as usize) / 8));
 
         let mut idx = 0;
 
-        match du {
+        match P::du {
             10 => {
                 // MLKEM512 and MLKEM768
                 let mut t = [0i16; 4];

--- a/crypto/mlkem/src/mlkem.rs
+++ b/crypto/mlkem/src/mlkem.rs
@@ -90,6 +90,7 @@
 //! private key encoding (which is often called the "semi-expanded format" since the in-memory representation
 //! is still larger).
 //! Contact us if you need such a thing implemented.
+//!
 //! ## Deterministic encapsulation
 //!
 //! This section pertains to [`MLKEM::encaps_internal`] which allows to pass in the encapsulation randomness
@@ -132,7 +133,7 @@ use crate::aux_functions::{
     expandA, pack_ciphertext, sample_poly_CBD, sample_vector_CBD, unpack_ciphertext_u,
     unpack_ciphertext_v,
 };
-use crate::matrix::{Matrix, Vector};
+use crate::matrix::{MatrixTrait, VectorTrait};
 use crate::mlkem_keys::{
     MLKEM512PrivateKey, MLKEM512PublicKey, MLKEM768PrivateKey, MLKEM768PublicKey,
     MLKEM1024PrivateKey, MLKEM1024PublicKey,
@@ -141,6 +142,7 @@ use crate::mlkem_keys::{
     MLKEMPrivateKeyExpanded, MLKEMPublicKeyInternalTrait, MLKEMPublicKeyTrait,
 };
 use crate::mlkem_keys::{MLKEMPrivateKeyInternalTrait, MLKEMPrivateKeyTrait};
+use crate::params::{MLKEM512Params, MLKEM768Params, MLKEM1024Params, MLKEMParams};
 use crate::polynomial::Polynomial;
 use bouncycastle_core::errors::KEMError;
 use bouncycastle_core::errors::RNGError;
@@ -175,53 +177,34 @@ pub const MLKEM_SS_LEN: usize = 32;
 pub(crate) const N: usize = 256;
 pub(crate) const q: i16 = 3329;
 pub(crate) const q_inv: i32 = 62209;
-pub(crate) const ETA2: i16 = 2;
 pub(crate) const POLY_BYTES: usize = 384;
 
-/* ML-KEM-512 params */
+/* ML-KEM-512 sizes (FIPS 203, Table 3) */
 
 /// Length of the \[u8] holding a ML-KEM-512 public key.
-pub const MLKEM512_PK_LEN: usize = 800;
+pub const MLKEM512_PK_LEN: usize = MLKEM512Params::PK_LEN;
 /// Length of the \[u8] holding a ML-KEM-512 private key.
-pub const MLKEM512_SK_LEN: usize = 1632;
+pub const MLKEM512_SK_LEN: usize = MLKEM512Params::SK_LEN;
 /// Length of the \[u8] holding a ML-KEM-512 ciphertext.
-pub const MLKEM512_CT_LEN: usize = 768;
-pub(crate) const MLKEM512_k: usize = 2;
-pub(crate) const MLKEM512_ETA1: i16 = 3;
-pub(crate) const MLKEM512_DU: i16 = 10;
-pub(crate) const MLKEM512_DV: i16 = 4;
-/// Maps to "required RBG strength (bits)" in FIPS 203 Table 2
-pub(crate) const MLKEM512_LAMBDA: i16 = 128;
+pub const MLKEM512_CT_LEN: usize = MLKEM512Params::CT_LEN;
 
-/* ML-KEM-768 params */
+/* ML-KEM-768 sizes (FIPS 203, Table 3) */
 
 /// Length of the \[u8] holding a ML-KEM-768 public key.
-pub const MLKEM768_PK_LEN: usize = 1184;
+pub const MLKEM768_PK_LEN: usize = MLKEM768Params::PK_LEN;
 /// Length of the \[u8] holding a ML-KEM-768 private key.
-pub const MLKEM768_SK_LEN: usize = 2400;
+pub const MLKEM768_SK_LEN: usize = MLKEM768Params::SK_LEN;
 /// Length of the \[u8] holding a ML-KEM-768 ciphertext.
-pub const MLKEM768_CT_LEN: usize = 1088;
-pub(crate) const MLKEM768_k: usize = 3;
-pub(crate) const MLKEM768_ETA1: i16 = 2;
-pub(crate) const MLKEM768_DU: i16 = 10;
-pub(crate) const MLKEM768_DV: i16 = 4;
-/// Maps to "required RBG strength (bits)" in FIPS 203 Table 2
-pub(crate) const MLKEM768_LAMBDA: i16 = 192;
+pub const MLKEM768_CT_LEN: usize = MLKEM768Params::CT_LEN;
 
-/* ML-KEM-1024 params */
+/* ML-KEM-1024 sizes (FIPS 203, Table 3) */
 
 /// Length of the \[u8] holding a ML-KEM-1024 public key.
-pub const MLKEM1024_PK_LEN: usize = 1568;
+pub const MLKEM1024_PK_LEN: usize = MLKEM1024Params::PK_LEN;
 /// Length of the \[u8] holding a ML-KEM-1024 private key.
-pub const MLKEM1024_SK_LEN: usize = 3168;
+pub const MLKEM1024_SK_LEN: usize = MLKEM1024Params::SK_LEN;
 /// Length of the \[u8] holding a ML-KEM-1024 ciphertext.
-pub const MLKEM1024_CT_LEN: usize = 1568;
-pub(crate) const MLKEM1024_k: usize = 4;
-pub(crate) const MLKEM1024_ETA1: i16 = 2;
-pub(crate) const MLKEM1024_DU: i16 = 11;
-pub(crate) const MLKEM1024_DV: i16 = 5;
-/// Maps to "required RBG strength (bits)" in FIPS 203 Table 2
-pub(crate) const MLKEM1024_LAMBDA: i16 = 256;
+pub const MLKEM1024_CT_LEN: usize = MLKEM1024Params::CT_LEN;
 
 // Typedefs just to make the algorithms look more like the FIPS 204 sample code.
 pub(crate) type G = SHA3_512;
@@ -232,116 +215,96 @@ pub(crate) type J = SHAKE256;
 
 /// The ML-KEM-512 algorithm.
 pub type MLKEM512 = MLKEM<
+    MLKEM512Params,
+    MLKEM512PublicKey,
+    MLKEM512PrivateKey,
     MLKEM512_PK_LEN,
     MLKEM512_SK_LEN,
     MLKEM512_CT_LEN,
     MLKEM_SS_LEN,
-    MLKEM512PublicKey,
-    MLKEM512PrivateKey,
-    MLKEM512_k,
-    MLKEM512_ETA1,
-    MLKEM512_DU,
-    MLKEM512_DV,
-    MLKEM512_LAMBDA,
 >;
-
-impl Algorithm for MLKEM512 {
-    const ALG_NAME: &'static str = ML_KEM_512_NAME;
-    const MAX_SECURITY_STRENGTH: SecurityStrength = SecurityStrength::_128bit;
-}
-/// Assigned by NIST in the Computer Security Objects Register: id-alg-ml-kem-512 { kems 1 }
-impl AlgorithmOID for MLKEM512 {
-    const OID: &'static [u32] = &[2, 16, 840, 1, 101, 3, 4, 4, 1];
-    const OID_DER: &'static [u8] =
-        &[0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x04, 0x01];
-}
 
 /// The ML-KEM-768 algorithm.
 pub type MLKEM768 = MLKEM<
+    MLKEM768Params,
+    MLKEM768PublicKey,
+    MLKEM768PrivateKey,
     MLKEM768_PK_LEN,
     MLKEM768_SK_LEN,
     MLKEM768_CT_LEN,
     MLKEM_SS_LEN,
-    MLKEM768PublicKey,
-    MLKEM768PrivateKey,
-    MLKEM768_k,
-    MLKEM768_ETA1,
-    MLKEM768_DU,
-    MLKEM768_DV,
-    MLKEM768_LAMBDA,
 >;
-
-impl Algorithm for MLKEM768 {
-    const ALG_NAME: &'static str = ML_KEM_768_NAME;
-    const MAX_SECURITY_STRENGTH: SecurityStrength = SecurityStrength::_192bit;
-}
-/// Assigned by NIST in the Computer Security Objects Register: id-alg-ml-kem-768 { kems 2 }
-impl AlgorithmOID for MLKEM768 {
-    const OID: &'static [u32] = &[2, 16, 840, 1, 101, 3, 4, 4, 2];
-    const OID_DER: &'static [u8] =
-        &[0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x04, 0x02];
-}
 
 /// The ML-KEM-1024 algorithm.
 pub type MLKEM1024 = MLKEM<
+    MLKEM1024Params,
+    MLKEM1024PublicKey,
+    MLKEM1024PrivateKey,
     MLKEM1024_PK_LEN,
     MLKEM1024_SK_LEN,
     MLKEM1024_CT_LEN,
     MLKEM_SS_LEN,
-    MLKEM1024PublicKey,
-    MLKEM1024PrivateKey,
-    MLKEM1024_k,
-    MLKEM1024_ETA1,
-    MLKEM1024_DU,
-    MLKEM1024_DV,
-    MLKEM1024_LAMBDA,
 >;
 
-impl Algorithm for MLKEM1024 {
-    const ALG_NAME: &'static str = ML_KEM_1024_NAME;
-    const MAX_SECURITY_STRENGTH: SecurityStrength = SecurityStrength::_256bit;
+impl<
+    P: MLKEMParams,
+    PK: MLKEMPublicKeyTrait<P, PK_LEN> + MLKEMPublicKeyInternalTrait<P, PK_LEN>,
+    SK: MLKEMPrivateKeyTrait<P, PK, SK_LEN, PK_LEN>
+        + MLKEMPrivateKeyInternalTrait<P, PK, SK_LEN, PK_LEN>,
+    const PK_LEN: usize,
+    const SK_LEN: usize,
+    const CT_LEN: usize,
+    const SS_LEN: usize,
+> Algorithm for MLKEM<P, PK, SK, PK_LEN, SK_LEN, CT_LEN, SS_LEN>
+{
+    const ALG_NAME: &'static str = P::ALG_NAME;
+    const MAX_SECURITY_STRENGTH: SecurityStrength = P::MAX_SECURITY_STRENGTH;
 }
-/// Assigned by NIST in the Computer Security Objects Register: id-alg-ml-kem-1024 { kems 3 }
-impl AlgorithmOID for MLKEM1024 {
-    const OID: &'static [u32] = &[2, 16, 840, 1, 101, 3, 4, 4, 3];
-    const OID_DER: &'static [u8] =
-        &[0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x04, 0x03];
+
+/// The OIDs NIST assigned in the Computer Security Objects Register: id-alg-ml-kem-512
+/// { kems 1 }, id-alg-ml-kem-768 { kems 2 } and id-alg-ml-kem-1024 { kems 3 }. As with
+/// [`Algorithm`], the values belong to the parameter set, so one impl covers all three.
+impl<
+    P: MLKEMParams,
+    PK: MLKEMPublicKeyTrait<P, PK_LEN> + MLKEMPublicKeyInternalTrait<P, PK_LEN>,
+    SK: MLKEMPrivateKeyTrait<P, PK, SK_LEN, PK_LEN>
+        + MLKEMPrivateKeyInternalTrait<P, PK, SK_LEN, PK_LEN>,
+    const PK_LEN: usize,
+    const SK_LEN: usize,
+    const CT_LEN: usize,
+    const SS_LEN: usize,
+> AlgorithmOID for MLKEM<P, PK, SK, PK_LEN, SK_LEN, CT_LEN, SS_LEN>
+{
+    const OID: &'static [u32] = P::OID;
+    const OID_DER: &'static [u8] = P::OID_DER;
 }
 
 /// The core internal implementation of the ML-KEM algorithm.
 /// This needs to be public for the compiler to be able to find it, but you shouldn't ever
 /// need to use this directly. Please use the named public types.
 pub struct MLKEM<
+    P: MLKEMParams,
+    PK: MLKEMPublicKeyTrait<P, PK_LEN> + MLKEMPublicKeyInternalTrait<P, PK_LEN>,
+    SK: MLKEMPrivateKeyTrait<P, PK, SK_LEN, PK_LEN>
+        + MLKEMPrivateKeyInternalTrait<P, PK, SK_LEN, PK_LEN>,
     const PK_LEN: usize,
     const SK_LEN: usize,
     const CT_LEN: usize,
     const SS_LEN: usize,
-    PK: MLKEMPublicKeyTrait<k, PK_LEN> + MLKEMPublicKeyInternalTrait<k, PK_LEN>,
-    SK: MLKEMPrivateKeyTrait<k, PK, SK_LEN, PK_LEN>
-        + MLKEMPrivateKeyInternalTrait<k, PK, SK_LEN, PK_LEN>,
-    const k: usize,
-    const eta: i16,
-    const du: i16,
-    const dv: i16,
-    const LAMBDA: i16,
 > {
-    _phantom: PhantomData<(PK, SK)>,
+    _phantom: PhantomData<(P, PK, SK)>,
 }
 
 impl<
+    P: MLKEMParams,
+    PK: MLKEMPublicKeyTrait<P, PK_LEN> + MLKEMPublicKeyInternalTrait<P, PK_LEN>,
+    SK: MLKEMPrivateKeyTrait<P, PK, SK_LEN, PK_LEN>
+        + MLKEMPrivateKeyInternalTrait<P, PK, SK_LEN, PK_LEN>,
     const PK_LEN: usize,
     const SK_LEN: usize,
     const CT_LEN: usize,
     const SS_LEN: usize,
-    PK: MLKEMPublicKeyTrait<k, PK_LEN> + MLKEMPublicKeyInternalTrait<k, PK_LEN>,
-    SK: MLKEMPrivateKeyTrait<k, PK, SK_LEN, PK_LEN>
-        + MLKEMPrivateKeyInternalTrait<k, PK, SK_LEN, PK_LEN>,
-    const k: usize,
-    const eta1: i16,
-    const du: i16,
-    const dv: i16,
-    const LAMBDA: i16,
-> MLKEM<PK_LEN, SK_LEN, CT_LEN, SS_LEN, PK, SK, k, eta1, du, dv, LAMBDA>
+> MLKEM<P, PK, SK, PK_LEN, SK_LEN, CT_LEN, SS_LEN>
 {
     /// Algorithm 16 ML-KEM.KeyGen_internal(𝑑, 𝑧)
     /// Uses randomness to generate an encapsulation key and a corresponding decapsulation key.
@@ -358,7 +321,7 @@ impl<
             ));
         }
 
-        if seed.security_strength() < SecurityStrength::from_bits(LAMBDA as usize) {
+        if seed.security_strength() < P::MAX_SECURITY_STRENGTH {
             return Err(KEMError::KeyGenError(
                 "Seed SecurityStrength must match algorithm security strength",
             ));
@@ -385,7 +348,7 @@ impl<
     /// Input: randomness 𝑑 ∈ 𝔹32 .
     /// Output: encryption key ek_PKE ∈ 𝔹384𝑘+32.
     /// Output: decryption key dk_PKE ∈ 𝔹384𝑘.
-    fn pke_keygen(d: &[u8; 32]) -> (PK, Secret<Vector<k>>) {
+    fn pke_keygen(d: &[u8; 32]) -> (PK, Secret<P::VecK>) {
         // 1: (𝜌, 𝜎) ← G(𝑑‖𝑘)
         //  ▷ expand 32+1 bytes to two pseudorandom 32-byte seeds1
         // rho: public seed
@@ -393,7 +356,7 @@ impl<
         let (rho, mut sigma) = {
             let mut g = G::new();
             g.do_update(d);
-            g.do_update(&[k as u8]);
+            g.do_update(&[P::k as u8]);
             let mut buf = [0u8; 64];
             let bytes_written = g.do_final_out(&mut buf);
             debug_assert_eq!(bytes_written, 64);
@@ -412,9 +375,9 @@ impl<
         //   ▷ 𝐬[𝑖] ∈ ℤ256 sampled from CBD
         // 10: 𝑁 ← 𝑁 + 1
         // Note: here n = 0
-        let s_hat: Secret<Vector<k>> = {
-            let mut s: Secret<Vector<k>> = Secret::new();
-            *s = sample_vector_CBD::<k, eta1>(&sigma, 0);
+        let s_hat: Secret<P::VecK> = {
+            let mut s: Secret<P::VecK> = Secret::new();
+            *s = sample_vector_CBD::<P>(&sigma, 0, P::eta1);
 
             // 16: 𝐬_hat ← NTT(𝐬)̂
             s.ntt();
@@ -427,7 +390,7 @@ impl<
         let mut t_hat = {
             // 3: for (𝑖 ← 0; 𝑖 < 𝑘; 𝑖++)
             //  ▷ generate matrix A_hat ∈ (ℤ256)^k x k
-            let A_hat = expandA(&rho);
+            let A_hat = expandA::<P>(&rho);
 
             A_hat.matrix_vector_ntt::<false>(&s_hat)
         };
@@ -441,7 +404,7 @@ impl<
             //   ▷ 𝐞[𝑖] ∈ ℤ256 sampled from CBD
             // 14: 𝑁 ← 𝑁 + 1
             // Note: here n = k
-            let mut e = sample_vector_CBD::<k, eta1>(&sigma, k as u8);
+            let mut e = sample_vector_CBD::<P>(&sigma, P::k as u8, P::eta1);
 
             e.ntt(); // technically now e_hat
             e.reduce();
@@ -464,7 +427,7 @@ impl<
     /// Input: message 𝑚 ∈ 𝔹32 .
     /// Input: randomness 𝑟 ∈ 𝔹32 .
     /// Output: ciphertext 𝑐 ∈ 𝔹32(𝑑𝑢𝑘+𝑑𝑣).
-    fn pke_encrypt(ek: &PK, A_hat: &Matrix<k, k>, m: [u8; 32], r: &[u8; 32]) -> [u8; CT_LEN] {
+    fn pke_encrypt(ek: &PK, A_hat: &P::MatrixA, m: [u8; 32], r: &[u8; 32]) -> [u8; CT_LEN] {
         // 1: 𝑁 ← 0
         //  since the number of loops here is static, the N values can be hard-coded rather than using a counter
 
@@ -484,7 +447,7 @@ impl<
         // 11: 𝑁 ← 𝑁 + 1
         // Note: here n = 0
         let y_hat = {
-            let mut y = sample_vector_CBD::<k, eta1>(&r, 0);
+            let mut y = sample_vector_CBD::<P>(&r, 0, P::eta1);
 
             // 18: 𝐲_hat ← NTT(𝐲)
             y.ntt();
@@ -502,7 +465,7 @@ impl<
             //  ▷ 𝐞[𝑖] ∈ ℤ256 sampled from CBD𝑞
             // 14: 𝑁 ← 𝑁 + 1
             // note: here n = k
-            let e1 = sample_vector_CBD::<k, ETA2>(&r, k as u8);
+            let e1 = sample_vector_CBD::<P>(&r, P::k as u8, P::eta2);
 
             u.add_vector_ntt(&e1);
         }
@@ -517,7 +480,7 @@ impl<
         // 17: 𝑒2 ← SamplePolyCBD𝜂2(PRF𝜂2 (𝑟, 𝑁))
         //  ▷ sample 𝑒2 ∈ ℤ256 from CBD
         // note: here n = 2k
-        let e2 = sample_poly_CBD::<ETA2>(&r, 2 * k as u8);
+        let e2 = sample_poly_CBD(&r, 2 * P::k as u8, P::eta2);
         v.add(&e2);
 
         let mu = Polynomial::from_msg(m);
@@ -525,7 +488,7 @@ impl<
 
         v.poly_reduce();
 
-        pack_ciphertext::<k, CT_LEN, du, dv>(&u, &v)
+        pack_ciphertext::<P, CT_LEN>(&u, &v)
     }
 
     /// Algorithm 17 ML-KEM.Encaps_internal(ek, 𝑚)
@@ -562,10 +525,10 @@ impl<
     /// Please don't do it.
     pub fn encaps_internal(
         ek: &PK,
-        A_hat: Option<&Matrix<k, k>>,
+        A_hat: Option<&P::MatrixA>,
         m: [u8; 32],
     ) -> ([u8; 32], [u8; CT_LEN]) {
-        debug_assert_eq!(CT_LEN, 32 * ((du as usize) * k + (dv as usize)));
+        debug_assert_eq!(CT_LEN, 32 * ((P::du as usize) * P::k + (P::dv as usize)));
 
         // 1: (𝐾, 𝑟) ← G(𝑚‖H(ek))
         //  ▷ derive shared secret key 𝐾 and randomness 𝑟
@@ -606,7 +569,7 @@ impl<
         // 3: 𝐮′ ← Decompress_𝑑𝑢(ByteDecode_𝑑𝑢(𝑐1))
         // 4: 𝑣′ ← Decompress_𝑑𝑣(ByteDecode_𝑑𝑣(𝑐2))
         let v1 = {
-            let mut u_prime = unpack_ciphertext_u::<k, CT_LEN, du, dv>(&ct);
+            let mut u_prime = unpack_ciphertext_u::<P, CT_LEN>(&ct);
 
             // 5: 𝐬_hat ← ByteDecode12(dkPKE)
             //   Unnecessary here because dk is already decoded
@@ -620,7 +583,7 @@ impl<
         };
 
         let w = {
-            let mut v_prime = unpack_ciphertext_v::<k, CT_LEN, du, dv>(&ct);
+            let mut v_prime = unpack_ciphertext_v::<P, CT_LEN>(&ct);
 
             v_prime.sub(&v1);
             v_prime.poly_reduce();
@@ -637,11 +600,7 @@ impl<
     /// Input: decapsulation key dk ∈ 𝔹768𝑘+96 .
     /// Input: ciphertext 𝑐 ∈ 𝔹32(𝑑𝑢𝑘+𝑑𝑣).
     /// Output: shared secret key 𝐾 ∈ 𝔹32 .
-    fn decaps_internal(
-        dk: &SK,
-        A_hat: Option<&Matrix<k, k>>,
-        c: [u8; CT_LEN],
-    ) -> [u8; MLKEM_SS_LEN] {
+    fn decaps_internal(dk: &SK, A_hat: Option<&P::MatrixA>, c: [u8; CT_LEN]) -> [u8; MLKEM_SS_LEN] {
         // Structured to mirror the FIPS as closely as possible, with unnamed scopes
         // used to limit the number of live stack variables at any given time.
 
@@ -720,20 +679,16 @@ impl<
 }
 
 impl<
+    P: MLKEMParams,
+    PK: MLKEMPublicKeyTrait<P, PK_LEN> + MLKEMPublicKeyInternalTrait<P, PK_LEN>,
+    SK: MLKEMPrivateKeyTrait<P, PK, SK_LEN, PK_LEN>
+        + MLKEMPrivateKeyInternalTrait<P, PK, SK_LEN, PK_LEN>,
     const PK_LEN: usize,
     const SK_LEN: usize,
     const CT_LEN: usize,
     const SS_LEN: usize,
-    PK: MLKEMPublicKeyTrait<k, PK_LEN> + MLKEMPublicKeyInternalTrait<k, PK_LEN>,
-    SK: MLKEMPrivateKeyTrait<k, PK, SK_LEN, PK_LEN>
-        + MLKEMPrivateKeyInternalTrait<k, PK, SK_LEN, PK_LEN>,
-    const k: usize,
-    const eta1: i16,
-    const du: i16,
-    const dv: i16,
-    const LAMBDA: i16,
-> MLKEMTrait<PK_LEN, SK_LEN, CT_LEN, SS_LEN, PK, SK, k, eta1, du, dv, LAMBDA>
-    for MLKEM<PK_LEN, SK_LEN, CT_LEN, SS_LEN, PK, SK, k, eta1, du, dv, LAMBDA>
+> MLKEMTrait<P, PK, SK, PK_LEN, SK_LEN, CT_LEN, SS_LEN>
+    for MLKEM<P, PK, SK, PK_LEN, SK_LEN, CT_LEN, SS_LEN>
 {
     /// Imports a secret key from a seed.
     fn keygen_from_seed(seed: &KeyMaterial<64>) -> Result<(PK, SK), KEMError> {
@@ -778,18 +733,18 @@ impl<
     }
 
     fn encaps_for_expanded_key(
-        pk: &MLKEMPublicKeyExpanded<k, PK, PK_LEN>,
+        pk: &MLKEMPublicKeyExpanded<P, PK, PK_LEN>,
     ) -> Result<(KeyMaterial<SS_LEN>, [u8; CT_LEN]), KEMError> {
         let mut os_rng = HashDRBG_SHA512::new_from_os();
         Self::encaps_for_expanded_key_rng(pk, &mut os_rng)
     }
 
     fn encaps_for_expanded_key_rng(
-        pk: &MLKEMPublicKeyExpanded<k, PK, PK_LEN>,
+        pk: &MLKEMPublicKeyExpanded<P, PK, PK_LEN>,
         rng: &mut dyn RNG,
     ) -> Result<(KeyMaterial<SS_LEN>, [u8; CT_LEN]), KEMError> {
         // Source the random message m from the provided RNG
-        if rng.security_strength() < SecurityStrength::from_bits(LAMBDA as usize) {
+        if rng.security_strength() < P::MAX_SECURITY_STRENGTH {
             return Err(RNGError::SecurityStrengthInsufficientForAlgorithm)?;
         }
         let mut m = [0u8; 32];
@@ -799,20 +754,20 @@ impl<
 
         let mut key = KeyMaterial::<SS_LEN>::from_bytes_as_type(&ss, KeyType::CryptographicRandom)?;
         do_hazardous_operations(&mut key, |key| {
-            key.set_security_strength(SecurityStrength::from_bits(LAMBDA as usize))
+            key.set_security_strength(P::MAX_SECURITY_STRENGTH)
         })?;
 
         Ok((key, ct))
     }
 
     fn decaps_with_expanded_key(
-        sk: &MLKEMPrivateKeyExpanded<k, PK, SK, SK_LEN, PK_LEN>,
+        sk: &MLKEMPrivateKeyExpanded<P, PK, SK, SK_LEN, PK_LEN>,
         ct: &[u8],
     ) -> Result<KeyMaterial<SS_LEN>, KEMError> {
         /* decapsulation inputs checks described on FIPS 203 section 7.3 */
         // 1. (Ciphertext type check) If 𝑐 is not a byte array of length 32(𝑑𝑢 𝑘 + 𝑑𝑣) for the values of 𝑑𝑢,
         //     𝑑𝑣, and 𝑘 specified by the relevant parameter set, then input checking has failed.
-        debug_assert_eq!(CT_LEN, 32 * ((du as usize) * k + (dv as usize)));
+        debug_assert_eq!(CT_LEN, 32 * ((P::du as usize) * P::k + (P::dv as usize)));
 
         if ct.len() != CT_LEN {
             return Err(KEMError::LengthError("Ciphertext has the incorrect length"));
@@ -830,7 +785,7 @@ impl<
 
         let mut key = KeyMaterial::<SS_LEN>::from_bytes_as_type(&K, KeyType::CryptographicRandom)?;
         do_hazardous_operations(&mut key, |key| {
-            key.set_security_strength(SecurityStrength::from_bits(LAMBDA as usize))
+            key.set_security_strength(P::MAX_SECURITY_STRENGTH)
         })?;
 
         Ok(key)
@@ -839,18 +794,14 @@ impl<
 
 /// Trait for all three of the ML-DSA algorithm variants.
 pub trait MLKEMTrait<
+    P: MLKEMParams,
+    PK: MLKEMPublicKeyTrait<P, PK_LEN> + MLKEMPublicKeyInternalTrait<P, PK_LEN>,
+    SK: MLKEMPrivateKeyTrait<P, PK, SK_LEN, PK_LEN>
+        + MLKEMPrivateKeyInternalTrait<P, PK, SK_LEN, PK_LEN>,
     const PK_LEN: usize,
     const SK_LEN: usize,
     const CT_LEN: usize,
     const SS_LEN: usize,
-    PK: MLKEMPublicKeyTrait<k, PK_LEN> + MLKEMPublicKeyInternalTrait<k, PK_LEN>,
-    SK: MLKEMPrivateKeyTrait<k, PK, SK_LEN, PK_LEN>
-        + MLKEMPrivateKeyInternalTrait<k, PK, SK_LEN, PK_LEN>,
-    const k: usize,
-    const eta: i16,
-    const du: i16,
-    const dv: i16,
-    const LAMBDA: i16,
 >: Sized
 {
     /// Generates a fresh key pair.
@@ -862,7 +813,7 @@ pub trait MLKEMTrait<
     // Should still be ok in FIPS mode, provided that you're using the FIPS-approved RNG.
     fn keygen_from_rng(rng: &mut dyn RNG) -> Result<(PK, SK), KEMError> {
         // Source the seed from the provided RNG
-        if rng.security_strength() < SecurityStrength::from_bits(LAMBDA as usize) {
+        if rng.security_strength() < P::MAX_SECURITY_STRENGTH {
             return Err(RNGError::SecurityStrengthInsufficientForAlgorithm)?;
         }
         let mut seed = KeyMaterial::<64>::new();
@@ -893,37 +844,32 @@ pub trait MLKEMTrait<
 
     /// Same as [`KEMEncapsulator::encaps`], but acts on an [`MLKEMPublicKeyExpanded`].
     fn encaps_for_expanded_key(
-        pk: &MLKEMPublicKeyExpanded<k, PK, PK_LEN>,
+        pk: &MLKEMPublicKeyExpanded<P, PK, PK_LEN>,
     ) -> Result<(KeyMaterial<SS_LEN>, [u8; CT_LEN]), KEMError>;
 
     /// Same as [`KEMEncapsulator::encaps`], but acts on an [`MLKEMPublicKeyExpanded`] and uses a provided RNG.
     fn encaps_for_expanded_key_rng(
-        pk: &MLKEMPublicKeyExpanded<k, PK, PK_LEN>,
+        pk: &MLKEMPublicKeyExpanded<P, PK, PK_LEN>,
         rng: &mut dyn RNG,
     ) -> Result<(KeyMaterial<SS_LEN>, [u8; CT_LEN]), KEMError>;
 
     /// Same as [`KEMDecapsulator::decaps`], but acts on an [`MLKEMPrivateKeyExpanded`].
     fn decaps_with_expanded_key(
-        sk: &MLKEMPrivateKeyExpanded<k, PK, SK, SK_LEN, PK_LEN>,
+        sk: &MLKEMPrivateKeyExpanded<P, PK, SK, SK_LEN, PK_LEN>,
         ct: &[u8],
     ) -> Result<KeyMaterial<SS_LEN>, KEMError>;
 }
 
 impl<
+    P: MLKEMParams,
+    PK: MLKEMPublicKeyTrait<P, PK_LEN> + MLKEMPublicKeyInternalTrait<P, PK_LEN>,
+    SK: MLKEMPrivateKeyTrait<P, PK, SK_LEN, PK_LEN>
+        + MLKEMPrivateKeyInternalTrait<P, PK, SK_LEN, PK_LEN>,
     const PK_LEN: usize,
     const SK_LEN: usize,
     const CT_LEN: usize,
     const SS_LEN: usize,
-    PK: MLKEMPublicKeyTrait<k, PK_LEN> + MLKEMPublicKeyInternalTrait<k, PK_LEN>,
-    SK: MLKEMPrivateKeyTrait<k, PK, SK_LEN, PK_LEN>
-        + MLKEMPrivateKeyInternalTrait<k, PK, SK_LEN, PK_LEN>,
-    const k: usize,
-    const eta: i16,
-    const du: i16,
-    const dv: i16,
-    const LAMBDA: i16,
-> KEMEncapsulator<PK, PK_LEN, CT_LEN, SS_LEN>
-    for MLKEM<PK_LEN, SK_LEN, CT_LEN, SS_LEN, PK, SK, k, eta, du, dv, LAMBDA>
+> KEMEncapsulator<PK, PK_LEN, CT_LEN, SS_LEN> for MLKEM<P, PK, SK, PK_LEN, SK_LEN, CT_LEN, SS_LEN>
 {
     /// Performs an encapsulation against the given public key, using the library's default internal RNG.
     /// Returns (shared_secret_key, ciphertext)
@@ -944,25 +890,20 @@ impl<
         pk: &PK,
         rng: &mut dyn RNG,
     ) -> Result<(KeyMaterial<SS_LEN>, [u8; CT_LEN]), KEMError> {
-        Self::encaps_for_expanded_key_rng(&MLKEMPublicKeyExpanded::<k, PK, PK_LEN>::from(pk), rng)
+        Self::encaps_for_expanded_key_rng(&MLKEMPublicKeyExpanded::<P, PK, PK_LEN>::from(pk), rng)
     }
 }
 
 impl<
+    P: MLKEMParams,
+    PK: MLKEMPublicKeyTrait<P, PK_LEN> + MLKEMPublicKeyInternalTrait<P, PK_LEN>,
+    SK: MLKEMPrivateKeyTrait<P, PK, SK_LEN, PK_LEN>
+        + MLKEMPrivateKeyInternalTrait<P, PK, SK_LEN, PK_LEN>,
     const PK_LEN: usize,
     const SK_LEN: usize,
     const CT_LEN: usize,
     const SS_LEN: usize,
-    PK: MLKEMPublicKeyTrait<k, PK_LEN> + MLKEMPublicKeyInternalTrait<k, PK_LEN>,
-    SK: MLKEMPrivateKeyTrait<k, PK, SK_LEN, PK_LEN>
-        + MLKEMPrivateKeyInternalTrait<k, PK, SK_LEN, PK_LEN>,
-    const k: usize,
-    const eta: i16,
-    const du: i16,
-    const dv: i16,
-    const LAMBDA: i16,
-> KEMDecapsulator<SK, SK_LEN, CT_LEN, SS_LEN>
-    for MLKEM<PK_LEN, SK_LEN, CT_LEN, SS_LEN, PK, SK, k, eta, du, dv, LAMBDA>
+> KEMDecapsulator<SK, SK_LEN, CT_LEN, SS_LEN> for MLKEM<P, PK, SK, PK_LEN, SK_LEN, CT_LEN, SS_LEN>
 {
     /// Performs a decapsulation of the given ciphertext.
     /// Returns the shared secret key.
@@ -971,7 +912,7 @@ impl<
     /// As ML-KEM is an implicitly-rejecting KEM, this returns an error only if the ciphertext is invalid (ie the wrong length)..
     fn decaps(sk: &SK, ct: &[u8]) -> Result<KeyMaterial<SS_LEN>, KEMError> {
         Self::decaps_with_expanded_key(
-            &MLKEMPrivateKeyExpanded::<k, PK, SK, SK_LEN, PK_LEN>::from(sk),
+            &MLKEMPrivateKeyExpanded::<P, PK, SK, SK_LEN, PK_LEN>::from(sk),
             ct,
         )
     }

--- a/crypto/mlkem/src/mlkem.rs
+++ b/crypto/mlkem/src/mlkem.rs
@@ -181,29 +181,29 @@ pub(crate) const POLY_BYTES: usize = 384;
 
 /* ML-KEM-512 sizes (FIPS 203, Table 3) */
 
-/// Length of the \[u8] holding a ML-KEM-512 public key.
+/// Length of the \[u8] holding an ML-KEM-512 public key.
 pub const MLKEM512_PK_LEN: usize = MLKEM512Params::PK_LEN;
-/// Length of the \[u8] holding a ML-KEM-512 private key.
+/// Length of the \[u8] holding an ML-KEM-512 private key.
 pub const MLKEM512_SK_LEN: usize = MLKEM512Params::SK_LEN;
-/// Length of the \[u8] holding a ML-KEM-512 ciphertext.
+/// Length of the \[u8] holding an ML-KEM-512 ciphertext.
 pub const MLKEM512_CT_LEN: usize = MLKEM512Params::CT_LEN;
 
 /* ML-KEM-768 sizes (FIPS 203, Table 3) */
 
-/// Length of the \[u8] holding a ML-KEM-768 public key.
+/// Length of the \[u8] holding an ML-KEM-768 public key.
 pub const MLKEM768_PK_LEN: usize = MLKEM768Params::PK_LEN;
-/// Length of the \[u8] holding a ML-KEM-768 private key.
+/// Length of the \[u8] holding an ML-KEM-768 private key.
 pub const MLKEM768_SK_LEN: usize = MLKEM768Params::SK_LEN;
-/// Length of the \[u8] holding a ML-KEM-768 ciphertext.
+/// Length of the \[u8] holding an ML-KEM-768 ciphertext.
 pub const MLKEM768_CT_LEN: usize = MLKEM768Params::CT_LEN;
 
 /* ML-KEM-1024 sizes (FIPS 203, Table 3) */
 
-/// Length of the \[u8] holding a ML-KEM-1024 public key.
+/// Length of the \[u8] holding an ML-KEM-1024 public key.
 pub const MLKEM1024_PK_LEN: usize = MLKEM1024Params::PK_LEN;
-/// Length of the \[u8] holding a ML-KEM-1024 private key.
+/// Length of the \[u8] holding an ML-KEM-1024 private key.
 pub const MLKEM1024_SK_LEN: usize = MLKEM1024Params::SK_LEN;
-/// Length of the \[u8] holding a ML-KEM-1024 ciphertext.
+/// Length of the \[u8] holding an ML-KEM-1024 ciphertext.
 pub const MLKEM1024_CT_LEN: usize = MLKEM1024Params::CT_LEN;
 
 // Typedefs just to make the algorithms look more like the FIPS 204 sample code.

--- a/crypto/mlkem/src/mlkem.rs
+++ b/crypto/mlkem/src/mlkem.rs
@@ -528,8 +528,6 @@ impl<
         A_hat: Option<&P::MatrixA>,
         m: [u8; 32],
     ) -> ([u8; 32], [u8; CT_LEN]) {
-        debug_assert_eq!(CT_LEN, 32 * ((P::du as usize) * P::k + (P::dv as usize)));
-
         // 1: (𝐾, 𝑟) ← G(𝑚‖H(ek))
         //  ▷ derive shared secret key 𝐾 and randomness 𝑟
         let K: [u8; MLKEM_SS_LEN];
@@ -767,7 +765,6 @@ impl<
         /* decapsulation inputs checks described on FIPS 203 section 7.3 */
         // 1. (Ciphertext type check) If 𝑐 is not a byte array of length 32(𝑑𝑢 𝑘 + 𝑑𝑣) for the values of 𝑑𝑢,
         //     𝑑𝑣, and 𝑘 specified by the relevant parameter set, then input checking has failed.
-        debug_assert_eq!(CT_LEN, 32 * ((P::du as usize) * P::k + (P::dv as usize)));
 
         if ct.len() != CT_LEN {
             return Err(KEMError::LengthError("Ciphertext has the incorrect length"));

--- a/crypto/mlkem/src/mlkem_keys.rs
+++ b/crypto/mlkem/src/mlkem_keys.rs
@@ -1,14 +1,14 @@
 use crate::aux_functions::{byte_decode, byte_encode, expandA};
-use crate::matrix::{Matrix, Vector};
+use crate::matrix::VectorTrait;
 use crate::mlkem::{H, POLY_BYTES, q};
-use crate::mlkem::{MLKEM512_PK_LEN, MLKEM512_SK_LEN, MLKEM512_k};
-use crate::mlkem::{MLKEM768_PK_LEN, MLKEM768_SK_LEN, MLKEM768_k};
-use crate::mlkem::{MLKEM1024_PK_LEN, MLKEM1024_SK_LEN, MLKEM1024_k};
-use crate::{ML_KEM_512_NAME, ML_KEM_768_NAME, ML_KEM_1024_NAME};
+use crate::mlkem::{MLKEM512_PK_LEN, MLKEM512_SK_LEN};
+use crate::mlkem::{MLKEM768_PK_LEN, MLKEM768_SK_LEN};
+use crate::mlkem::{MLKEM1024_PK_LEN, MLKEM1024_SK_LEN};
+use crate::params::{MLKEM512Params, MLKEM768Params, MLKEM1024Params, MLKEMParams};
 use bouncycastle_core::errors::KEMError;
 use bouncycastle_core::key_material;
 use bouncycastle_core::key_material::{KeyMaterial, KeyMaterialTrait, KeyType};
-use bouncycastle_core::traits::{Hash, KEMPrivateKey, KEMPublicKey, SecurityStrength};
+use bouncycastle_core::traits::{Hash, KEMPrivateKey, KEMPublicKey};
 use bouncycastle_sha3::SHA3_256;
 use bouncycastle_utils::secret::Secret;
 use core::fmt;
@@ -23,29 +23,29 @@ use crate::polynomial::Polynomial;
 /* Pub Types */
 
 /// ML-KEM-512 Public Key
-pub type MLKEM512PublicKey = MLKEMPublicKey<MLKEM512_k, MLKEM512_PK_LEN>;
+pub type MLKEM512PublicKey = MLKEMPublicKey<MLKEM512Params, MLKEM512_PK_LEN>;
 /// ML-KEM-512 Private Key
 pub type MLKEM512PrivateKey =
-    MLKEMPrivateKey<MLKEM512_k, MLKEM512PublicKey, MLKEM512_SK_LEN, MLKEM512_PK_LEN>;
+    MLKEMPrivateKey<MLKEM512Params, MLKEM512PublicKey, MLKEM512_SK_LEN, MLKEM512_PK_LEN>;
 /// ML-KEM-768 Public Key
-pub type MLKEM768PublicKey = MLKEMPublicKey<MLKEM768_k, MLKEM768_PK_LEN>;
+pub type MLKEM768PublicKey = MLKEMPublicKey<MLKEM768Params, MLKEM768_PK_LEN>;
 /// ML-KEM-768 Private Key
 pub type MLKEM768PrivateKey =
-    MLKEMPrivateKey<MLKEM768_k, MLKEM768PublicKey, MLKEM768_SK_LEN, MLKEM768_PK_LEN>;
+    MLKEMPrivateKey<MLKEM768Params, MLKEM768PublicKey, MLKEM768_SK_LEN, MLKEM768_PK_LEN>;
 /// ML-KEM-1024 Public Key
-pub type MLKEM1024PublicKey = MLKEMPublicKey<MLKEM1024_k, MLKEM1024_PK_LEN>;
+pub type MLKEM1024PublicKey = MLKEMPublicKey<MLKEM1024Params, MLKEM1024_PK_LEN>;
 /// ML-KEM-1024 Private Key
 pub type MLKEM1024PrivateKey =
-    MLKEMPrivateKey<MLKEM1024_k, MLKEM1024PublicKey, MLKEM1024_SK_LEN, MLKEM1024_PK_LEN>;
+    MLKEMPrivateKey<MLKEM1024Params, MLKEM1024PublicKey, MLKEM1024_SK_LEN, MLKEM1024_PK_LEN>;
 
 /* Pre-expanded keys for repeated operations */
 
 /// ML-KEM-512 Public Key with a pre-expanded public matrix A for repeated encaps operations.
 pub type MLKEM512PublicKeyExpanded =
-    MLKEMPublicKeyExpanded<MLKEM512_k, MLKEM512PublicKey, MLKEM512_PK_LEN>;
+    MLKEMPublicKeyExpanded<MLKEM512Params, MLKEM512PublicKey, MLKEM512_PK_LEN>;
 /// ML-KEM-512 Private Key with a pre-expanded public matrix A for repeated decaps operations.
 pub type MLKEM512PrivateKeyExpanded = MLKEMPrivateKeyExpanded<
-    MLKEM512_k,
+    MLKEM512Params,
     MLKEM512PublicKey,
     MLKEM512PrivateKey,
     MLKEM512_SK_LEN,
@@ -53,10 +53,10 @@ pub type MLKEM512PrivateKeyExpanded = MLKEMPrivateKeyExpanded<
 >;
 /// ML-KEM-768 Public Key with a pre-expanded public matrix A for repeated encaps operations.
 pub type MLKEM768PublicKeyExpanded =
-    MLKEMPublicKeyExpanded<MLKEM768_k, MLKEM768PublicKey, MLKEM768_PK_LEN>;
+    MLKEMPublicKeyExpanded<MLKEM768Params, MLKEM768PublicKey, MLKEM768_PK_LEN>;
 /// ML-KEM-768 Private Key with a pre-expanded public matrix A for repeated decaps operations.
 pub type MLKEM768PrivateKeyExpanded = MLKEMPrivateKeyExpanded<
-    MLKEM768_k,
+    MLKEM768Params,
     MLKEM768PublicKey,
     MLKEM768PrivateKey,
     MLKEM768_SK_LEN,
@@ -64,10 +64,10 @@ pub type MLKEM768PrivateKeyExpanded = MLKEMPrivateKeyExpanded<
 >;
 /// ML-KEM-1024 Public Key with a pre-expanded public matrix A for repeated encaps operations.
 pub type MLKEM1024PublicKeyExpanded =
-    MLKEMPublicKeyExpanded<MLKEM1024_k, MLKEM1024PublicKey, MLKEM1024_PK_LEN>;
+    MLKEMPublicKeyExpanded<MLKEM1024Params, MLKEM1024PublicKey, MLKEM1024_PK_LEN>;
 /// ML-KEM-1024 Private Key with a pre-expanded public matrix A for repeated decaps operations.
 pub type MLKEM1024PrivateKeyExpanded = MLKEMPrivateKeyExpanded<
-    MLKEM1024_k,
+    MLKEM1024Params,
     MLKEM1024PublicKey,
     MLKEM1024PrivateKey,
     MLKEM1024_SK_LEN,
@@ -75,50 +75,57 @@ pub type MLKEM1024PrivateKeyExpanded = MLKEMPrivateKeyExpanded<
 >;
 
 /// An ML-KEM public key.
-#[derive(Clone)]
-pub struct MLKEMPublicKey<const k: usize, const PK_LEN: usize> {
-    t_hat: Vector<k>,
+pub struct MLKEMPublicKey<P: MLKEMParams, const PK_LEN: usize> {
+    t_hat: P::VecK,
     rho: [u8; 32],
 }
 
+// Written out rather than derived: `#[derive(Clone)]` would demand `P: Clone`, and `P` is a
+// marker for the parameter set that is never stored, only used to name the field types.
+impl<P: MLKEMParams, const PK_LEN: usize> Clone for MLKEMPublicKey<P, PK_LEN> {
+    fn clone(&self) -> Self {
+        Self { t_hat: self.t_hat, rho: self.rho }
+    }
+}
+
 /// General trait for all ML-KEM public keys types.
-pub trait MLKEMPublicKeyTrait<const k: usize, const PK_LEN: usize>: KEMPublicKey<PK_LEN> {
+pub trait MLKEMPublicKeyTrait<P: MLKEMParams, const PK_LEN: usize>: KEMPublicKey<PK_LEN> {
     /// Algorithm 23 pkDecode(𝑝𝑘)
     /// Reverses the procedure pkEncode.
     /// Input: Public key 𝑝𝑘 ∈ 𝔹32+32𝑘(bitlen (𝑞−1)−𝑑).
     /// Output: 𝜌 ∈ 𝔹32, 𝐭1 ∈ 𝑅𝑘 with coefficients in [0, 2bitlen (𝑞−1)−𝑑 − 1].
     fn pk_decode(pk: &[u8; PK_LEN]) -> Result<Self, KEMError>;
     /// Get a copy of the expanded public matrix A_hat
-    fn A_hat(&self) -> Matrix<k, k>;
+    fn A_hat(&self) -> P::MatrixA;
     /// Get the hash of the public key
     fn compute_hash(&self) -> [u8; 32];
 }
 
-pub(crate) trait MLKEMPublicKeyInternalTrait<const k: usize, const PK_LEN: usize>:
-    MLKEMPublicKeyTrait<k, PK_LEN>
+pub(crate) trait MLKEMPublicKeyInternalTrait<P: MLKEMParams, const PK_LEN: usize>:
+    MLKEMPublicKeyTrait<P, PK_LEN>
 {
     /// Not exposing a constructor publicly because you should have to get an instance either by
     /// running a keygen, or by decoding an existing key.
-    fn new(t_hat: Vector<k>, rho: [u8; 32]) -> Self;
+    fn new(t_hat: P::VecK, rho: [u8; 32]) -> Self;
 
     /// Get a ref to t1
-    fn t_hat(&self) -> &Vector<k>;
+    fn t_hat(&self) -> &P::VecK;
 }
 
-impl<const k: usize, const PK_LEN: usize> MLKEMPublicKeyTrait<k, PK_LEN>
-    for MLKEMPublicKey<k, PK_LEN>
+impl<P: MLKEMParams, const PK_LEN: usize> MLKEMPublicKeyTrait<P, PK_LEN>
+    for MLKEMPublicKey<P, PK_LEN>
 {
     fn pk_decode(pk: &[u8; PK_LEN]) -> Result<Self, KEMError> {
         let (pk_chunks, last_chunk) = pk.as_chunks::<POLY_BYTES>();
 
         // that should divide evenly the remainder of the array, leaving space for rho at the end
-        debug_assert_eq!(pk_chunks.len(), k);
+        debug_assert_eq!(pk_chunks.len(), P::k);
         debug_assert_eq!(last_chunk.len(), 32);
 
         let t_hat = {
-            let mut t_hat = Vector::<k>::new();
+            let mut t_hat = P::VecK::new();
 
-            for (t_i, pk_chunk) in t_hat.elems.iter_mut().zip(pk_chunks) {
+            for (t_i, pk_chunk) in t_hat.elems_mut().iter_mut().zip(pk_chunks) {
                 t_i.coeffs.copy_from_slice(&byte_decode::<12, POLY_BYTES>(pk_chunk).coeffs);
 
                 // FIPS 203 says:
@@ -141,8 +148,8 @@ impl<const k: usize, const PK_LEN: usize> MLKEMPublicKeyTrait<k, PK_LEN>
         Ok(Self::new(t_hat, rho))
     }
 
-    fn A_hat(&self) -> Matrix<k, k> {
-        expandA(&self.rho)
+    fn A_hat(&self) -> P::MatrixA {
+        expandA::<P>(&self.rho)
     }
 
     fn compute_hash(&self) -> [u8; 32] {
@@ -153,19 +160,19 @@ impl<const k: usize, const PK_LEN: usize> MLKEMPublicKeyTrait<k, PK_LEN>
     }
 }
 
-impl<const k: usize, const PK_LEN: usize> MLKEMPublicKeyInternalTrait<k, PK_LEN>
-    for MLKEMPublicKey<k, PK_LEN>
+impl<P: MLKEMParams, const PK_LEN: usize> MLKEMPublicKeyInternalTrait<P, PK_LEN>
+    for MLKEMPublicKey<P, PK_LEN>
 {
-    fn new(t_hat: Vector<k>, rho: [u8; 32]) -> Self {
+    fn new(t_hat: P::VecK, rho: [u8; 32]) -> Self {
         Self { rho, t_hat }
     }
 
-    fn t_hat(&self) -> &Vector<k> {
+    fn t_hat(&self) -> &P::VecK {
         &self.t_hat
     }
 }
 
-impl<const k: usize, const PK_LEN: usize> KEMPublicKey<PK_LEN> for MLKEMPublicKey<k, PK_LEN> {
+impl<P: MLKEMParams, const PK_LEN: usize> KEMPublicKey<PK_LEN> for MLKEMPublicKey<P, PK_LEN> {
     /// Encodes the public key as per FIPS 203 Algorithm 13
     /// 19: ekPKE ← ByteEncode12(𝐭)‖𝜌
     fn encode(&self) -> [u8; PK_LEN] {
@@ -177,7 +184,7 @@ impl<const k: usize, const PK_LEN: usize> KEMPublicKey<PK_LEN> for MLKEMPublicKe
     /// Encodes the public key as per FIPS 203 Algorithm 13
     /// 19: ekPKE ← ByteEncode12(𝐭)‖𝜌
     fn encode_out(&self, out: &mut [u8; PK_LEN]) -> usize {
-        debug_assert_eq!(PK_LEN, 12 * k * 32 + 32);
+        debug_assert_eq!(PK_LEN, 12 * P::k * 32 + 32);
         debug_assert_eq!(POLY_BYTES, 12 * 32);
 
         out.fill(0);
@@ -185,10 +192,10 @@ impl<const k: usize, const PK_LEN: usize> KEMPublicKey<PK_LEN> for MLKEMPublicKe
         let (pk_chunks, last_chunk) = out.as_chunks_mut::<POLY_BYTES>();
 
         // that should divide evenly the remainder of the array, leaving space for rho at the end
-        debug_assert_eq!(pk_chunks.len(), k);
+        debug_assert_eq!(pk_chunks.len(), P::k);
         debug_assert_eq!(last_chunk.len(), 32);
 
-        for (pk_chunk, t_i) in pk_chunks.into_iter().zip(&self.t_hat.elems) {
+        for (pk_chunk, t_i) in pk_chunks.into_iter().zip(self.t_hat.elems()) {
             pk_chunk.copy_from_slice(&byte_encode::<12, POLY_BYTES>(t_i));
         }
         last_chunk.copy_from_slice(&self.rho);
@@ -205,70 +212,66 @@ impl<const k: usize, const PK_LEN: usize> KEMPublicKey<PK_LEN> for MLKEMPublicKe
     }
 }
 
-impl<const k: usize, const PK_LEN: usize> Eq for MLKEMPublicKey<k, PK_LEN> {}
+impl<P: MLKEMParams, const PK_LEN: usize> Eq for MLKEMPublicKey<P, PK_LEN> {}
 
-impl<const k: usize, const PK_LEN: usize> PartialEq for MLKEMPublicKey<k, PK_LEN> {
+impl<P: MLKEMParams, const PK_LEN: usize> PartialEq for MLKEMPublicKey<P, PK_LEN> {
     fn eq(&self, other: &Self) -> bool {
         bouncycastle_utils::ct::ct_eq_bytes(&self.encode(), &other.encode())
     }
 }
 
-impl<const k: usize, const PK_LEN: usize> Debug for MLKEMPublicKey<k, PK_LEN> {
+impl<P: MLKEMParams, const PK_LEN: usize> Debug for MLKEMPublicKey<P, PK_LEN> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        let alg = match k {
-            2 => ML_KEM_512_NAME,
-            3 => ML_KEM_768_NAME,
-            4 => ML_KEM_1024_NAME,
-            _ => panic!("Unsupported key length"),
-        };
         let hash = SHA3_256::new().hash(&self.encode());
-        write!(f, "MLKEMPublicKey {{ alg: {}, pub_key_hash: {:x?} }}", alg, hash)
+        write!(f, "MLKEMPublicKey {{ alg: {}, pub_key_hash: {:x?} }}", P::ALG_NAME, hash)
     }
 }
 
-impl<const k: usize, const PK_LEN: usize> Display for MLKEMPublicKey<k, PK_LEN> {
+impl<P: MLKEMParams, const PK_LEN: usize> Display for MLKEMPublicKey<P, PK_LEN> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        let alg = match k {
-            2 => ML_KEM_512_NAME,
-            3 => ML_KEM_768_NAME,
-            4 => ML_KEM_1024_NAME,
-            _ => panic!("Unsupported key length"),
-        };
         let hash = SHA3_256::new().hash(&self.encode());
-        write!(f, "MLKEMPublicKey {{ alg: {}, pub_key_hash: {:x?} }}", alg, hash)
+        write!(f, "MLKEMPublicKey {{ alg: {}, pub_key_hash: {:x?} }}", P::ALG_NAME, hash)
     }
 }
 
 /// A fully expanded ML-KEM public key that includes the intermediate values needed for performing multiple encaps operations
 /// against the same public key, which causes the MLKEMPublicKey struct to take up more memory, but results
 /// in more efficient repeated encaps() operations.
-#[derive(Clone)]
 pub struct MLKEMPublicKeyExpanded<
-    const k: usize,
-    PK: MLKEMPublicKeyInternalTrait<k, PK_LEN>,
+    P: MLKEMParams,
+    PK: MLKEMPublicKeyInternalTrait<P, PK_LEN>,
     const PK_LEN: usize,
 > {
     pub(crate) ek: PK,
-    pub(crate) A_hat: Matrix<k, k>,
+    pub(crate) A_hat: P::MatrixA,
 }
 
-impl<const k: usize, PK: MLKEMPublicKeyInternalTrait<k, PK_LEN>, const PK_LEN: usize>
-    MLKEMPublicKeyInternalTrait<k, PK_LEN> for MLKEMPublicKeyExpanded<k, PK, PK_LEN>
+/// See the note on [`MLKEMPublicKey`]'s `Clone` for why this is not derived.
+impl<P: MLKEMParams, PK: MLKEMPublicKeyInternalTrait<P, PK_LEN>, const PK_LEN: usize> Clone
+    for MLKEMPublicKeyExpanded<P, PK, PK_LEN>
 {
-    fn new(t_hat: Vector<k>, rho: [u8; 32]) -> Self {
+    fn clone(&self) -> Self {
+        Self { ek: self.ek.clone(), A_hat: self.A_hat.clone() }
+    }
+}
+
+impl<P: MLKEMParams, PK: MLKEMPublicKeyInternalTrait<P, PK_LEN>, const PK_LEN: usize>
+    MLKEMPublicKeyInternalTrait<P, PK_LEN> for MLKEMPublicKeyExpanded<P, PK, PK_LEN>
+{
+    fn new(t_hat: P::VecK, rho: [u8; 32]) -> Self {
         let ek = PK::new(t_hat, rho);
         let A_hat = ek.A_hat();
 
         Self { ek, A_hat }
     }
 
-    fn t_hat(&self) -> &Vector<k> {
+    fn t_hat(&self) -> &P::VecK {
         self.ek.t_hat()
     }
 }
 
-impl<const k: usize, PK: MLKEMPublicKeyInternalTrait<k, PK_LEN>, const PK_LEN: usize>
-    KEMPublicKey<PK_LEN> for MLKEMPublicKeyExpanded<k, PK, PK_LEN>
+impl<P: MLKEMParams, PK: MLKEMPublicKeyInternalTrait<P, PK_LEN>, const PK_LEN: usize>
+    KEMPublicKey<PK_LEN> for MLKEMPublicKeyExpanded<P, PK, PK_LEN>
 {
     fn encode(&self) -> [u8; PK_LEN] {
         let mut pk = [0u8; PK_LEN];
@@ -292,51 +295,39 @@ impl<const k: usize, PK: MLKEMPublicKeyInternalTrait<k, PK_LEN>, const PK_LEN: u
     }
 }
 
-impl<const k: usize, PK: MLKEMPublicKeyInternalTrait<k, PK_LEN>, const PK_LEN: usize> PartialEq
-    for MLKEMPublicKeyExpanded<k, PK, PK_LEN>
+impl<P: MLKEMParams, PK: MLKEMPublicKeyInternalTrait<P, PK_LEN>, const PK_LEN: usize> PartialEq
+    for MLKEMPublicKeyExpanded<P, PK, PK_LEN>
 {
     fn eq(&self, other: &Self) -> bool {
         self.encode() == other.encode()
     }
 }
 
-impl<const k: usize, PK: MLKEMPublicKeyInternalTrait<k, PK_LEN>, const PK_LEN: usize> Eq
-    for MLKEMPublicKeyExpanded<k, PK, PK_LEN>
+impl<P: MLKEMParams, PK: MLKEMPublicKeyInternalTrait<P, PK_LEN>, const PK_LEN: usize> Eq
+    for MLKEMPublicKeyExpanded<P, PK, PK_LEN>
 {
 }
 
-impl<const k: usize, PK: MLKEMPublicKeyInternalTrait<k, PK_LEN>, const PK_LEN: usize> Debug
-    for MLKEMPublicKeyExpanded<k, PK, PK_LEN>
+impl<P: MLKEMParams, PK: MLKEMPublicKeyInternalTrait<P, PK_LEN>, const PK_LEN: usize> Debug
+    for MLKEMPublicKeyExpanded<P, PK, PK_LEN>
 {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        let alg = match k {
-            2 => ML_KEM_512_NAME,
-            3 => ML_KEM_768_NAME,
-            4 => ML_KEM_1024_NAME,
-            _ => panic!("Unsupported key length"),
-        };
         let hash = SHA3_256::new().hash(&self.encode());
-        write!(f, "MLKEMPublicKeyExpanded {{ alg: {}, pub_key_hash: {:x?} }}", alg, hash)
+        write!(f, "MLKEMPublicKeyExpanded {{ alg: {}, pub_key_hash: {:x?} }}", P::ALG_NAME, hash)
     }
 }
 
-impl<const k: usize, PK: MLKEMPublicKeyInternalTrait<k, PK_LEN>, const PK_LEN: usize> Display
-    for MLKEMPublicKeyExpanded<k, PK, PK_LEN>
+impl<P: MLKEMParams, PK: MLKEMPublicKeyInternalTrait<P, PK_LEN>, const PK_LEN: usize> Display
+    for MLKEMPublicKeyExpanded<P, PK, PK_LEN>
 {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        let alg = match k {
-            2 => ML_KEM_512_NAME,
-            3 => ML_KEM_768_NAME,
-            4 => ML_KEM_1024_NAME,
-            _ => panic!("Unsupported key length"),
-        };
         let hash = SHA3_256::new().hash(&self.encode());
-        write!(f, "MLKEMPublicKeyExpanded {{ alg: {}, pub_key_hash: {:x?} }}", alg, hash)
+        write!(f, "MLKEMPublicKeyExpanded {{ alg: {}, pub_key_hash: {:x?} }}", P::ALG_NAME, hash)
     }
 }
 
-impl<const k: usize, PK: MLKEMPublicKeyInternalTrait<k, PK_LEN>, const PK_LEN: usize>
-    MLKEMPublicKeyTrait<k, PK_LEN> for MLKEMPublicKeyExpanded<k, PK, PK_LEN>
+impl<P: MLKEMParams, PK: MLKEMPublicKeyInternalTrait<P, PK_LEN>, const PK_LEN: usize>
+    MLKEMPublicKeyTrait<P, PK_LEN> for MLKEMPublicKeyExpanded<P, PK, PK_LEN>
 {
     fn pk_decode(pk: &[u8; PK_LEN]) -> Result<Self, KEMError> {
         let ek = PK::pk_decode(pk)?;
@@ -344,7 +335,7 @@ impl<const k: usize, PK: MLKEMPublicKeyInternalTrait<k, PK_LEN>, const PK_LEN: u
         Ok(Self { ek, A_hat })
     }
 
-    fn A_hat(&self) -> Matrix<k, k> {
+    fn A_hat(&self) -> P::MatrixA {
         self.A_hat.clone()
     }
 
@@ -353,8 +344,8 @@ impl<const k: usize, PK: MLKEMPublicKeyInternalTrait<k, PK_LEN>, const PK_LEN: u
     }
 }
 
-impl<const k: usize, PK: MLKEMPublicKeyInternalTrait<k, PK_LEN>, const PK_LEN: usize> From<&PK>
-    for MLKEMPublicKeyExpanded<k, PK, PK_LEN>
+impl<P: MLKEMParams, PK: MLKEMPublicKeyInternalTrait<P, PK_LEN>, const PK_LEN: usize> From<&PK>
+    for MLKEMPublicKeyExpanded<P, PK, PK_LEN>
 {
     /// Fully expands the intermediate values needed for performing multiple encaps operations
     /// against the same public key, which causes the MLKEMPublicKey struct to take up
@@ -368,43 +359,64 @@ impl<const k: usize, PK: MLKEMPublicKeyInternalTrait<k, PK_LEN>, const PK_LEN: u
 /// An ML-KEM private key.
 ///
 // Dev note: This will automatically inherit the [`Secret`] protections because [`Polynomial`] wraps the underlying data with [`Secret`].
-#[derive(Clone)]
 pub struct MLKEMPrivateKey<
-    const k: usize,
-    PK: MLKEMPublicKeyInternalTrait<k, PK_LEN>,
+    P: MLKEMParams,
+    PK: MLKEMPublicKeyInternalTrait<P, PK_LEN>,
     const SK_LEN: usize,
     const PK_LEN: usize,
 > {
-    s_hat: Secret<Vector<k>>,
+    s_hat: Secret<P::VecK>,
     ek: PK,
     pk_hash: [u8; 32],
     z: Secret<[u8; 32]>,
     seed_d: Option<Secret<[u8; 32]>>,
 }
 
+/// See the note on [`MLKEMPublicKey`]'s `Clone` for why this is not derived.
 impl<
-    const k: usize,
-    PK: MLKEMPublicKeyInternalTrait<k, PK_LEN>,
+    P: MLKEMParams,
+    PK: MLKEMPublicKeyInternalTrait<P, PK_LEN>,
     const SK_LEN: usize,
     const PK_LEN: usize,
-> MLKEMPrivateKey<k, PK, SK_LEN, PK_LEN>
+> Clone for MLKEMPrivateKey<P, PK, SK_LEN, PK_LEN>
+{
+    fn clone(&self) -> Self {
+        Self {
+            s_hat: self.s_hat.clone(),
+            ek: self.ek.clone(),
+            pk_hash: self.pk_hash,
+            z: self.z.clone(),
+            seed_d: self.seed_d.clone(),
+        }
+    }
+}
+
+impl<
+    P: MLKEMParams,
+    PK: MLKEMPublicKeyInternalTrait<P, PK_LEN>,
+    const SK_LEN: usize,
+    const PK_LEN: usize,
+> MLKEMPrivateKey<P, PK, SK_LEN, PK_LEN>
 {
     /// As described on Algorithm 16 line
     ///   3: dk ← (dkPKE ‖ ek ‖ H(ek) ‖ 𝑧)
     fn sk_encode_out(&self, out: &mut [u8; SK_LEN]) -> usize {
         out.fill(0);
 
-        debug_assert_eq!(SK_LEN, /* dk_pke*/ 12*k*32 + /*ek*/PK_LEN + /*H(ek)*/32 + /*z*/32);
+        debug_assert_eq!(
+            SK_LEN,
+            /* dk_pke*/ 12*P::k*32 + /*ek*/PK_LEN + /*H(ek)*/32 + /*z*/32
+        );
 
         let mut pos = 0usize;
 
         /* dk_pke */
         // Alg 13; line 20: dkPKE ← ByteEncode12(𝐬)
-        for i in 0..k {
+        for i in 0..P::k {
             out[i * POLY_BYTES..(i + 1) * POLY_BYTES]
                 .copy_from_slice(&byte_encode::<12, POLY_BYTES>(&self.s_hat[i]));
         }
-        pos += k * POLY_BYTES;
+        pos += P::k * POLY_BYTES;
 
         /* ek */
         // Alg 13; line 19: ekPKE ← ByteEncode12(𝐭)‖𝜌
@@ -426,8 +438,8 @@ impl<
 
 /// General trait for all ML-KEM private keys types.
 pub trait MLKEMPrivateKeyTrait<
-    const k: usize,
-    PK: MLKEMPublicKeyInternalTrait<k, PK_LEN>,
+    P: MLKEMParams,
+    PK: MLKEMPublicKeyInternalTrait<P, PK_LEN>,
     const SK_LEN: usize,
     const PK_LEN: usize,
 >: KEMPrivateKey<SK_LEN>
@@ -444,8 +456,8 @@ pub trait MLKEMPrivateKeyTrait<
 }
 
 pub(crate) trait MLKEMPrivateKeyInternalTrait<
-    const k: usize,
-    PK: MLKEMPublicKeyTrait<k, PK_LEN>,
+    P: MLKEMParams,
+    PK: MLKEMPublicKeyTrait<P, PK_LEN>,
     const SK_LEN: usize,
     const PK_LEN: usize,
 >
@@ -453,7 +465,7 @@ pub(crate) trait MLKEMPrivateKeyInternalTrait<
     /// Not exposing a constructor publicly because you should have to get an instance either by
     /// running a keygen, or by decoding an existing key.
     fn new(
-        s_hat: Secret<Vector<k>>,
+        s_hat: Secret<P::VecK>,
         ek: PK,
         h: [u8; 32],
         z: Secret<[u8; 32]>,
@@ -461,17 +473,17 @@ pub(crate) trait MLKEMPrivateKeyInternalTrait<
     ) -> Self;
 
     /// Get a ref to s_hat
-    fn s_hat(&self) -> &Vector<k>;
+    fn s_hat(&self) -> &P::VecK;
 
     fn z(&self) -> &Secret<[u8; 32]>;
 }
 
 impl<
-    const k: usize,
-    PK: MLKEMPublicKeyInternalTrait<k, PK_LEN>,
+    P: MLKEMParams,
+    PK: MLKEMPublicKeyInternalTrait<P, PK_LEN>,
     const SK_LEN: usize,
     const PK_LEN: usize,
-> MLKEMPrivateKeyTrait<k, PK, SK_LEN, PK_LEN> for MLKEMPrivateKey<k, PK, SK_LEN, PK_LEN>
+> MLKEMPrivateKeyTrait<P, PK, SK_LEN, PK_LEN> for MLKEMPrivateKey<P, PK, SK_LEN, PK_LEN>
 {
     fn seed(&self) -> Option<KeyMaterial<64>> {
         if self.seed_d.is_none() {
@@ -483,12 +495,7 @@ impl<
             let mut seed = KeyMaterial::<64>::from_bytes_as_type(&*tmp, KeyType::Seed).unwrap();
 
             key_material::do_hazardous_operations(&mut seed, |seed| {
-                seed.set_security_strength(match k {
-                    2 => SecurityStrength::_128bit,
-                    3 => SecurityStrength::_192bit,
-                    4 => SecurityStrength::_256bit,
-                    _ => unreachable!("Invalid mlkem param set"),
-                })
+                seed.set_security_strength(P::MAX_SECURITY_STRENGTH)
             })
             .unwrap();
 
@@ -505,14 +512,17 @@ impl<
     }
 
     fn sk_decode(sk: &[u8; SK_LEN]) -> Result<Self, KEMError> {
-        debug_assert_eq!(SK_LEN, /* dk_pke*/ 12*k*32 + /*ek*/PK_LEN + /*H(ek)*/32 + /*z*/32);
+        debug_assert_eq!(
+            SK_LEN,
+            /* dk_pke*/ 12*P::k*32 + /*ek*/PK_LEN + /*H(ek)*/32 + /*z*/32
+        );
 
         let mut pos = 0usize;
 
         /* dk_pke */
-        let mut s_hat: Secret<Vector<k>> = Secret::new();
+        let mut s_hat: Secret<P::VecK> = Secret::new();
         // for (s_i, sk_chunk) in s_hat.0.iter_mut().zip(sk_chunks) {
-        for i in 0..k {
+        for i in 0..P::k {
             s_hat[i] = byte_decode::<12, POLY_BYTES>(
                 sk[i * POLY_BYTES..(i + 1) * POLY_BYTES].try_into().unwrap(),
             );
@@ -529,7 +539,7 @@ impl<
                 }
             }
         }
-        pos += k * POLY_BYTES;
+        pos += P::k * POLY_BYTES;
 
         /* ek */
         let ek = PK::pk_decode(sk[pos..pos + PK_LEN].try_into().unwrap())?;
@@ -557,15 +567,15 @@ impl<
 }
 
 impl<
-    const k: usize,
-    PK: MLKEMPublicKeyInternalTrait<k, PK_LEN>,
+    P: MLKEMParams,
+    PK: MLKEMPublicKeyInternalTrait<P, PK_LEN>,
     const SK_LEN: usize,
     const PK_LEN: usize,
-> MLKEMPrivateKeyInternalTrait<k, PK, SK_LEN, PK_LEN> for MLKEMPrivateKey<k, PK, SK_LEN, PK_LEN>
+> MLKEMPrivateKeyInternalTrait<P, PK, SK_LEN, PK_LEN> for MLKEMPrivateKey<P, PK, SK_LEN, PK_LEN>
 {
     /// Note to future maintainers: FIPS 203 section 7.3 requires that ek be hashed and compared to pk_hash.
     fn new(
-        s_hat: Secret<Vector<k>>,
+        s_hat: Secret<P::VecK>,
         ek: PK,
         pk_hash: [u8; 32],
         z: Secret<[u8; 32]>,
@@ -574,7 +584,7 @@ impl<
         Self { s_hat, ek, pk_hash, z, seed_d: seed_d.clone() }
     }
 
-    fn s_hat(&self) -> &Vector<k> {
+    fn s_hat(&self) -> &P::VecK {
         &self.s_hat
     }
 
@@ -584,11 +594,11 @@ impl<
 }
 
 impl<
-    const k: usize,
-    PK: MLKEMPublicKeyInternalTrait<k, PK_LEN>,
+    P: MLKEMParams,
+    PK: MLKEMPublicKeyInternalTrait<P, PK_LEN>,
     const SK_LEN: usize,
     const PK_LEN: usize,
-> KEMPrivateKey<SK_LEN> for MLKEMPrivateKey<k, PK, SK_LEN, PK_LEN>
+> KEMPrivateKey<SK_LEN> for MLKEMPrivateKey<P, PK, SK_LEN, PK_LEN>
 {
     fn encode(&self) -> [u8; SK_LEN] {
         let mut out = [0u8; SK_LEN];
@@ -617,20 +627,20 @@ impl<
 }
 
 impl<
-    const k: usize,
-    PK: MLKEMPublicKeyInternalTrait<k, PK_LEN>,
+    P: MLKEMParams,
+    PK: MLKEMPublicKeyInternalTrait<P, PK_LEN>,
     const SK_LEN: usize,
     const PK_LEN: usize,
-> Eq for MLKEMPrivateKey<k, PK, SK_LEN, PK_LEN>
+> Eq for MLKEMPrivateKey<P, PK, SK_LEN, PK_LEN>
 {
 }
 
 impl<
-    const k: usize,
-    PK: MLKEMPublicKeyInternalTrait<k, PK_LEN>,
+    P: MLKEMParams,
+    PK: MLKEMPublicKeyInternalTrait<P, PK_LEN>,
     const SK_LEN: usize,
     const PK_LEN: usize,
-> PartialEq for MLKEMPrivateKey<k, PK, SK_LEN, PK_LEN>
+> PartialEq for MLKEMPrivateKey<P, PK, SK_LEN, PK_LEN>
 {
     fn eq(&self, other: &Self) -> bool {
         let self_encoded = self.encode();
@@ -641,23 +651,17 @@ impl<
 
 /// Debug impl mainly to prevent the secret key from being printed in logs.
 impl<
-    const k: usize,
-    PK: MLKEMPublicKeyInternalTrait<k, PK_LEN>,
+    P: MLKEMParams,
+    PK: MLKEMPublicKeyInternalTrait<P, PK_LEN>,
     const SK_LEN: usize,
     const PK_LEN: usize,
-> fmt::Debug for MLKEMPrivateKey<k, PK, SK_LEN, PK_LEN>
+> fmt::Debug for MLKEMPrivateKey<P, PK, SK_LEN, PK_LEN>
 {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        let alg = match k {
-            2 => ML_KEM_512_NAME,
-            3 => ML_KEM_768_NAME,
-            4 => ML_KEM_1024_NAME,
-            _ => panic!("Unsupported key length"),
-        };
         write!(
             f,
             "MLKEMPrivateKey {{ alg: {}, pub_key_hash: {:x?}, has_seed: {} }}",
-            alg,
+            P::ALG_NAME,
             self.pk_hash,
             self.seed_d.is_some(),
         )
@@ -666,23 +670,17 @@ impl<
 
 /// Display impl mainly to prevent the secret key from being printed in logs.
 impl<
-    const k: usize,
-    PK: MLKEMPublicKeyInternalTrait<k, PK_LEN>,
+    P: MLKEMParams,
+    PK: MLKEMPublicKeyInternalTrait<P, PK_LEN>,
     const SK_LEN: usize,
     const PK_LEN: usize,
-> Display for MLKEMPrivateKey<k, PK, SK_LEN, PK_LEN>
+> Display for MLKEMPrivateKey<P, PK, SK_LEN, PK_LEN>
 {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        let alg = match k {
-            2 => ML_KEM_512_NAME,
-            3 => ML_KEM_768_NAME,
-            4 => ML_KEM_1024_NAME,
-            _ => panic!("Unsupported key length"),
-        };
         write!(
             f,
             "MLKEMPrivateKey {{ alg: {}, pub_key_hash: {:x?}, has_seed: {} }}",
-            alg,
+            P::ALG_NAME,
             self.pk_hash,
             self.seed_d.is_some(),
         )
@@ -692,28 +690,42 @@ impl<
 /// A fully expanded ML-KEM private key that includes the intermediate values needed for performing
 /// multiple decaps operations with the same private key, which causes the private key struct to
 /// take up more memory, but results in more efficient repeated decaps() operations.
-#[derive(Clone)]
 pub struct MLKEMPrivateKeyExpanded<
-    const k: usize,
-    PK: MLKEMPublicKeyInternalTrait<k, PK_LEN>,
-    SK: MLKEMPrivateKeyTrait<k, PK, SK_LEN, PK_LEN>
-        + MLKEMPrivateKeyInternalTrait<k, PK, SK_LEN, PK_LEN>,
+    P: MLKEMParams,
+    PK: MLKEMPublicKeyInternalTrait<P, PK_LEN>,
+    SK: MLKEMPrivateKeyTrait<P, PK, SK_LEN, PK_LEN>
+        + MLKEMPrivateKeyInternalTrait<P, PK, SK_LEN, PK_LEN>,
     const SK_LEN: usize,
     const PK_LEN: usize,
 > {
     _phantom: core::marker::PhantomData<PK>,
     pub(crate) dk: SK,
-    pub(crate) A_hat: Matrix<k, k>,
+    pub(crate) A_hat: P::MatrixA,
+}
+
+/// See the note on [`MLKEMPublicKey`]'s `Clone` for why this is not derived.
+impl<
+    P: MLKEMParams,
+    PK: MLKEMPublicKeyInternalTrait<P, PK_LEN>,
+    SK: MLKEMPrivateKeyTrait<P, PK, SK_LEN, PK_LEN>
+        + MLKEMPrivateKeyInternalTrait<P, PK, SK_LEN, PK_LEN>,
+    const SK_LEN: usize,
+    const PK_LEN: usize,
+> Clone for MLKEMPrivateKeyExpanded<P, PK, SK, SK_LEN, PK_LEN>
+{
+    fn clone(&self) -> Self {
+        Self { _phantom: core::marker::PhantomData, dk: self.dk.clone(), A_hat: self.A_hat.clone() }
+    }
 }
 
 impl<
-    const k: usize,
-    PK: MLKEMPublicKeyInternalTrait<k, PK_LEN>,
-    SK: MLKEMPrivateKeyTrait<k, PK, SK_LEN, PK_LEN>
-        + MLKEMPrivateKeyInternalTrait<k, PK, SK_LEN, PK_LEN>,
+    P: MLKEMParams,
+    PK: MLKEMPublicKeyInternalTrait<P, PK_LEN>,
+    SK: MLKEMPrivateKeyTrait<P, PK, SK_LEN, PK_LEN>
+        + MLKEMPrivateKeyInternalTrait<P, PK, SK_LEN, PK_LEN>,
     const SK_LEN: usize,
     const PK_LEN: usize,
-> From<&SK> for MLKEMPrivateKeyExpanded<k, PK, SK, SK_LEN, PK_LEN>
+> From<&SK> for MLKEMPrivateKeyExpanded<P, PK, SK, SK_LEN, PK_LEN>
 {
     /// Fully expands the intermediate values needed for performing multiple encaps operations
     /// against the same public key, which causes the MLKEMPublicKey struct to take up
@@ -725,13 +737,13 @@ impl<
 }
 
 impl<
-    const k: usize,
-    PK: MLKEMPublicKeyInternalTrait<k, PK_LEN>,
-    SK: MLKEMPrivateKeyTrait<k, PK, SK_LEN, PK_LEN>
-        + MLKEMPrivateKeyInternalTrait<k, PK, SK_LEN, PK_LEN>,
+    P: MLKEMParams,
+    PK: MLKEMPublicKeyInternalTrait<P, PK_LEN>,
+    SK: MLKEMPrivateKeyTrait<P, PK, SK_LEN, PK_LEN>
+        + MLKEMPrivateKeyInternalTrait<P, PK, SK_LEN, PK_LEN>,
     const SK_LEN: usize,
     const PK_LEN: usize,
-> KEMPrivateKey<SK_LEN> for MLKEMPrivateKeyExpanded<k, PK, SK, SK_LEN, PK_LEN>
+> KEMPrivateKey<SK_LEN> for MLKEMPrivateKeyExpanded<P, PK, SK, SK_LEN, PK_LEN>
 {
     fn encode(&self) -> [u8; SK_LEN] {
         self.dk.encode()
@@ -749,13 +761,13 @@ impl<
 }
 
 impl<
-    const k: usize,
-    PK: MLKEMPublicKeyInternalTrait<k, PK_LEN>,
-    SK: MLKEMPrivateKeyTrait<k, PK, SK_LEN, PK_LEN>
-        + MLKEMPrivateKeyInternalTrait<k, PK, SK_LEN, PK_LEN>,
+    P: MLKEMParams,
+    PK: MLKEMPublicKeyInternalTrait<P, PK_LEN>,
+    SK: MLKEMPrivateKeyTrait<P, PK, SK_LEN, PK_LEN>
+        + MLKEMPrivateKeyInternalTrait<P, PK, SK_LEN, PK_LEN>,
     const SK_LEN: usize,
     const PK_LEN: usize,
-> PartialEq for MLKEMPrivateKeyExpanded<k, PK, SK, SK_LEN, PK_LEN>
+> PartialEq for MLKEMPrivateKeyExpanded<P, PK, SK, SK_LEN, PK_LEN>
 {
     fn eq(&self, other: &Self) -> bool {
         self.dk.eq(&other.dk)
@@ -763,36 +775,30 @@ impl<
 }
 
 impl<
-    const k: usize,
-    PK: MLKEMPublicKeyInternalTrait<k, PK_LEN>,
-    SK: MLKEMPrivateKeyTrait<k, PK, SK_LEN, PK_LEN>
-        + MLKEMPrivateKeyInternalTrait<k, PK, SK_LEN, PK_LEN>,
+    P: MLKEMParams,
+    PK: MLKEMPublicKeyInternalTrait<P, PK_LEN>,
+    SK: MLKEMPrivateKeyTrait<P, PK, SK_LEN, PK_LEN>
+        + MLKEMPrivateKeyInternalTrait<P, PK, SK_LEN, PK_LEN>,
     const SK_LEN: usize,
     const PK_LEN: usize,
-> Eq for MLKEMPrivateKeyExpanded<k, PK, SK, SK_LEN, PK_LEN>
+> Eq for MLKEMPrivateKeyExpanded<P, PK, SK, SK_LEN, PK_LEN>
 {
 }
 
 impl<
-    const k: usize,
-    PK: MLKEMPublicKeyInternalTrait<k, PK_LEN>,
-    SK: MLKEMPrivateKeyTrait<k, PK, SK_LEN, PK_LEN>
-        + MLKEMPrivateKeyInternalTrait<k, PK, SK_LEN, PK_LEN>,
+    P: MLKEMParams,
+    PK: MLKEMPublicKeyInternalTrait<P, PK_LEN>,
+    SK: MLKEMPrivateKeyTrait<P, PK, SK_LEN, PK_LEN>
+        + MLKEMPrivateKeyInternalTrait<P, PK, SK_LEN, PK_LEN>,
     const SK_LEN: usize,
     const PK_LEN: usize,
-> Debug for MLKEMPrivateKeyExpanded<k, PK, SK, SK_LEN, PK_LEN>
+> Debug for MLKEMPrivateKeyExpanded<P, PK, SK, SK_LEN, PK_LEN>
 {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        let alg = match k {
-            2 => ML_KEM_512_NAME,
-            3 => ML_KEM_768_NAME,
-            4 => ML_KEM_1024_NAME,
-            _ => panic!("Unsupported key length"),
-        };
         write!(
             f,
             "MLKEMPrivateKeyExpanded {{ alg: {}, pub_key_hash: {:x?}, has_seed: {} }}",
-            alg,
+            P::ALG_NAME,
             self.dk.pk().compute_hash(),
             self.dk.seed().is_some(),
         )
@@ -800,25 +806,19 @@ impl<
 }
 
 impl<
-    const k: usize,
-    PK: MLKEMPublicKeyInternalTrait<k, PK_LEN>,
-    SK: MLKEMPrivateKeyTrait<k, PK, SK_LEN, PK_LEN>
-        + MLKEMPrivateKeyInternalTrait<k, PK, SK_LEN, PK_LEN>,
+    P: MLKEMParams,
+    PK: MLKEMPublicKeyInternalTrait<P, PK_LEN>,
+    SK: MLKEMPrivateKeyTrait<P, PK, SK_LEN, PK_LEN>
+        + MLKEMPrivateKeyInternalTrait<P, PK, SK_LEN, PK_LEN>,
     const SK_LEN: usize,
     const PK_LEN: usize,
-> Display for MLKEMPrivateKeyExpanded<k, PK, SK, SK_LEN, PK_LEN>
+> Display for MLKEMPrivateKeyExpanded<P, PK, SK, SK_LEN, PK_LEN>
 {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        let alg = match k {
-            2 => ML_KEM_512_NAME,
-            3 => ML_KEM_768_NAME,
-            4 => ML_KEM_1024_NAME,
-            _ => panic!("Unsupported key length"),
-        };
         write!(
             f,
             "MLKEMPrivateKeyExpanded {{ alg: {}, pub_key_hash: {:x?}, has_seed: {} }}",
-            alg,
+            P::ALG_NAME,
             self.dk.pk().compute_hash(),
             self.dk.seed().is_some(),
         )
@@ -826,14 +826,14 @@ impl<
 }
 
 impl<
-    const k: usize,
-    PK: MLKEMPublicKeyInternalTrait<k, PK_LEN>,
-    SK: MLKEMPrivateKeyTrait<k, PK, SK_LEN, PK_LEN>
-        + MLKEMPrivateKeyInternalTrait<k, PK, SK_LEN, PK_LEN>,
+    P: MLKEMParams,
+    PK: MLKEMPublicKeyInternalTrait<P, PK_LEN>,
+    SK: MLKEMPrivateKeyTrait<P, PK, SK_LEN, PK_LEN>
+        + MLKEMPrivateKeyInternalTrait<P, PK, SK_LEN, PK_LEN>,
     const SK_LEN: usize,
     const PK_LEN: usize,
-> MLKEMPrivateKeyTrait<k, PK, SK_LEN, PK_LEN>
-    for MLKEMPrivateKeyExpanded<k, PK, SK, SK_LEN, PK_LEN>
+> MLKEMPrivateKeyTrait<P, PK, SK_LEN, PK_LEN>
+    for MLKEMPrivateKeyExpanded<P, PK, SK, SK_LEN, PK_LEN>
 {
     fn seed(&self) -> Option<KeyMaterial<64>> {
         self.dk.seed()

--- a/crypto/mlkem/src/mlkem_keys.rs
+++ b/crypto/mlkem/src/mlkem_keys.rs
@@ -184,7 +184,6 @@ impl<P: MLKEMParams, const PK_LEN: usize> KEMPublicKey<PK_LEN> for MLKEMPublicKe
     /// Encodes the public key as per FIPS 203 Algorithm 13
     /// 19: ekPKE ← ByteEncode12(𝐭)‖𝜌
     fn encode_out(&self, out: &mut [u8; PK_LEN]) -> usize {
-        debug_assert_eq!(PK_LEN, 12 * P::k * 32 + 32);
         debug_assert_eq!(POLY_BYTES, 12 * 32);
 
         out.fill(0);

--- a/crypto/mlkem/src/params.rs
+++ b/crypto/mlkem/src/params.rs
@@ -49,15 +49,15 @@ pub trait MLKEMParams: MLKEMParamsInternalTrait {
 
     /* Derived. Never written out per parameter set -- see the module docs. */
 
-    /// The length of an encapsulation key: FIPS 203, Algorithm 16 (ML-KEM.KeyGen) gives
+    /// The length of an encapsulation key: FIPS 203, Algorithm 16 (ML-KEM.KeyGen_internal) gives
     /// ek ∈ 𝔹^(384𝑘+32).
     const PK_LEN: usize = 384 * Self::k + 32;
 
-    /// The length of a decapsulation key: FIPS 203, Algorithm 16 (ML-KEM.KeyGen) gives
+    /// The length of a decapsulation key: FIPS 203, Algorithm 16 (ML-KEM.KeyGen_internal) gives
     /// dk ∈ 𝔹^(768𝑘+96).
     const SK_LEN: usize = 768 * Self::k + 96;
 
-    /// The length of a ciphertext: FIPS 203, Algorithm 17 (ML-KEM.Encaps) gives
+    /// The length of a ciphertext: FIPS 203, Algorithm 17 (ML-KEM.Encaps_internal) gives
     /// 𝑐 ∈ 𝔹^(32(𝑑𝑢𝑘+𝑑𝑣)).
     const CT_LEN: usize = 32 * (Self::du as usize * Self::k + Self::dv as usize);
 

--- a/crypto/mlkem/src/params.rs
+++ b/crypto/mlkem/src/params.rs
@@ -1,0 +1,223 @@
+//! The three ML-KEM parameter sets of FIPS 203, Section 8, as a sealed trait with one type per set.
+//!
+//! # Derived parameters
+//!
+//! FIPS 203, Table 2 assigns five values per set (𝑘, 𝜂1, 𝜂2, 𝑑𝑢, 𝑑𝑣); its last column, the
+//! required RBG strength, is carried by `MAX_SECURITY_STRENGTH`.
+//! The three sizes of Table 3 are each a function of those, so they are written once as defaulted
+//! associated consts rather than three times as a hand-computed number. `params::tests` checks every
+//! derivation against the values tabulated in FIPS 203.
+
+use crate::matrix::{Matrix, MatrixTrait, Vector, VectorTrait};
+use crate::mlkem::{ML_KEM_512_NAME, ML_KEM_768_NAME, ML_KEM_1024_NAME, MLKEM_SS_LEN};
+use bouncycastle_core::traits::SecurityStrength;
+
+/// A crate-private (aka "sealed") trait that prevents a new ML-KEM parameter set from being defined
+/// outside this crate.
+trait MLKEMParamsInternalTrait {}
+
+/// One ML-KEM parameter set: the values of FIPS 203, Table 2 and Table 3, and the types whose size
+/// they determine.
+///
+/// Sealed via a private supertrait, so [`MLKEM512Params`], [`MLKEM768Params`] and
+/// [`MLKEM1024Params`] are the only implementations.
+pub trait MLKEMParams: MLKEMParamsInternalTrait {
+    /* FIPS 203, Table 2: the values assigned by each parameter set. */
+
+    /// 𝑘, the rank of the module.
+    const k: usize;
+    /// 𝜂1, the CBD parameter used for the secret vector 𝐬 and the keygen error vector 𝐞.
+    const eta1: i16;
+    /// 𝜂2, the CBD parameter used for the encaps error terms 𝐞1 and 𝑒2.
+    /// FIPS 203, Table 2 lists this per parameter set even though all three assign it 2.
+    const eta2: i16;
+    /// 𝑑𝑢, the compression parameter for 𝐮.
+    const du: i16;
+    /// 𝑑𝑣, the compression parameter for 𝑣.
+    const dv: i16;
+
+    /* Algorithm meta-data */
+
+    /// The algorithm name, as reported by `Algorithm::ALG_NAME`.
+    const ALG_NAME: &'static str;
+    /// The strength claimed for this parameter set, as reported by `Algorithm::MAX_SECURITY_STRENGTH`.
+    const MAX_SECURITY_STRENGTH: SecurityStrength;
+    /// The OID in component form, as reported by `AlgorithmOID::OID`.
+    const OID: &'static [u32];
+    /// The DER encoding of [`MLKEMParams::OID`], as reported by `AlgorithmOID::OID_DER`.
+    const OID_DER: &'static [u8];
+
+    /* Derived. Never written out per parameter set -- see the module docs. */
+
+    /// The length of an encapsulation key: FIPS 203, Algorithm 16 (ML-KEM.KeyGen) gives
+    /// ek ∈ 𝔹^(384𝑘+32).
+    const PK_LEN: usize = 384 * Self::k + 32;
+
+    /// The length of a decapsulation key: FIPS 203, Algorithm 16 (ML-KEM.KeyGen) gives
+    /// dk ∈ 𝔹^(768𝑘+96).
+    const SK_LEN: usize = 768 * Self::k + 96;
+
+    /// The length of a ciphertext: FIPS 203, Algorithm 17 (ML-KEM.Encaps) gives
+    /// 𝑐 ∈ 𝔹^(32(𝑑𝑢𝑘+𝑑𝑣)).
+    const CT_LEN: usize = 32 * (Self::du as usize * Self::k + Self::dv as usize);
+
+    /// The length of a shared secret. 32 bytes for every parameter set (FIPS 203, Table 3).
+    const SS_LEN: usize = MLKEM_SS_LEN;
+
+    /* Types whose size depends on the parameter set. */
+
+    /// A vector of 𝑘 polynomials, i.e. an element of 𝑅^𝑘.
+    type VecK: VectorTrait;
+    /// The 𝑘 × 𝑘 public matrix 𝐀̂.
+    type MatrixA: MatrixTrait<Vec = Self::VecK>;
+}
+
+/// The ML-KEM-512 parameter set (FIPS 203, Table 2).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MLKEM512Params;
+/// The ML-KEM-768 parameter set (FIPS 203, Table 2).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MLKEM768Params;
+/// The ML-KEM-1024 parameter set (FIPS 203, Table 2).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MLKEM1024Params;
+
+impl MLKEMParamsInternalTrait for MLKEM512Params {}
+impl MLKEMParamsInternalTrait for MLKEM768Params {}
+impl MLKEMParamsInternalTrait for MLKEM1024Params {}
+
+impl MLKEMParams for MLKEM512Params {
+    const k: usize = 2;
+    const eta1: i16 = 3;
+    const eta2: i16 = 2;
+    const du: i16 = 10;
+    const dv: i16 = 4;
+
+    const ALG_NAME: &'static str = ML_KEM_512_NAME;
+    const MAX_SECURITY_STRENGTH: SecurityStrength = SecurityStrength::_128bit;
+    /// Assigned by NIST in the Computer Security Objects Register: id-alg-ml-kem-512 { kems 1 }
+    const OID: &'static [u32] = &[2, 16, 840, 1, 101, 3, 4, 4, 1];
+    const OID_DER: &'static [u8] =
+        &[0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x04, 0x01];
+
+    type VecK = Vector<2>;
+    type MatrixA = Matrix<2, 2>;
+}
+
+impl MLKEMParams for MLKEM768Params {
+    const k: usize = 3;
+    const eta1: i16 = 2;
+    const eta2: i16 = 2;
+    const du: i16 = 10;
+    const dv: i16 = 4;
+
+    const ALG_NAME: &'static str = ML_KEM_768_NAME;
+    const MAX_SECURITY_STRENGTH: SecurityStrength = SecurityStrength::_192bit;
+    /// Assigned by NIST in the Computer Security Objects Register: id-alg-ml-kem-768 { kems 2 }
+    const OID: &'static [u32] = &[2, 16, 840, 1, 101, 3, 4, 4, 2];
+    const OID_DER: &'static [u8] =
+        &[0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x04, 0x02];
+
+    type VecK = Vector<3>;
+    type MatrixA = Matrix<3, 3>;
+}
+
+impl MLKEMParams for MLKEM1024Params {
+    const k: usize = 4;
+    const eta1: i16 = 2;
+    const eta2: i16 = 2;
+    const du: i16 = 11;
+    const dv: i16 = 5;
+
+    const ALG_NAME: &'static str = ML_KEM_1024_NAME;
+    const MAX_SECURITY_STRENGTH: SecurityStrength = SecurityStrength::_256bit;
+    /// Assigned by NIST in the Computer Security Objects Register: id-alg-ml-kem-1024 { kems 3 }
+    const OID: &'static [u32] = &[2, 16, 840, 1, 101, 3, 4, 4, 3];
+    const OID_DER: &'static [u8] =
+        &[0x06, 0x09, 0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x04, 0x03];
+
+    type VecK = Vector<4>;
+    type MatrixA = Matrix<4, 4>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// FIPS 203, Table 2, transcribed row by row: the five values each parameter set
+    /// assigns, plus its last column. `(k, eta1, eta2, du, dv, rbg_strength)`.
+    const TABLE_2: [(usize, i16, i16, i16, i16, i16); 3] =
+        [(2, 3, 2, 10, 4, 128), (3, 2, 2, 10, 4, 192), (4, 2, 2, 11, 5, 256)];
+
+    /// FIPS 203, Table 3, transcribed row by row, in bytes:
+    /// `(encapsulation key, decapsulation key, ciphertext, shared secret key)`.
+    const TABLE_3: [(usize, usize, usize, usize); 3] =
+        [(800, 1632, 768, 32), (1184, 2400, 1088, 32), (1568, 3168, 1568, 32)];
+
+    fn check_table_2<P: MLKEMParams>(i: usize) {
+        let (k, eta1, eta2, du, dv, rbg_strength) = TABLE_2[i];
+        assert_eq!(P::k, k, "{}: 𝑘", P::ALG_NAME);
+        assert_eq!(P::eta1, eta1, "{}: 𝜂1", P::ALG_NAME);
+        assert_eq!(P::eta2, eta2, "{}: 𝜂2", P::ALG_NAME);
+        assert_eq!(P::du, du, "{}: 𝑑𝑢", P::ALG_NAME);
+        assert_eq!(P::dv, dv, "{}: 𝑑𝑣", P::ALG_NAME);
+        assert_eq!(
+            P::MAX_SECURITY_STRENGTH,
+            SecurityStrength::from_bits(rbg_strength as usize),
+            "{}: required RBG strength",
+            P::ALG_NAME
+        );
+    }
+
+    fn check_table_3<P: MLKEMParams>(i: usize) {
+        let (pk_len, sk_len, ct_len, ss_len) = TABLE_3[i];
+        assert_eq!(P::PK_LEN, pk_len, "{}: encapsulation key size", P::ALG_NAME);
+        assert_eq!(P::SK_LEN, sk_len, "{}: decapsulation key size", P::ALG_NAME);
+        assert_eq!(P::CT_LEN, ct_len, "{}: ciphertext size", P::ALG_NAME);
+        assert_eq!(P::SS_LEN, ss_len, "{}: shared secret size", P::ALG_NAME);
+    }
+
+    /// The associated types must be as long as `k` says; they are written out by hand per
+    /// parameter set, so this guards against a typo in one of them.
+    fn check_associated_type_sizes<P: MLKEMParams>() {
+        assert_eq!(<P::VecK as VectorTrait>::LEN, P::k, "{}: VecK vs 𝑘", P::ALG_NAME);
+        assert_eq!(<P::MatrixA as MatrixTrait>::ROWS, P::k, "{}: MatrixA rows vs 𝑘", P::ALG_NAME);
+        assert_eq!(<P::MatrixA as MatrixTrait>::COLS, P::k, "{}: MatrixA cols vs 𝑘", P::ALG_NAME);
+    }
+
+    #[test]
+    fn test_parameter_sets_match_fips203_table_2() {
+        check_table_2::<MLKEM512Params>(0);
+        check_table_2::<MLKEM768Params>(1);
+        check_table_2::<MLKEM1024Params>(2);
+    }
+
+    #[test]
+    fn test_sizes_match_fips203_table_3() {
+        check_table_3::<MLKEM512Params>(0);
+        check_table_3::<MLKEM768Params>(1);
+        check_table_3::<MLKEM1024Params>(2);
+    }
+
+    #[test]
+    fn test_associated_types_are_the_length_their_consts_claim() {
+        check_associated_type_sizes::<MLKEM512Params>();
+        check_associated_type_sizes::<MLKEM768Params>();
+        check_associated_type_sizes::<MLKEM1024Params>();
+    }
+
+    /// Each of the sizes of Table 3 also has a formula in FIPS 203, and the two must agree.
+    /// Table 3 is what is written down above; this is what re-derives it.
+    #[test]
+    fn test_table_3_sizes_agree_with_the_encoding_formulas() {
+        for (k, du, dv, pk, sk, ct) in [
+            (2usize, 10usize, 4usize, 800usize, 1632usize, 768usize),
+            (3, 10, 4, 1184, 2400, 1088),
+            (4, 11, 5, 1568, 3168, 1568),
+        ] {
+            assert_eq!(384 * k + 32, pk, "Algorithm 16: ek ∈ 𝔹^(384𝑘+32)");
+            assert_eq!(768 * k + 96, sk, "Algorithm 16: dk ∈ 𝔹^(768𝑘+96)");
+            assert_eq!(32 * (du * k + dv), ct, "Algorithm 17: 𝑐 ∈ 𝔹^(32(𝑑𝑢𝑘+𝑑𝑣))");
+        }
+    }
+}

--- a/crypto/mlkem/src/params.rs
+++ b/crypto/mlkem/src/params.rs
@@ -213,19 +213,4 @@ mod tests {
         check_associated_type_sizes::<MLKEM768Params>();
         check_associated_type_sizes::<MLKEM1024Params>();
     }
-
-    /// Each of the sizes of Table 3 also has a formula in FIPS 203, and the two must agree.
-    /// Table 3 is what is written down above; this is what re-derives it.
-    #[test]
-    fn test_table_3_sizes_agree_with_the_encoding_formulas() {
-        for (k, du, dv, pk, sk, ct) in [
-            (2usize, 10usize, 4usize, 800usize, 1632usize, 768usize),
-            (3, 10, 4, 1184, 2400, 1088),
-            (4, 11, 5, 1568, 3168, 1568),
-        ] {
-            assert_eq!(384 * k + 32, pk, "Algorithm 16: ek ∈ 𝔹^(384𝑘+32)");
-            assert_eq!(768 * k + 96, sk, "Algorithm 16: dk ∈ 𝔹^(768𝑘+96)");
-            assert_eq!(32 * (du * k + dv), ct, "Algorithm 17: 𝑐 ∈ 𝔹^(32(𝑑𝑢𝑘+𝑑𝑣))");
-        }
-    }
 }

--- a/crypto/mlkem/src/params.rs
+++ b/crypto/mlkem/src/params.rs
@@ -180,9 +180,17 @@ mod tests {
     /// The associated types must be as long as `k` says; they are written out by hand per
     /// parameter set, so this guards against a typo in one of them.
     fn check_associated_type_sizes<P: MLKEMParams>() {
-        assert_eq!(<P::VecK as VectorTrait>::LEN, P::k, "{}: VecK vs 𝑘", P::ALG_NAME);
-        assert_eq!(<P::MatrixA as MatrixTrait>::ROWS, P::k, "{}: MatrixA rows vs 𝑘", P::ALG_NAME);
-        assert_eq!(<P::MatrixA as MatrixTrait>::COLS, P::k, "{}: MatrixA cols vs 𝑘", P::ALG_NAME);
+        // Measured rather than read off a const: `MatrixTrait<Vec = Self::VecK>` already ties the
+        // matrix to the vector at the type level, so the only thing left to check is that both
+        // are 𝑘 polynomials long.
+        let poly = size_of::<crate::polynomial::Polynomial>();
+        assert_eq!(size_of::<P::VecK>(), P::k * poly, "{}: VecK vs 𝑘", P::ALG_NAME);
+        assert_eq!(
+            size_of::<P::MatrixA>(),
+            P::k * P::k * poly,
+            "{}: MatrixA vs 𝑘 × 𝑘",
+            P::ALG_NAME
+        );
     }
 
     #[test]

--- a/crypto/mlkem/src/polynomial.rs
+++ b/crypto/mlkem/src/polynomial.rs
@@ -6,6 +6,7 @@ use crate::aux_functions::{
     ZETAS, ZETAS_INV, barrett_reduce, montgomery_reduce, mul_mont, ntt_base_mult,
 };
 use crate::mlkem::{N, q};
+use crate::params::MLKEMParams;
 
 /// A polynomial over the ML-KEM ring.
 ///
@@ -14,7 +15,10 @@ use crate::mlkem::{N, q};
 /// and sometimes private keys.
 /// It is the responsibility of the caller to wrap sensitive instances in `Secret<Vector>`.
 #[derive(Clone, Copy)]
-pub(crate) struct Polynomial {
+///
+/// Public only because it appears in [`crate::VectorTrait`]'s signatures; its fields and
+/// operations are crate-private, so from outside it is an opaque handle.
+pub struct Polynomial {
     pub(crate) coeffs: [i16; N],
 }
 
@@ -136,13 +140,13 @@ impl Polynomial {
     /// This is an optimized version of
     ///   ByteEncode_𝑑𝑣( Compress_𝑑𝑣(𝑣) )
     /// which packs a single polynomial according to the packing coefficient dv
-    pub(crate) fn compress_poly<const dv: i16>(&self, out: &mut [u8]) {
-        // make sure we have received a dv
-        debug_assert!(dv == 4 || dv == 5);
+    pub(crate) fn compress_poly<P: MLKEMParams>(&self, out: &mut [u8]) {
+        // make sure we have received a P::dv
+        debug_assert!(P::dv == 4 || P::dv == 5);
 
         // make sure the right size output buffer is given
-        // each of the N i16's will take dv bits
-        debug_assert_eq!(out.len(), N * (dv as usize) / 8);
+        // each of the N i16's will take P::dv bits
+        debug_assert_eq!(out.len(), N * (P::dv as usize) / 8);
 
         let mut t = [0u8; 8];
         let mut idx = 0;
@@ -154,7 +158,7 @@ impl Polynomial {
         // let mut s = self.clone();
         // s.cond_sub_q();
 
-        match dv {
+        match P::dv {
             4 => {
                 // MLKEM512 and MLKEM768
                 for i in 0..N / 8 {
@@ -195,22 +199,18 @@ impl Polynomial {
     /// This is an optimized version of
     /// Decompress_𝑑𝑣( ByteDecode_𝑑𝑣(𝑐2) )
     /// which unpacks a single polynomial according to the packing coefficient dv
-    pub(crate) fn decompress_poly<const dv: i16>(compressed_v: &[u8]) -> Polynomial {
-        // make sure to received a dv
-        debug_assert!(dv == 4 || dv == 5);
-
+    pub(crate) fn decompress_poly<P: MLKEMParams>(compressed_v: &[u8]) -> Polynomial {
         // make sure the right size output buffer is given
-        // each of the N i16's will take dv bits
-        debug_assert_eq!(compressed_v.len(), N * (dv as usize) / 8);
+        // each of the N i16's will take P::dv bits
+        debug_assert_eq!(compressed_v.len(), N * (P::dv as usize) / 8);
 
         let mut v = Polynomial::new();
 
         let mut idx = 0usize;
 
-        // if self.m_engine.poly_compressed_bytes() == 128 {
-        match dv {
+        match P::dv {
+            // MLKEM512 and MLKEM768
             4 => {
-                // MLKEM512 and MLKEM768
                 for i in 0..N / 2 {
                     v[2 * i] =
                         (((((compressed_v[idx] & 15) as i16) as i32 * (q as i32)) + 8) >> 4) as i16;
@@ -219,8 +219,8 @@ impl Polynomial {
                     idx += 1;
                 }
             }
+            // MLKEM1024
             5 => {
-                // MLKEM1024
                 let mut t = [0u8; 8];
                 for i in 0..N / 8 {
                     t[0] = compressed_v[idx];

--- a/crypto/mlkem/src/polynomial.rs
+++ b/crypto/mlkem/src/polynomial.rs
@@ -320,7 +320,6 @@ impl Polynomial {
 ///
 /// Borrowed from:
 /// <https://github.com/pq-crystals/kyber/blob/main/ref/poly.c#L290>
-/// Note: this is exposed publicly only for testing purposes and there is no good reason to use it in production code.
 pub(crate) fn base_mult_montgomery(a: &Polynomial, b: &Polynomial) -> Polynomial {
     let mut r = Polynomial::new();
 

--- a/crypto/mlkem/tests/mlkem_tests.rs
+++ b/crypto/mlkem/tests/mlkem_tests.rs
@@ -813,6 +813,42 @@ mod mlkem_tests {
         fake_rng.set_security_strength(SecurityStrength::_256bit);
         _ = MLKEM1024::encaps_rng(&pk1024, &mut fake_rng).unwrap();
     }
+
+    #[test]
+    fn algorithm_names_and_oids() {
+        use bouncycastle_core::traits::{Algorithm, AlgorithmOID, SecurityStrength};
+
+        // `Algorithm` and `AlgorithmOID` are implemented once, generically over the parameter set,
+        // so nothing else states these per algorithm. Pinned here so that a wrong wiring of the
+        // blanket impls, or a typo in a parameter set, is a test failure rather than a silently
+        // mislabelled algorithm or an unparseable OID.
+        assert_eq!(MLKEM512::ALG_NAME, "ML-KEM-512");
+        assert_eq!(MLKEM768::ALG_NAME, "ML-KEM-768");
+        assert_eq!(MLKEM1024::ALG_NAME, "ML-KEM-1024");
+
+        assert_eq!(MLKEM512::MAX_SECURITY_STRENGTH, SecurityStrength::_128bit);
+        assert_eq!(MLKEM768::MAX_SECURITY_STRENGTH, SecurityStrength::_192bit);
+        assert_eq!(MLKEM1024::MAX_SECURITY_STRENGTH, SecurityStrength::_256bit);
+
+        // NIST's Computer Security Objects Register: id-alg-ml-kem-512 { kems 1 },
+        // id-alg-ml-kem-768 { kems 2 }, id-alg-ml-kem-1024 { kems 3 }.
+        assert_eq!(MLKEM512::OID, &[2, 16, 840, 1, 101, 3, 4, 4, 1]);
+        assert_eq!(MLKEM768::OID, &[2, 16, 840, 1, 101, 3, 4, 4, 2]);
+        assert_eq!(MLKEM1024::OID, &[2, 16, 840, 1, 101, 3, 4, 4, 3]);
+
+        for (oid, der) in [
+            (MLKEM512::OID, MLKEM512::OID_DER),
+            (MLKEM768::OID, MLKEM768::OID_DER),
+            (MLKEM1024::OID, MLKEM1024::OID_DER),
+        ] {
+            assert_eq!(der[0], 0x06, "DER tag must be OBJECT IDENTIFIER");
+            assert_eq!(der[1] as usize, der.len() - 2, "DER length must match the content");
+            assert_eq!(
+                &der[2..],
+                &[0x60, 0x86, 0x48, 0x01, 0x65, 0x03, 0x04, 0x04, *oid.last().unwrap() as u8]
+            );
+        }
+    }
 }
 
 // struct Kat {


### PR DESCRIPTION
Solution: #105 introduces a really nice pattern for encapsulating AES params, and I want to also apply this to the ML-DSA and ML-KEM crates.
The pattern is to hide all the params in a pub trait, with a private trait that seals it.

The entrypoint to start the review is: [the new `trait MLDSAParams` in params.rs](https://github.com/bcgit/bc-rust/pull/117/changes#diff-48ae221c656bd9944170ee0984ae7041abbb62f1b53ac28530227685113ffa3eR45).

This allows for greatly simplifying [the previous turbofish construction](https://github.com/bcgit/bc-rust/blob/main/crypto/mldsa/src/mldsa.rs#L629), which was getting quite out of hand, brittle, and easy to make a mistake.

It used to be:

```rust
pub type MLDSA44 = MLDSA<
    MLDSA44_PK_LEN,
    MLDSA44_SK_LEN,
    MLDSA44_SIG_LEN,
    MLDSA44PublicKey,
    MLDSA44PrivateKey,
    MLDSA44_TAU,
    MLDSA44_LAMBDA,
    MLDSA44_GAMMA1,
    MLDSA44_GAMMA2,
    MLDSA44_k,
    MLDSA44_l,
    MLDSA44_ETA,
    MLDSA44_BETA,
    MLDSA44_OMEGA,
    MLDSA44_C_TILDE,
    MLDSA44_POLY_Z_PACKED_LEN,
    MLDSA44_POLY_W1_PACKED_LEN,
    MLDSA44_LAMBDA_over_4,
    MLDSA44_GAMMA1_MINUS_BETA,
    MLDSA44_GAMMA2_MINUS_BETA,
    MLDSA44_GAMMA1_MASK_LEN,
>;
```

And it's now:

```rust
pub type MLDSA44 = MLDSA<
    MLDSA44Params,
    MLDSA44PublicKey,
    MLDSA44PrivateKey,
    MLDSA44_PK_LEN,
    MLDSA44_SK_LEN,
    MLDSA44_SIG_LEN,
>;
```

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com> 